### PR TITLE
Refactor configuration routing and fix Playwright interaction timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Send a POST request to `/v1/chat/completions` (or any other available endpoint) 
 | `gemini-3-flash`            | Fast and efficient model (default) |
 | `gemini-3-flash-thinking`   | Enhanced reasoning model           |
 
+### Provider Routing
+
+Requests to `/v1/chat/completions` are automatically routed based on the model prefix or an explicit provider field.
+
+| Model Prefix | Provider | Example |
+| ------------ | -------- | ------- |
+| *(none)*     | Gemini   | `gemini-3-flash` |
+| `playwright/`| Gemini (Playwright) | `playwright/gemini-3-pro` |
+| `atlas/`     | Atlas    | `atlas/MiniMax-M2` |
+
+---
+
 ### Example Request (Basic)
 
 ```json
@@ -232,7 +244,6 @@ Lists available Gemini "Gems" associated with the account. The returned Gem IDs 
 
 | Section     | Option     | Description                                | Example Value           |
 | ----------- | ---------- | ------------------------------------------ | ----------------------- |
-| [AI]        | default_ai | Default service for `/v1/chat/completions` | `gemini`                |
 | [Browser]   | name       | Browser for cookie-based authentication    | `chrome`               |
 | [EnabledAI] | gemini     | Enable/disable Gemini service              | `true`                  |
 | [Proxy]     | http_proxy | Proxy for Gemini connections (optional)    | `http://127.0.0.1:2334` |
@@ -245,10 +256,6 @@ If the cookies are left empty, the application will automatically retrieve them 
 ### Sample `config.conf`
 
 ```ini
-[AI]
-# Default AI service.
-default_ai = gemini
-
 [Gemini]
 # Choose the backend adapter (webapi or playwright)
 backend = webapi

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Send a POST request to `/v1/chat/completions` (or any other available endpoint) 
 
 ### Provider Routing
 
-Requests to `/v1/chat/completions` are automatically routed based on the model prefix or an explicit provider field.
+Requests to `/v1/chat/completions` are automatically routed based on the model prefix or an explicit provider field. If no prefix is found, the system falls back to the default Gemini provider, which will use the strategy defined by `[Gemini] backend`.
 
 | Model Prefix | Provider | Example |
 | ------------ | -------- | ------- |

--- a/README.md
+++ b/README.md
@@ -249,12 +249,11 @@ If the cookies are left empty, the application will automatically retrieve them 
 # Default AI service.
 default_ai = gemini
 
-# Default model for Gemini (options: gemini-3-pro, gemini-3-flash, gemini-3-flash-thinking)
-default_model_gemini = gemini-3-flash
-
-# Gemini cookies (leave empty to use browser_cookies3 for automatic authentication).
-gemini_cookie_1psid =
-gemini_cookie_1psidts =
+[Gemini]
+# Choose the backend adapter (webapi or playwright)
+backend = webapi
+# Default model to use when none is specified in the request
+default_model = gemini-3-flash
 
 [EnabledAI]
 # Enable or disable AI services.

--- a/config.conf.example
+++ b/config.conf.example
@@ -15,6 +15,8 @@ name = chrome
 # Execution Strategy:
 # - webapi:    Lightweight, fast, uses unofficial API wrappers.
 # - playwright: Browser-native runtime (Chromium). Most resilient.
+# NOTE: Using a 'playwright/...' model prefix in your request will 
+# automatically override this global backend configuration.
 #
 # Default Model:
 # Choose the model to be used when none is specified in the request.
@@ -39,8 +41,13 @@ gemini = true
 
 # --- Atlas Cloud Configuration ---
 # API key and endpoint for the Atlas Cloud provider.
-# NOTE: Environment variables (ATLASCLOUD_API_KEY, ATLASCLOUD_BASE_URL) 
-# take precedence over these settings.
+#
+# Precedence Order:
+# OS Env > .env.local > .env > config.conf > defaults
+#
+# NOTE: For production, Docker, or CI/CD deployments, it is highly 
+# recommended to use environment variables (ATLASCLOUD_API_KEY, 
+# ATLASCLOUD_BASE_URL) rather than committing secrets to this file.
 [Atlas]
 api_key = 
 base_url = https://api.atlascloud.ai/v1
@@ -57,22 +64,39 @@ http_proxy =
 [Playwright]
 # Run in headless mode (true/false)
 headless = false
-# Maximum concurrent pages across all sessions (HARD LIMIT via semaphore)
-max_concurrent_pages = 5
-# Global soft-cap for total open pages across all sessions (eviction threshold)
-max_total_tabs = 50
-# Maximum conversations to keep in the LRU registry per provider
-max_persistent_conversations = 20
-# Timeouts in milliseconds
-navigation_timeout = 30000
-ui_wait_timeout = 15000
-# Eviction timeouts in seconds
-idle_conversation_timeout = 900
-lease_timeout = 180
+
 # Directory for provider browser storage state files
 auth_state_dir = runtime/auth
+
 # Concurrency locking backend for on-demand authentication coordination.
 # Default: in_memory (process-bound). Swapping this is required for production
 # multi-worker/Gunicorn or horizontally scaled SaaS deployments to avoid races.
 # Supported future values: redis, postgres.
 auth_lock_backend = in_memory
+
+# =====================================================================
+# --- Advanced Playwright Engine Tuning ---
+# ⚠️ Only modify these if you understand the runtime architecture.
+# =====================================================================
+
+# -- Capacity Limits --
+# Maximum concurrent pages across all sessions (HARD LIMIT via semaphore)
+max_concurrent_pages = 5
+
+# Global soft-cap for total open pages across all sessions (eviction threshold)
+max_total_tabs = 50
+
+# Maximum conversations to keep in the LRU registry per provider
+max_persistent_conversations = 20
+
+# -- Timeouts (Milliseconds) --
+# Passed directly to Playwright underlying APIs.
+navigation_timeout = 30000
+ui_wait_timeout = 15000
+
+# -- Timeouts (Seconds) --
+# Used by Python asyncio layer for application-level lifecycle management.
+chunk_timeout = 90
+total_request_timeout = 120
+idle_conversation_timeout = 900
+lease_timeout = 180

--- a/config.conf.example
+++ b/config.conf.example
@@ -38,6 +38,14 @@ gemini_cookie_1psidts =
 [EnabledAI]
 gemini = true
 
+# --- Atlas Cloud Configuration ---
+# API key and endpoint for the Atlas Cloud provider.
+# NOTE: Environment variables (ATLASCLOUD_API_KEY, ATLASCLOUD_BASE_URL) 
+# take precedence over these settings.
+[Atlas]
+api_key = 
+base_url = https://api.atlascloud.ai/v1
+
 # --- Gemini Execution Strategy ---
 # Choose the backend adapter for Gemini execution.
 # - webapi:    Lightweight, fast, uses unofficial API wrappers.

--- a/config.conf.example
+++ b/config.conf.example
@@ -15,14 +15,19 @@ name = chrome
 [AI]
 default_ai = gemini
 
-# --- Gemini Model Configuration ---
-# Choose the model to be used when Gemini is selected as the AI.
-# Available models (gemini-webapi >= 2.0.0):
-# - gemini-3-pro
-# - gemini-3-flash
-# - gemini-3-flash-thinking
-# - unspecified                (use account default)
-default_model_gemini = gemini-3-flash
+# --- Gemini Configuration ---
+# Configure the Google Gemini provider.
+#
+# Execution Strategy:
+# - webapi:    Lightweight, fast, uses unofficial API wrappers.
+# - playwright: Browser-native runtime (Chromium). Most resilient.
+#
+# Default Model:
+# Choose the model to be used when none is specified in the request.
+# Available models: gemini-3-pro, gemini-3-flash, gemini-3-flash-thinking, unspecified
+[Gemini]
+backend = webapi
+default_model = gemini-3-flash
 
 # --- Gemini Cookies (DEPRECATED) ---
 # ⚠️ WARNING: Configuration-backed cookie storage is deprecated.
@@ -45,13 +50,6 @@ gemini = true
 [Atlas]
 api_key = 
 base_url = https://api.atlascloud.ai/v1
-
-# --- Gemini Execution Strategy ---
-# Choose the backend adapter for Gemini execution.
-# - webapi:    Lightweight, fast, uses unofficial API wrappers.
-# - playwright: Browser-native runtime (Chromium). Most resilient.
-[Gemini]
-backend = webapi
 
 # --- Proxy Configuration ---
 # The app, use this proxy to connect gemini servers.

--- a/config.conf.example
+++ b/config.conf.example
@@ -9,12 +9,6 @@
 [Browser]
 name = chrome
 
-# --- AI Provider Settings ---
-# Select the default AI service.
-# Currently supported: gemini, atlas
-[AI]
-default_ai = gemini
-
 # --- Gemini Configuration ---
 # Configure the Google Gemini provider.
 #

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -46,7 +46,7 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
     if "Cookies" not in config:
         config["Cookies"] = {}
     if "AI" not in config:
-        config["AI"] = {"default_model_gemini": "gemini-3-flash"}
+        config["AI"] = {}
     if "Proxy" not in config:
         config["Proxy"] = {"http_proxy": ""}
     if "Playwright" not in config:
@@ -81,10 +81,20 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
         is_headless = env_headless.strip().lower() in ("1", "true", "yes", "on")
         config["Playwright"]["headless"] = "true" if is_headless else "false"
 
+    # Resolve Gemini default model with legacy fallback
+    # Precedence: [Gemini] default_model > [AI] default_model_gemini > hardcoded default
+    legacy_gemini_model = config.get("AI", "default_model_gemini", fallback=None)
+    
     if "Gemini" not in config:
         config["Gemini"] = {
-            "backend": "webapi"
+            "backend": "webapi",
+            "default_model": legacy_gemini_model or "gemini-3-flash"
         }
+    else:
+        if "backend" not in config["Gemini"]:
+            config["Gemini"]["backend"] = "webapi"
+        if "default_model" not in config["Gemini"]:
+            config["Gemini"]["default_model"] = legacy_gemini_model or "gemini-3-flash"
     
     # Validate Gemini backend
     gemini_backend = config["Gemini"].get("backend", "webapi").lower().strip()

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -45,8 +45,6 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
         config["Browser"] = {"name": "chrome"}
     if "Cookies" not in config:
         config["Cookies"] = {}
-    if "AI" not in config:
-        config["AI"] = {}
     if "Proxy" not in config:
         config["Proxy"] = {"http_proxy": ""}
     if "Playwright" not in config:

--- a/src/app/services/browser/adapters/gemini_adapter.py
+++ b/src/app/services/browser/adapters/gemini_adapter.py
@@ -13,6 +13,9 @@ class GeminiProviderAdapter(BaseProviderAdapter):
     Implements only the minimal DOM selectors, form inputs, URL parsing,
     and authentication heuristics, with zero changes to orchestration.
     """
+    def __init__(self, ui_wait_timeout: int = 15000):
+        self.ui_wait_timeout = ui_wait_timeout
+
     @property
     def provider_name(self) -> str:
         return "gemini"
@@ -64,7 +67,7 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         if await submit_button.count() == 0:
             submit_button = page.locator(SELECTORS["SEND_BUTTON"]).first
 
-        await submit_button.wait_for(state="visible", timeout=5000)
+        await submit_button.wait_for(state="visible", timeout=self.ui_wait_timeout)
         
         if not await submit_button.is_enabled():
             await page.keyboard.press("Space")

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -42,12 +42,6 @@ class BrowserEngine:
         self.is_shutting_down = False
         self._shutdown_started = False
         self._disconnect_handled = False
-        
-        # Basic provider adapter registry mapping
-        from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
-        self.adapters = {
-            "gemini": GeminiProviderAdapter()
-        }
 
     @classmethod
     async def get_instance(cls, headless: Optional[bool] = None) -> 'BrowserEngine':

--- a/src/app/services/providers/atlas/client.py
+++ b/src/app/services/providers/atlas/client.py
@@ -66,11 +66,16 @@ class AtlasClient:
 
 
 def get_atlas_client() -> AtlasClient:
-    api_key = os.getenv("ATLASCLOUD_API_KEY")
+    from app.config import CONFIG
+
+    api_key = os.getenv("ATLASCLOUD_API_KEY") or CONFIG.get("Atlas", "api_key", fallback=None)
     if not api_key:
         raise AtlasClientNotConfiguredError(
-            "Atlas Cloud API key not configured. Set ATLASCLOUD_API_KEY in .env.local or environment."
+            "Atlas Cloud API key not configured. Set ATLASCLOUD_API_KEY in .env.local or [Atlas] api_key in config.conf."
         )
 
-    base_url = os.getenv("ATLASCLOUD_BASE_URL", "https://api.atlascloud.ai/v1")
+    base_url = (
+        os.getenv("ATLASCLOUD_BASE_URL")
+        or CONFIG.get("Atlas", "base_url", fallback="https://api.atlascloud.ai/v1")
+    )
     return AtlasClient(api_key=api_key, base_url=base_url)

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -28,6 +28,23 @@ from app.logger import logger
 from app.config import CONFIG
 from app.schemas.request import OpenAIChatRequest
 
+@dataclass(frozen=True)
+class PlaywrightAdapterConfig:
+    """Consolidated configuration for the Playwright adapter."""
+    navigation_timeout: int
+    ui_wait_timeout: int
+    chunk_timeout: int
+    total_request_timeout: int
+
+    @classmethod
+    def load(cls) -> "PlaywrightAdapterConfig":
+        return cls(
+            navigation_timeout=CONFIG["Playwright"].getint("navigation_timeout", 30000),
+            ui_wait_timeout=CONFIG["Playwright"].getint("ui_wait_timeout", 15000),
+            chunk_timeout=CONFIG["Playwright"].getint("chunk_timeout", 90),
+            total_request_timeout=CONFIG["Playwright"].getint("total_request_timeout", 120)
+        )
+
 @dataclass
 class PlaywrightRequestState:
     """Shared state for a single request lifecycle in Playwright."""
@@ -57,6 +74,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
     
     def __init__(self, provider):
         self.provider = provider
+        self.config = PlaywrightAdapterConfig.load()
 
     async def chat_completions(self, request: OpenAIChatRequest, cid: str, is_new_conversation: bool, tools_prompt: str) -> Any:
         request_id = str(uuid.uuid4()).replace("-", "_")
@@ -87,8 +105,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
 
             engine = await get_browser_engine()
             session = await engine.get_session("gemini")
-            adapter = GeminiProviderAdapter()
-            
+            adapter = GeminiProviderAdapter(ui_wait_timeout=self.config.ui_wait_timeout)
             for attempt in range(1, max_retries + 1):
                 page_lease = None
                 observer_task = None
@@ -156,31 +173,29 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                     page._gemini_callbacks[state.request_id] = bridge_callback
                     await asyncio.sleep(0.01)
                     
-                    nav_timeout = CONFIG["Playwright"].getint("navigation_timeout", 30000)
-                    
                     # 2. Target Navigation
                     check_generation()
                     if state.reused_conversation:
                         target_url = f"https://gemini.google.com/app/{state.conversation_id}"
                         if page.url != target_url:
                             if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                            await page.goto(target_url, wait_until="domcontentloaded", timeout=nav_timeout)
+                            await page.goto(target_url, wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
                             if state.active_tab: state.active_tab.heartbeat("navigation_end")
                     elif request.conversation_id:
                         if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                        await page.goto(f"https://gemini.google.com/app/{request.conversation_id}", wait_until="domcontentloaded", timeout=nav_timeout)
+                        await page.goto(f"https://gemini.google.com/app/{request.conversation_id}", wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
                         if state.active_tab: state.active_tab.heartbeat("navigation_end")
                     else:
                         if "gemini.google.com/app" not in page.url:
                             if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                            await page.goto("https://gemini.google.com/app", wait_until="domcontentloaded", timeout=nav_timeout)
+                            await page.goto("https://gemini.google.com/app", wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
                             if state.active_tab: state.active_tab.heartbeat("navigation_end")
                     
                     input_locator = page.locator(SELECTORS["INPUT"]).first
                     if state.active_tab: state.active_tab.heartbeat("input_wait")
                     try:
                         check_generation()
-                        await input_locator.wait_for(state="visible", timeout=15000)
+                        await input_locator.wait_for(state="visible", timeout=self.config.ui_wait_timeout)
                         await asyncio.sleep(0.5)
                     except (PlaywrightTimeoutError, PlaywrightError) as e:
                         state.page_poisoned = True
@@ -262,7 +277,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            # Error mapping logic...
+            # Map internal Playwright and provider errors to appropriate HTTP status codes
             poison_session_errors = (SessionNotAliveError, BrowserDisconnectedError, BrowserGenerationMismatchError)
             if isinstance(e, poison_session_errors) and session:
                 await session.handle_session_failure()
@@ -298,7 +313,6 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
 
     async def _sse_generator(self, queue: asyncio.Queue, model: str, page: Page, state: PlaywrightRequestState, observer_task: Optional[asyncio.Task], engine: Any, session: Any, lease: ManagedPage):
         from app.utils.streaming import format_sse_chunk, get_done_chunk
-        chunk_timeout = CONFIG["Playwright"].getint("chunk_timeout", 90)
         
         try:
             while True:
@@ -312,7 +326,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                                     state.conversation_id = match.group(1)
                                     state.active_tab = await session.register_conversation(state.conversation_id, lease)
 
-                    payload = await asyncio.wait_for(queue.get(), timeout=chunk_timeout)
+                    payload = await asyncio.wait_for(queue.get(), timeout=self.config.chunk_timeout)
                     if payload.get("type") == "done": break
                     
                     if state.active_tab:
@@ -341,10 +355,9 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
             await self._cleanup(observer_task, state, lease, session)
 
     async def _get_buffered_response(self, queue: asyncio.Queue, model: str, page: Page, state: PlaywrightRequestState, observer_task: Optional[asyncio.Task], engine: Any, session: Any, lease: ManagedPage):
-        total_timeout = CONFIG["Playwright"].getint("total_request_timeout", 120)
         try:
             full_text = ""
-            async with asyncio.timeout(total_timeout):
+            async with asyncio.timeout(self.config.total_request_timeout):
                 while True:
                     if state.queue_overflow: raise QueueOverflowError("Event queue saturated")
                     if not state.conversation_id and not state.active_tab:

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -47,6 +47,10 @@ class GeminiProvider(BaseProvider):
         if not request.messages:
             raise HTTPException(status_code=400, detail="No messages provided.")
 
+        # Apply default model if none provided
+        if not request.model:
+            request.model = CONFIG["Gemini"].get("default_model", "gemini-3-flash")
+
         validate_model_name(request.model)
 
         # 1. Resolve or generate conversation_id securely

--- a/src/run.py
+++ b/src/run.py
@@ -67,7 +67,7 @@ def print_server_info(host: str, port: int, mode: str):
         try:
             CONFIG = load_config()
             print(f"  - Browser: {CONFIG['Browser']['name']}")
-            print(f"  - Model: {CONFIG['AI']['default_model_gemini']}")
+            print(f"  - Model: {CONFIG['Gemini']['default_model']}")
         except Exception:
             print("  - Could not load config details.")
         print("\n🔗 API Endpoints:")


### PR DESCRIPTION
## Summary

Refactors project configuration to better match the provider-centric architecture, removes unused/dead settings, documents the actual provider routing behavior, and fixes the Playwright UI wait timeout configuration.

## Key Changes

* Removed the unused `[AI] default_ai` setting; provider selection now remains explicitly based on request `provider`, model prefixes, or the existing Gemini fallback.
* Removed the abandoned `[Astraflow]` configuration section and added `[Atlas]` configuration fallback support while preserving `ATLASCLOUD_*` environment variable precedence.
* Moved Gemini default model ownership from `[AI] default_model_gemini` to `[Gemini] default_model`, with legacy fallback support for existing configs.
* Kept `[Gemini] backend` as the authoritative default strategy for unprefixed Gemini requests, while documenting prefix overrides such as `playwright/...`.
* Updated `config.conf.example` and `README.md` to clarify provider routing, Atlas config precedence, Gemini backend behavior, and Playwright timeout units.
* Fixed `ui_wait_timeout` so it is actually applied to Gemini Playwright UI waits instead of being ignored due to hardcoded timeout values.
* Centralized Playwright adapter timeout reads to avoid scattered config lookups in the request path.

## Testing

* `pytest`
* Result: `130 passed`
