### PR TITLE
Separate Gemini authentication workflow from AuthManager

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -32,6 +32,14 @@ async def lifespan(app: FastAPI):
     else:
         logger.error("Failed to initialize Gemini client in server process.")
 
+    # Register Gemini Auth Strategy
+    try:
+        from app.services.providers.gemini.auth import GeminiAuthStrategy
+        get_auth_manager().set_strategy(GeminiAuthStrategy())
+        logger.info("Gemini authentication strategy registered.")
+    except Exception as e:
+        logger.error(f"Failed to register Gemini auth strategy: {e}")
+
     # Initialize session managers
     try:
         await init_session_managers()

--- a/src/app/services/browser/auth_manager.py
+++ b/src/app/services/browser/auth_manager.py
@@ -1,28 +1,12 @@
 # src/app/services/browser/auth_manager.py
 import os
-import json
 import asyncio
 import time
 import threading
 from typing import Dict, Any, Optional
-from app.config import CONFIG, get_default_auth_state_dir
+from app.config import CONFIG
 from app.logger import logger
-
-class AuthStatus:
-    # Playwright Statuses
-    VALID_SESSION = "VALID_SESSION"
-    NO_SESSION = "NO_SESSION"
-    EXPIRED_SESSION = "EXPIRED_SESSION"
-    INVALID_STATE = "INVALID_STATE"
-
-    # gemini-webapi Statuses
-    AUTHENTICATED = "AUTHENTICATED"
-    GUEST = "GUEST"
-    INVALID = "INVALID"
-
-class LoginState:
-    IDLE = "IDLE"
-    LOGIN_IN_PROGRESS = "LOGIN_IN_PROGRESS"
+from app.services.browser.auth_types import AuthStatus, LoginState
 
 class AuthCoordinationLock:
     """
@@ -94,12 +78,19 @@ class AuthManager:
         if backend_name == "in_memory":
             self.coordination_lock = InMemoryAuthLock()
 
+        self._strategy = None
         self._cached_playwright_status = None
         self._cached_webapi_status = None
         self._last_validated = 0.0
         self._active_login_task: Optional[asyncio.Task] = None
         self._legacy_fallback_active = False
         self._initialized = True
+
+    def set_strategy(self, strategy: Any) -> None:
+        """
+        Register a provider-specific authentication strategy.
+        """
+        self._strategy = strategy
 
     @property
     def login_state(self) -> str:
@@ -127,69 +118,43 @@ class AuthManager:
             cls._instance = cls()
         return cls._instance
 
-    def get_state_path(self) -> str:
-        auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
-        return os.path.join(auth_state_dir, "gemini.json")
-
     def refresh_playwright_status_lightweight(self) -> str:
         """
         Lightweight check for Playwright session status.
-        Does NOT launch Playwright or perform any network navigations.
-
-        NOTE: This only performs a structural and syntax check of the authentication state.
-        It validates JSON integrity and checks for necessary cookie schemas.
-        It does NOT execute any DOM-level or server-side active authentication checks,
-        which are deferred to runtime request routing to maintain zero-latency status endpoints.
+        Delegates to the registered strategy.
         """
-        from app.services.browser.auth_loader import GeminiAuthStateLoader
-        
-        # Resolve authentication utilizing prioritized hierarchy in GeminiAuthStateLoader
-        auth_data, is_legacy = GeminiAuthStateLoader.load_auth_state_with_fallback()
-        
-        if auth_data:
-            self._cached_playwright_status = AuthStatus.VALID_SESSION
-            self._legacy_fallback_active = is_legacy
-            return AuthStatus.VALID_SESSION
-
-        # Neither present
-        self._cached_playwright_status = AuthStatus.NO_SESSION
-        self._legacy_fallback_active = False
-        return AuthStatus.NO_SESSION
+        status = self.refresh_status()
+        return status.get("playwright_status", AuthStatus.NO_SESSION)
 
     def refresh_webapi_status_lightweight(self) -> str:
         """
         Lightweight check for gemini-webapi connection status.
+        Delegates to the registered strategy.
         """
-        try:
-            import app.services.gemini_client as gc
-            client_instance = gc._gemini_client
-            if client_instance is None:
-                self._cached_webapi_status = AuthStatus.INVALID
-                return AuthStatus.INVALID
-
-            status_name = client_instance.client.account_status.name if hasattr(client_instance.client, 'account_status') else "UNKNOWN"
-            if status_name == "AVAILABLE":
-                self._cached_webapi_status = AuthStatus.AUTHENTICATED
-            elif status_name == "UNAUTHENTICATED":
-                self._cached_webapi_status = AuthStatus.GUEST
-            else:
-                self._cached_webapi_status = AuthStatus.INVALID
-        except Exception as e:
-            logger.debug(f"AuthManager: Error reading webapi status: {e}")
-            self._cached_webapi_status = AuthStatus.INVALID
-
-        return self._cached_webapi_status
+        status = self.refresh_status()
+        return status.get("webapi_status", AuthStatus.INVALID)
 
     def refresh_status(self) -> Dict[str, Any]:
         """
         Perform a lightweight refresh of both authentication pathways.
+        Delegates to the registered strategy.
         """
-        playwright_status = self.refresh_playwright_status_lightweight()
-        webapi_status = self.refresh_webapi_status_lightweight()
+        if not self._strategy:
+            return {
+                "playwright_status": AuthStatus.NO_SESSION,
+                "webapi_status": AuthStatus.INVALID,
+                "last_validated": time.time()
+            }
+
+        res = self._strategy.refresh_status()
+        self._cached_playwright_status = res.get("playwright")
+        self._cached_webapi_status = res.get("webapi")
+        self._legacy_fallback_active = res.get("is_legacy", False)
         self._last_validated = time.time()
+        
         return {
-            "playwright_status": playwright_status,
-            "webapi_status": webapi_status,
+            "playwright_status": self._cached_playwright_status,
+            "webapi_status": self._cached_webapi_status,
             "last_validated": self._last_validated
         }
 
@@ -200,6 +165,8 @@ class AuthManager:
         if self._cached_playwright_status is None or self._cached_webapi_status is None:
             self.refresh_status()
 
+        state_path = self._strategy.get_state_path() if self._strategy else "N/A"
+
         status_payload = {
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "login_state": self.login_state,
@@ -208,7 +175,7 @@ class AuthManager:
             },
             "playwright": {
                 "status": self._cached_playwright_status,
-                "auth_state_file": self.get_state_path(),
+                "auth_state_file": state_path,
                 "last_validated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self._last_validated)),
                 "validation_details": "Lightweight syntax check only. Active browser/DOM validation is deferred to runtime request execution to preserve zero-latency performance."
             }
@@ -232,13 +199,10 @@ class AuthManager:
         """
         Triggers the on-demand bootstrap login workflow asynchronously in the background.
         Coordinates locks and active state machine.
-
-        CONCURRENCY SAFETY:
-        Checking and transitioning the login state are protected by the AuthCoordinationLock.
-        This provides a clear abstraction boundary so that future multi-worker or SaaS
-        deployments can swap the default InMemoryAuthLock for a distributed lock backend
-        (such as Redis SET NX or Postgres advisory locks).
         """
+        if not self._strategy:
+            raise RuntimeError("No authentication strategy registered.")
+            
         if not self.coordination_lock.acquire():
             raise ValueError("Authentication in progress.")
 
@@ -248,36 +212,29 @@ class AuthManager:
     async def _run_login_task(self) -> None:
         async with self.login_lock:
             try:
-                await self.run_login_flow()
+                if not self._check_display_available():
+                    raise RuntimeError("Headful interactive sign-in is unsupported in this headless container environment.")
+
+                from app.services.browser.engine import get_browser_engine
+                bootstrap_engine = await get_browser_engine(headless=False, is_bootstrap=True)
+                
+                async with bootstrap_engine as engine:
+                    await self._strategy.run_login_flow(engine)
+                
                 self._cached_playwright_status = AuthStatus.VALID_SESSION
                 
                 # Re-initialize the direct gemini-webapi client with the newly saved cookies
                 try:
-                    from app.services.gemini_client import init_gemini_client
-                    from app.services.providers.gemini.session_manager import init_session_managers
-                    from app.services.factory import ProviderFactory
-                    
-                    logger.info("AuthManager: Clearing and closing registered Gemini provider in ProviderFactory...")
-                    await ProviderFactory.close_provider("gemini")
-
-                    logger.info("AuthManager: Re-initializing direct Gemini WebAPI client...")
-                    init_success = await init_gemini_client()
-                    if not init_success:
-                        raise RuntimeError("Gemini direct client initialization returned False.")
-                    
-                    logger.info("AuthManager: Re-initializing session managers with new client...")
-                    await init_session_managers()
-                    
+                    await self._strategy.run_post_login_recovery()
                     logger.info("AuthManager: Instantly refreshing local authentication statuses...")
                     self.refresh_status()
                 except Exception as e:
-                    logger.error(f"AuthManager: Direct Gemini WebAPI client re-initialization failed: {e}")
+                    logger.error(f"AuthManager: Post-login recovery failed: {e}")
                     self._cached_webapi_status = AuthStatus.INVALID
-                    self.refresh_playwright_status_lightweight()
             except Exception as e:
                 logger.error(f"AuthManager: Background login flow failed: {e}")
-                # Refresh playwright status (which might be EXPIRED_SESSION or NO_SESSION)
-                self.refresh_playwright_status_lightweight()
+                # Refresh status (which might be EXPIRED_SESSION or NO_SESSION)
+                self.refresh_status()
             finally:
                 self._active_login_task = None
                 self._last_validated = time.time()
@@ -286,132 +243,18 @@ class AuthManager:
     async def run_login_flow(self) -> None:
         """
         Orchestrate the headful login workflow using core BrowserEngine primitives.
+        Delegates to the registered strategy.
         """
-        from app.services.browser.engine import get_browser_engine
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
-        
-        # 1. Perform environment checks
+        if not self._strategy:
+            raise RuntimeError("No authentication strategy registered.")
+            
         if not self._check_display_available():
             raise RuntimeError("Headful interactive sign-in is unsupported in this headless container environment.")
 
-        # Robust selectors for verification to prevent false-positives
-        SIGN_IN_SELECTORS = [
-            'a[href*="accounts.google.com"]',
-            'a:has-text("Sign in")',
-            'button:has-text("Sign in")',
-            'a[aria-label*="Sign in"]',
-            '.sign-in-button'
-        ]
-
-        AUTHENTICATED_SELECTORS = [
-            'a[href*="SignOutOptions"]',
-            'a[href*="myaccount.google.com"]',
-            'img[src*="googleusercontent.com"]',
-            '[aria-label*="Google Account"]'
-        ]
-
+        from app.services.browser.engine import get_browser_engine
         bootstrap_engine = await get_browser_engine(headless=False, is_bootstrap=True)
         async with bootstrap_engine as engine:
-            logger.info("AuthManager: Launching isolated bootstrap browser...")
-            page_wrapper = await engine.get_page("gemini", enable_persistence=True)
-            page = page_wrapper.page
-            session = await engine.get_session("gemini", enable_persistence=True)
-            
-            logger.info("AuthManager: Navigating to https://gemini.google.com/app...")
-            await page.goto("https://gemini.google.com/app")
-            
-            login_detected = False
-            user_closed = False
-            last_state = None
-            try:
-                # Poll every 2 seconds for a maximum of 5 minutes (150 iterations)
-                for _ in range(150):
-                    if page.is_closed():
-                        user_closed = True
-                        break
-                    
-                    # 1. Check if the page is currently on a Google login/account URL
-                    current_url = page.url
-                    is_google_login = "accounts.google.com" in current_url
-                    
-                    # 2. Check for visible sign-in buttons on the page
-                    has_sign_in_button = False
-                    for selector in SIGN_IN_SELECTORS:
-                        try:
-                            if await page.locator(selector).first.is_visible():
-                                has_sign_in_button = True
-                                break
-                        except Exception:
-                            pass
-                    
-                    # 3. Check if the Gemini chat input box is visible
-                    input_visible = await page.locator(SELECTORS["INPUT"]).first.is_visible()
-                    
-                    # 4. Check for Google Account/profile avatar or menu indicators
-                    has_auth_indicator = False
-                    for selector in AUTHENTICATED_SELECTORS:
-                        try:
-                            if await page.locator(selector).first.is_visible():
-                                has_auth_indicator = True
-                                break
-                        except Exception:
-                            pass
-
-                    # 5. Determine active state
-                    if is_google_login:
-                        current_state = "sign_in_page_detected"
-                    elif input_visible and not has_sign_in_button and "gemini.google.com" in current_url:
-                        current_state = "authenticated_chat_detected"
-                    else:
-                        current_state = "waiting_for_user_login"
-
-                    # Log transitions between states
-                    if current_state != last_state:
-                        if current_state == "sign_in_page_detected":
-                            logger.info("AuthManager Status: sign_in_page_detected")
-                        elif current_state == "authenticated_chat_detected":
-                            logger.info("AuthManager Status: authenticated_chat_detected")
-                        elif current_state == "waiting_for_user_login":
-                            logger.info("AuthManager Status: waiting_for_user_login")
-                        last_state = current_state
-
-                    # If authentication is confirmed with strong evidence, save state and exit
-                    if current_state == "authenticated_chat_detected":
-                        login_detected = True
-                        await session.save_state()
-                        logger.info("AuthManager: Success! Google sign-in detected and state saved atomically.")
-                        break
-
-                    await asyncio.sleep(2)
-            except Exception as e:
-                logger.warning(f"AuthManager: Exception during login monitoring: {e}")
-                try:
-                    # If page is physically closed, or exception indicates target closure, classify as user_closed
-                    err_msg = str(e).lower()
-                    if (
-                        "target closed" in err_msg
-                        or "page closed" in err_msg
-                        or "context closed" in err_msg
-                        or page.is_closed()
-                    ):
-                        user_closed = True
-                except Exception:
-                    # Best-effort fallback: if page reference is completely broken/destroyed, assume closed by user
-                    user_closed = True
-            finally:
-                if page_wrapper:
-                    try:
-                        await page_wrapper.close()
-                    except Exception as e:
-                        logger.debug(f"AuthManager: page wrapper cleanup ignored: {e}")
-            
-            if not login_detected:
-                if user_closed:
-                    logger.warning("AuthManager Status: user_closed_login_window")
-                    raise RuntimeError("Interactive sign-in was closed by user.")
-                else:
-                    logger.warning("AuthManager Status: login_timeout")
-                    raise TimeoutError("Interactive sign-in timed out.")
+            await self._strategy.run_login_flow(engine)
 
     def _check_display_available(self) -> bool:
         """

--- a/src/app/services/browser/auth_types.py
+++ b/src/app/services/browser/auth_types.py
@@ -1,0 +1,17 @@
+# src/app/services/browser/auth_types.py
+
+class AuthStatus:
+    # Playwright Statuses
+    VALID_SESSION = "VALID_SESSION"
+    NO_SESSION = "NO_SESSION"
+    EXPIRED_SESSION = "EXPIRED_SESSION"
+    INVALID_STATE = "INVALID_STATE"
+
+    # gemini-webapi Statuses
+    AUTHENTICATED = "AUTHENTICATED"
+    GUEST = "GUEST"
+    INVALID = "INVALID"
+
+class LoginState:
+    IDLE = "IDLE"
+    LOGIN_IN_PROGRESS = "LOGIN_IN_PROGRESS"

--- a/src/app/services/providers/gemini/auth.py
+++ b/src/app/services/providers/gemini/auth.py
@@ -1,0 +1,174 @@
+# src/app/services/providers/gemini/auth.py
+import os
+import asyncio
+from typing import Dict, Any, Optional
+from app.config import CONFIG, get_default_auth_state_dir
+from app.logger import logger
+from app.services.browser.auth_types import AuthStatus
+
+class GeminiAuthStrategy:
+    """
+    Gemini-specific authentication workflow strategy.
+    Implements login flows, status checks, and recovery for Google Gemini.
+    """
+
+    def get_state_path(self) -> str:
+        auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
+        return os.path.join(auth_state_dir, "gemini.json")
+
+    def refresh_status(self) -> Dict[str, str]:
+        """
+        Perform lightweight status checks for Gemini.
+        Returns a dict with 'playwright' and 'webapi' status strings.
+        """
+        from app.services.browser.auth_loader import GeminiAuthStateLoader
+        
+        # 1. Check Playwright/JSON status
+        auth_data, is_legacy = GeminiAuthStateLoader.load_auth_state_with_fallback()
+        playwright_status = AuthStatus.VALID_SESSION if auth_data else AuthStatus.NO_SESSION
+        
+        # 2. Check direct WebAPI client status
+        webapi_status = AuthStatus.INVALID
+        try:
+            import app.services.gemini_client as gc
+            client_instance = gc._gemini_client
+            if client_instance:
+                status_name = client_instance.client.account_status.name if hasattr(client_instance.client, 'account_status') else "UNKNOWN"
+                if status_name == "AVAILABLE":
+                    webapi_status = AuthStatus.AUTHENTICATED
+                elif status_name == "UNAUTHENTICATED":
+                    webapi_status = AuthStatus.GUEST
+        except Exception as e:
+            logger.debug(f"GeminiAuthStrategy: Error reading webapi status: {e}")
+
+        return {
+            "playwright": playwright_status,
+            "webapi": webapi_status,
+            "is_legacy": is_legacy
+        }
+
+    async def run_login_flow(self, engine) -> None:
+        """
+        Orchestrate the headful login workflow for Gemini.
+        """
+        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        
+        # Robust selectors for verification
+        SIGN_IN_SELECTORS = [
+            'a[href*="accounts.google.com"]',
+            'a:has-text("Sign in")',
+            'button:has-text("Sign in")',
+            'a[aria-label*="Sign in"]',
+            '.sign-in-button'
+        ]
+
+        AUTHENTICATED_SELECTORS = [
+            'a[href*="SignOutOptions"]',
+            'a[href*="myaccount.google.com"]',
+            'img[src*="googleusercontent.com"]',
+            '[aria-label*="Google Account"]'
+        ]
+
+        logger.info("GeminiAuthStrategy: Launching isolated bootstrap browser...")
+        page_wrapper = await engine.get_page("gemini", enable_persistence=True)
+        page = page_wrapper.page
+        session = await engine.get_session("gemini", enable_persistence=True)
+        
+        login_detected = False
+        user_closed = False
+        last_state = None
+        
+        try:
+            logger.info("GeminiAuthStrategy: Navigating to https://gemini.google.com/app...")
+            await page.goto("https://gemini.google.com/app")
+            
+            # Poll every 2 seconds for a maximum of 5 minutes (150 iterations)
+            for _ in range(150):
+                if page.is_closed():
+                    user_closed = True
+                    break
+                
+                current_url = page.url
+                is_google_login = "accounts.google.com" in current_url
+                
+                has_sign_in_button = False
+                for selector in SIGN_IN_SELECTORS:
+                    try:
+                        if await page.locator(selector).first.is_visible():
+                            has_sign_in_button = True
+                            break
+                    except Exception:
+                        pass
+                
+                input_visible = await page.locator(SELECTORS["INPUT"]).first.is_visible()
+                
+                has_auth_indicator = False
+                for selector in AUTHENTICATED_SELECTORS:
+                    try:
+                        if await page.locator(selector).first.is_visible():
+                            has_auth_indicator = True
+                            break
+                    except Exception:
+                        pass
+
+                if is_google_login:
+                    current_state = "sign_in_page_detected"
+                elif input_visible and not has_sign_in_button and "gemini.google.com" in current_url:
+                    current_state = "authenticated_chat_detected"
+                else:
+                    current_state = "waiting_for_user_login"
+
+                if current_state != last_state:
+                    logger.info(f"GeminiAuthStrategy Status: {current_state}")
+                    last_state = current_state
+
+                if current_state == "authenticated_chat_detected":
+                    login_detected = True
+                    await session.save_state()
+                    logger.info("GeminiAuthStrategy: Success! Google sign-in detected and state saved atomically.")
+                    break
+
+                await asyncio.sleep(2)
+        except Exception as e:
+            err_msg = str(e).lower()
+            if (
+                "target closed" in err_msg
+                or "page closed" in err_msg
+                or "context closed" in err_msg
+            ):
+                logger.warning(f"GeminiAuthStrategy: Browser closure detected: {e}")
+                user_closed = True
+            else:
+                logger.error(f"GeminiAuthStrategy: Unexpected exception during login monitoring: {e}")
+                raise
+        finally:
+            if page_wrapper:
+                try:
+                    await page_wrapper.close()
+                except Exception as e:
+                    logger.debug(f"GeminiAuthStrategy: page wrapper cleanup ignored: {e}")
+
+        if not login_detected:
+            if user_closed:
+                raise RuntimeError("Interactive sign-in was closed by user.")
+            else:
+                raise TimeoutError("Interactive sign-in timed out.")
+
+    async def run_post_login_recovery(self) -> None:
+        """
+        Ordered recovery for Gemini components after successful login.
+        """
+        from app.services.gemini_client import init_gemini_client
+        from app.services.providers.gemini.session_manager import init_session_managers
+        from app.services.factory import ProviderFactory
+        
+        logger.info("GeminiAuthStrategy: Clearing and closing registered Gemini provider in ProviderFactory...")
+        await ProviderFactory.close_provider("gemini")
+
+        logger.info("GeminiAuthStrategy: Re-initializing direct Gemini WebAPI client...")
+        init_success = await init_gemini_client()
+        if not init_success:
+            raise RuntimeError("Gemini direct client initialization returned False.")
+        
+        logger.info("GeminiAuthStrategy: Re-initializing session managers with new client...")
+        await init_session_managers()

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -72,7 +72,8 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         backoff_delays = [1.0, 2.0, 4.0]
         
         try:
-            from app.services.browser.auth_manager import get_auth_manager, AuthStatus
+            from app.services.browser.auth_manager import get_auth_manager
+            from app.services.browser.auth_types import AuthStatus
             auth_mgr = get_auth_manager()
             if auth_mgr.coordination_lock.is_locked():
                 raise HTTPException(status_code=503, detail="Authentication in progress.")

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -117,7 +117,9 @@ def test_auth_manager_multi_worker_warning(mocker):
 async def test_run_login_flow_success(mocker):
     """Verify run_login_flow detects authenticated chat after traversing sign-in and guest states."""
     from app.services.browser.auth_manager import get_auth_manager
+    from app.services.providers.gemini.auth import GeminiAuthStrategy
     auth_mgr = get_auth_manager()
+    auth_mgr.set_strategy(GeminiAuthStrategy())
 
     # Mock display check
     mocker.patch.object(auth_mgr, "_check_display_available", return_value=True)
@@ -222,7 +224,9 @@ async def test_run_login_flow_success(mocker):
 async def test_run_login_flow_user_closed_window(mocker):
     """Verify run_login_flow raises RuntimeError when window is closed by user."""
     from app.services.browser.auth_manager import get_auth_manager
+    from app.services.providers.gemini.auth import GeminiAuthStrategy
     auth_mgr = get_auth_manager()
+    auth_mgr.set_strategy(GeminiAuthStrategy())
 
     mocker.patch.object(auth_mgr, "_check_display_available", return_value=True)
 
@@ -246,6 +250,39 @@ async def test_run_login_flow_user_closed_window(mocker):
     mocker.patch('asyncio.sleep', AsyncMock())
 
     with pytest.raises(RuntimeError, match="Interactive sign-in was closed by user"):
+        await auth_mgr.run_login_flow()
+
+
+@pytest.mark.asyncio
+async def test_run_login_flow_unexpected_exception_re_raised(mocker):
+    """Verify run_login_flow re-raises unexpected exceptions during polling."""
+    from app.services.browser.auth_manager import get_auth_manager
+    from app.services.providers.gemini.auth import GeminiAuthStrategy
+    auth_mgr = get_auth_manager()
+    auth_mgr.set_strategy(GeminiAuthStrategy())
+
+    mocker.patch.object(auth_mgr, "_check_display_available", return_value=True)
+
+    mock_page = MagicMock()
+    mock_page.is_closed.return_value = False
+    # Raise an unexpected error during navigation or polling
+    mock_page.goto = AsyncMock(side_effect=ValueError("Unexpected internal error"))
+
+    mock_page_wrapper = MagicMock()
+    mock_page_wrapper.page = mock_page
+    mock_page_wrapper.close = AsyncMock()
+
+    mock_session = AsyncMock()
+
+    mock_engine = MagicMock()
+    mock_engine.get_page = AsyncMock(return_value=mock_page_wrapper)
+    mock_engine.get_session = AsyncMock(return_value=mock_session)
+    mock_engine.__aenter__ = AsyncMock(return_value=mock_engine)
+    mock_engine.__aexit__ = AsyncMock(return_value=False)
+
+    mocker.patch('app.services.browser.engine.get_browser_engine', return_value=mock_engine)
+
+    with pytest.raises(ValueError, match="Unexpected internal error"):
         await auth_mgr.run_login_flow()
 
 


### PR DESCRIPTION
## Summary

This PR separates the Google Gemini-specific authentication workflow from the core `AuthManager`. `AuthManager` now remains responsible for generic orchestration, locking, task state, and status wrapping, while Gemini-specific login, status probing, and post-login recovery are delegated to `GeminiAuthStrategy`.

## Key Changes

- Added neutral auth status/login constants in `src/app/services/browser/auth_types.py`.
- Added `GeminiAuthStrategy` in `src/app/services/providers/gemini/auth.py`.
- Moved Gemini-specific URLs, selectors, Playwright login detection, auth-state checks, and post-login recovery into the Gemini provider layer.
- Refactored `AuthManager` to use lazy strategy registration and avoid provider-specific module imports.
- Registered `GeminiAuthStrategy` during application startup.
- Preserved existing `/v1/auth/status`, `/v1/auth/login`, and adapter-facing behavior.
- Preserved browser-closure normalization while re-raising unexpected login-flow exceptions.

## Testing

- `pytest`
- `127 passed`

## Notes

This is an ownership-boundary cleanup and a prerequisite for a later PR that may relocate `gemini_client.py` into the Gemini provider package.