### PR TITLE
Move Gemini session manager into provider package

### DIFF
--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -7,7 +7,7 @@ from fastapi.responses import StreamingResponse
 from app.logger import logger
 from app.schemas.request import GeminiRequest, OpenAIChatRequest
 from app.services.gemini_client import get_gemini_client, GeminiClientNotInitializedError
-from app.services.session_manager import get_translate_session_manager
+from app.services.providers.gemini.session_manager import get_translate_session_manager
 from app.services.factory import ProviderFactory
 
 router = APIRouter()

--- a/src/app/endpoints/gemini.py
+++ b/src/app/endpoints/gemini.py
@@ -6,7 +6,8 @@ from fastapi.responses import StreamingResponse
 from app.logger import logger
 from app.schemas.request import GeminiRequest
 from app.services.gemini_client import get_gemini_client, GeminiClientNotInitializedError
-from app.services.session_manager import get_gemini_chat_registry, generate_opaque_token
+from app.services.providers.gemini.session_manager import get_gemini_chat_registry
+from app.utils.tokens import generate_opaque_token
 
 from pathlib import Path
 from typing import Union, List, Optional

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.services.gemini_client import init_gemini_client, GeminiClientNotInitializedError
-from app.services.session_manager import init_session_managers
+from app.services.providers.gemini.session_manager import init_session_managers
 from app.services.browser.auth_manager import get_auth_manager
 from app.logger import logger
 

--- a/src/app/services/browser/auth_manager.py
+++ b/src/app/services/browser/auth_manager.py
@@ -254,7 +254,7 @@ class AuthManager:
                 # Re-initialize the direct gemini-webapi client with the newly saved cookies
                 try:
                     from app.services.gemini_client import init_gemini_client
-                    from app.services.session_manager import init_session_managers
+                    from app.services.providers.gemini.session_manager import init_session_managers
                     from app.services.factory import ProviderFactory
                     
                     logger.info("AuthManager: Clearing and closing registered Gemini provider in ProviderFactory...")

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -1,4 +1,4 @@
-# src/app/services/session_manager.py
+# src/app/services/providers/gemini/session_manager.py
 import asyncio
 import time
 import secrets

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -6,7 +6,7 @@ from fastapi.responses import StreamingResponse
 from gemini_webapi.exceptions import APIError
 
 from app.services.gemini_client import get_gemini_client, GeminiClientNotInitializedError
-from app.services.session_manager import get_gemini_chat_registry
+from app.services.providers.gemini.session_manager import get_gemini_chat_registry
 from app.services.providers.exceptions import SessionRecoveryError, SnapshotNotFoundError
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
 from app.services.providers.gemini.shared import (

--- a/tests/test_gemini_chat_concurrency.py
+++ b/tests/test_gemini_chat_concurrency.py
@@ -3,7 +3,8 @@ import json
 import pytest
 from httpx import AsyncClient, ASGITransport
 from app.main import app
-from app.services.session_manager import SessionRegistry, SessionManager, generate_opaque_token
+from app.services.providers.gemini.session_manager import SessionRegistry, SessionManager
+from app.utils.tokens import generate_opaque_token
 
 @pytest.mark.asyncio
 async def test_concurrent_independent_streams(mocker):
@@ -87,8 +88,11 @@ async def test_same_session_serialization(mocker):
 @pytest.mark.asyncio
 async def test_registry_capacity_exhaustion(mocker):
     """Verify HTTP 429 when all sessions are locked."""
-    from app.services import session_manager
-    mocker.patch("app.services.session_manager.MAX_SESSIONS", 2)
+    from app.services.providers.gemini import session_manager
+    mocker.patch(
+        "app.services.providers.gemini.session_manager.MAX_SESSIONS",
+        2,
+    )
     
     mock_client = mocker.Mock()
     registry = SessionRegistry(mock_client)
@@ -108,8 +112,11 @@ async def test_registry_capacity_exhaustion(mocker):
 @pytest.mark.asyncio
 async def test_pruning_protects_active_streams(mocker):
     """Verify that sessions with active streams are NOT pruned."""
-    from app.services import session_manager
-    mocker.patch("app.services.session_manager.MAX_SESSIONS", 1)
+    from app.services.providers.gemini import session_manager
+    mocker.patch(
+        "app.services.providers.gemini.session_manager.MAX_SESSIONS",
+        1,
+    )
     
     mock_client = mocker.Mock()
     registry = SessionRegistry(mock_client)

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -65,7 +65,7 @@ def test_convert_to_openai_format_with_tool_call(provider):
 async def test_chat_completions_stateful_buffered(mocker, provider):
     """Verify chat_completions retrieves SessionManager and executes stateful buffered response."""
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionManager, SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
     
     mock_client = mocker.Mock()
     mock_client.client.account_status.name = "AVAILABLE"
@@ -109,7 +109,7 @@ async def test_chat_completions_stateful_buffered(mocker, provider):
 @pytest.mark.asyncio
 async def test_chat_completions_invalid_model_buffered_returns_400_before_session_use(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionRegistry
 
     mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=mocker.Mock())
     mock_registry = mocker.Mock(spec=SessionRegistry)
@@ -133,7 +133,7 @@ async def test_chat_completions_invalid_model_buffered_returns_400_before_sessio
 @pytest.mark.asyncio
 async def test_chat_completions_invalid_model_streaming_returns_400_before_stream(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionRegistry
 
     mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=mocker.Mock())
     mock_registry = mocker.Mock(spec=SessionRegistry)
@@ -157,7 +157,7 @@ async def test_chat_completions_invalid_model_streaming_returns_400_before_strea
 @pytest.mark.asyncio
 async def test_chat_completions_with_conversation_id_requires_authenticated_client(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionRegistry
 
     mock_client = mocker.Mock()
     mock_client.client.account_status.name = "UNAUTHENTICATED"
@@ -189,7 +189,7 @@ async def test_chat_completions_with_conversation_id_requires_authenticated_clie
 @pytest.mark.asyncio
 async def test_chat_completions_with_conversation_id_fails_closed_when_auth_status_unknown(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionRegistry
 
     mock_client = SimpleNamespace(
         client=SimpleNamespace(account_status=SimpleNamespace())
@@ -217,7 +217,7 @@ async def test_chat_completions_with_conversation_id_fails_closed_when_auth_stat
 @pytest.mark.asyncio
 async def test_chat_completions_with_stale_conversation_id_returns_410(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionManager, SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
 
     mock_client = mocker.Mock()
     mock_client.client.account_status.name = "AVAILABLE"
@@ -255,7 +255,7 @@ async def test_chat_completions_with_stale_conversation_id_returns_410(mocker, p
 @pytest.mark.asyncio
 async def test_chat_completions_new_prompt_does_not_map_api_1097_to_recovery_error(mocker, provider):
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionManager, SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
 
     mock_client = mocker.Mock()
     mock_client.client.account_status.name = "AVAILABLE"
@@ -296,7 +296,7 @@ async def test_chat_completions_new_prompt_does_not_map_api_1097_to_recovery_err
 async def test_chat_completions_stateful_streaming(mocker, provider):
     """Verify chat_completions retrieves SessionManager and executes stateful streaming response with SSE format."""
     from app.schemas.request import OpenAIChatRequest
-    from app.services.session_manager import SessionManager, SessionRegistry
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
     
     mock_client = mocker.Mock()
     mock_client.client.account_status.name = "AVAILABLE"
@@ -350,7 +350,7 @@ async def test_chat_completions_stateful_streaming(mocker, provider):
 
 def test_transform_messages_formatting():
     """Verify transform_messages formatting behavior for different roles and tools."""
-    from app.services.session_manager import transform_messages
+    from app.services.providers.gemini.session_manager import transform_messages
     
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},

--- a/tests/test_persistent_conversation_layer.py
+++ b/tests/test_persistent_conversation_layer.py
@@ -6,7 +6,7 @@ from app.schemas.request import OpenAIChatRequest
 from app.services.providers.exceptions import SnapshotNotFoundError, StateIntegrityError
 from app.services.providers.gemini.provider import GeminiProvider
 from app.services.providers.sqlite_repository import SQLiteConversationRepository
-from app.services.session_manager import SessionRegistry
+from app.services.providers.gemini.session_manager import SessionRegistry
 
 
 class MockResponse:


### PR DESCRIPTION
## Summary

This PR relocates `session_manager.py` from `src/app/services/` to `src/app/services/providers/gemini/`.

The move aligns Gemini WebAPI-related conversation state ownership with the provider-centric architecture while preserving existing behavior and API contracts.

## Key Changes

- Moved `session_manager.py` into the Gemini provider package.
- Updated targeted imports in runtime code and tests.
- Updated `generate_opaque_token` imports to use `app.utils.tokens` directly instead of relying on transitive exports.
- Preserved existing class names, global registries, helper functions, and initialization behavior.

## Testing

```bash
PYTHONPATH=src pytest
````

Result:

```text
126 passed
```

## Notes

This is a structural ownership-alignment refactor only. No routing, API, persistence, or runtime behavior changes were introduced.