### PR TITLE
refactor: simplify run.py and fix shutdown sequences

### DIFF
--- a/docs/browser-runtime-architecture.md
+++ b/docs/browser-runtime-architecture.md
@@ -13,7 +13,9 @@ The `BrowserEngine` operates according to a strict state machine. Transitions in
 - **CLOSED**: All resources (browser, contexts, loops) have been released.
 
 ### State Rules:
-- **Terminal Shutdown**: Once `SHUTTING_DOWN` begins, `is_shutting_down` is set to `True`. This is irreversible.
+- **Terminal Shutdown / Decoupled Intent**: To prevent diagnostic race conditions and clean up cleanly, the engine decouples shutdown intention from execution:
+  - `is_shutting_down` (Public Boolean): Lifecycle intention flag. Declares the *intent* to terminate. Set immediately when any signal is captured or teardown begins to block concurrent work, prevent loop execution, and suppress connection warning logs during event loop closures. External signal handlers or parent process wrappers may choose to set `is_shutting_down = True` on the engine singleton. Such integrations must be validated against the application's shutdown lifecycle.
+  - `_shutdown_started` (Private Boolean): `close()` execution guard. Protects the physical teardown actions of closing browser processes and stopping Playwright. It must only be modified inside `close()` under the `management_lock`. Upstream or external systems must never mutate `_shutdown_started`.
 - **No Resurrection**: A `CLOSED` engine can never transition back to `HEALTHY`. A new process instance must be created.
 - **Enforcement**: Any call to `ensure_healthy()` during `SHUTTING_DOWN` or `CLOSED` must raise `RuntimeError("Browser engine is shutting down")`.
 

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -40,6 +40,7 @@ class BrowserEngine:
         self.max_pages = CONFIG["Playwright"].getint("max_concurrent_pages", 5)
         self.max_total_tabs = CONFIG["Playwright"].getint("max_total_tabs", 50)
         self.is_shutting_down = False
+        self._shutdown_started = False
         self._disconnect_handled = False
         
         # Basic provider adapter registry mapping
@@ -203,14 +204,16 @@ class BrowserEngine:
 
     async def close(self) -> None:
         async with self.management_lock:
-            if self.is_shutting_down: 
+            if self._shutdown_started: 
                 logger.debug("BrowserEngine: Shutdown already in progress or complete.", extra={"generation": self.browser_generation})
                 return
             if getattr(self, "is_bootstrap", False):
                 logger.info("BrowserEngine: Shutting down isolated bootstrap engine...", extra={"generation": self.browser_generation})
             else:
                 logger.info("BrowserEngine: Shutting down singleton runtime engine...", extra={"generation": self.browser_generation})
+            
             self.is_shutting_down = True
+            self._shutdown_started = True
             
             drain_start = time.monotonic()
             drain_timeout = 15.0

--- a/src/run.py
+++ b/src/run.py
@@ -1,20 +1,10 @@
 # src/run.py
 import argparse
 import asyncio
-import uvicorn
-import multiprocessing
-import time
 import sys
-import threading
-import os
-import signal
-from typing import Dict, Union, Tuple
+import uvicorn
+from typing import Tuple
 from fastapi.routing import APIRoute
-from typing import TYPE_CHECKING
-
-# This block is only processed by type checkers like Pylance
-if TYPE_CHECKING:
-    from multiprocessing.synchronize import Event as MultiprocessingEvent
 
 # Import tomli to read pyproject.toml
 try:
@@ -29,6 +19,7 @@ except ImportError:
 # --- App and Service Imports ---
 from app.config import load_config, CONFIG
 from app.main import app as webai_app
+
 
 # Helper class for terminal colors
 class Colors:
@@ -56,34 +47,6 @@ def get_app_info() -> Tuple[str, str]:
         return name, version
     except (FileNotFoundError, KeyError):
         return "WebAI-to-API", "N/A"
-
-
-# --- UNIFIED Server Runner Functions ---
-
-
-def start_webai_server(
-    host: str, port: int, stop_event: "MultiprocessingEvent"
-):
-    """Starts the WebAI Uvicorn server with a graceful shutdown mechanism."""
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
-    config = uvicorn.Config(
-        webai_app, host=host, port=port, reload=False, log_config=None, workers=1
-    )
-    server = uvicorn.Server(config)
-
-    def shutdown_monitor():
-        stop_event.wait()
-        server.should_exit = True
-
-    monitor_thread = threading.Thread(target=shutdown_monitor, daemon=True)
-    monitor_thread.start()
-
-    print_server_info(host, port, "webai")
-    server.run()
-    print(f"\n[WebAI Server] Process exited gracefully.")
 
 
 # --- Helper Function for Printing Info ---
@@ -135,14 +98,12 @@ def print_server_info(host: str, port: int, mode: str):
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
-    # Fix: Set the asyncio event loop policy for Windows in the main process as well.
+    # Fix: Set the asyncio event loop policy for Windows.
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    # This must be the first line inside the main block for multiprocessing on Windows.
-    multiprocessing.freeze_support()
 
     parser = argparse.ArgumentParser(
-        description="Run a managed server with WebAI capabilities."
+        description="Run the WebAI-to-API server."
     )
     parser.add_argument("--host", type=str, default="localhost", help="Host IP address")
     parser.add_argument("--port", type=int, default=6969, help="Port number")
@@ -164,31 +125,15 @@ if __name__ == "__main__":
         print("\nERROR:    No server modes are available to run. Exiting.")
         sys.exit(1)
 
-    print(f"\n[Controller] Starting server in 'webai' mode...")
+    # Print server information summary banner
+    print_server_info(args.host, args.port, "webai")
 
-    stop_event = multiprocessing.Event()
-    current_process = multiprocessing.Process(
-        target=start_webai_server, args=(args.host, args.port, stop_event)
+    # Run the Uvicorn server directly in the main thread
+    uvicorn.run(
+        webai_app,
+        host=args.host,
+        port=args.port,
+        reload=False,
+        log_config=None,
+        workers=1,
     )
-    current_process.start()
-
-    try:
-        # Keep main thread alive while subprocess is running
-        while current_process.is_alive():
-            time.sleep(1)
-    except KeyboardInterrupt:
-        print("\n[Controller] Ctrl+C detected. Initiating final shutdown...")
-    finally:
-        # Final cleanup
-        if stop_event and not stop_event.is_set():
-            stop_event.set()
-
-        if current_process and current_process.is_alive():
-            print("[Controller] Waiting for final server process to shut down...")
-            current_process.join(timeout=10)
-            if current_process.is_alive():
-                print("[Controller] Server did not shut down gracefully, terminating.")
-                current_process.terminate()
-
-        print("[Controller] Shutdown complete. Forcing exit.")
-        os._exit(0)


### PR DESCRIPTION
refactor: simplify run.py and harden engine shutdown lifecycle

### Changes

- Removed the legacy multiprocessing runner from run.py.
- Decoupled shutdown intent (`is_shutting_down`) from shutdown execution (`_shutdown_started`).
- Prevented duplicate BrowserEngine teardown execution while preserving idempotent cleanup behavior.
- Updated runtime architecture documentation to reflect the new shutdown-state model.

### Motivation

The previous implementation used `is_shutting_down` both as a lifecycle state flag and as the execution guard for `BrowserEngine.close()`. This made early shutdown signalling unsafe because cleanup could be skipped unintentionally.

The new design separates shutdown intent from teardown execution, allowing the runtime to enter shutdown mode early without bypassing browser and Playwright cleanup.