### PR TITLE
Enhancement: add retry and waiting in the conversation creation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,6 @@ import sys
 import time
 import utility
 import urllib.parse
-import asyncio
 from typing import Union
 import copy
 # Third-Party Imports

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,9 @@ import sys
 import time
 import utility
 import urllib.parse
-
+import asyncio
+from typing import Union
+import copy
 # Third-Party Imports
 import uvicorn
 
@@ -105,6 +107,7 @@ app.add_middleware(
 class MessageClaude(BaseModel):
     message: str
     stream: bool = True
+    conversation_id: Union[str, None] = None
 
 
 class MessageGemini(BaseModel):
@@ -113,6 +116,7 @@ class MessageGemini(BaseModel):
 class Message(BaseModel):
     message: str
     stream: bool = False
+
 
 
 #############################################
@@ -198,18 +202,36 @@ async def ask_claude(request: Request, message: MessageClaude):
         # cookie = os.environ.get("CLAUDE_COOKIE")
         return {"warning": "Looks like you're not logged in to Claude. Please either set the Claude cookie manually or log in to your Claude.ai account through your web browser."}
     
-    conversation_id = None
+    conversation_id = message.conversation_id
+    original_conversation_id = copy.deepcopy(conversation_id)
 
-    try:
-        if not conversation_id:
-            conversation = CLAUDE_CLIENT.create_new_chat()
-            conversation_id = conversation["uuid"]
-    except Exception as e:
-        print(conversation)
-        return ("error: ", conversation)
+    max_retry = 3
+    current_retry = 0
+    while current_retry < max_retry:
+        try:
+            if not conversation_id:
+                try:
+                    conversation = CLAUDE_CLIENT.create_new_chat()
+                    conversation_id = conversation["uuid"]
+                    break  
+                except Exception as e:
+                    current_retry += 1
+                    if current_retry == max_retry:
+                        return ("error: ", e)
+                    else:
+                        print("Retrying in 1 second...")
+                        await asyncio.sleep(1)
+            else:
+                break
+        except Exception as e:
+            return ("error: ", e)
 
     if not message.message:
         message.message = "Who are you?"
+
+    if not original_conversation_id:
+        # after the creation, you need to wait some time before to send
+        await asyncio.sleep(2)
 
     if message.stream:
         res = CLAUDE_CLIENT.stream_message(message.message, conversation_id)


### PR DESCRIPTION
I notice that:
- To continue the conversation we have created, we can pass it as a parameter rather than creating a new one.
- There maybe failure when creating the new conversation, so I add a retry.
- If you request the created conversation just after the creation,  you may fail to get the response.(Mayb the conversation is not ready on `claude sever` . ) So I add a waiting .

 
The error would be:
```bash
 {'error': {'message': 'We are unable to serve your re
quest', 'type': 'permission_error'}}
```
I not sure is this issue is common, I meet them sometimes. So I make this PR. XD