### PR TITLE
fix: config cookie keys not recognized, causing authentication to always fail

### DIFF
--- a/src/app/services/gemini_client.py
+++ b/src/app/services/gemini_client.py
@@ -39,8 +39,8 @@ async def init_gemini_client() -> bool:
             client = None
             
             if config_cookies:
-                # Strip potential double quotes from cookie values added manually by the user
-                cleaned_cookies = {k: v.strip('"') for k, v in config_cookies.items() if k in ["__Secure-1PSID", "__Secure-1PSIDTS"]}
+                # Strip potential double quotes from cookie values added manually by the user (Added gemini cookie for configs)
+                cleaned_cookies = {k: v.strip('"') for k, v in config_cookies.items() if k in ["__Secure-1PSID", "__Secure-1PSIDTS", "gemini_cookie_1psid", "gemini_cookie_1psidts", "gemini_cookie_1PSID", "gemini_cookie_1PSIDTS"]}
 
                 logger.info(f"Attempting to initialize Gemini client with {len(cleaned_cookies)} essential cookies from config...")
                 


### PR DESCRIPTION
Config.conf uses gemini_cookie_1psid/gemini_cookie_1psidts key names but the filter only checked for __Secure-1PSID/__Secure-1PSIDTS, causing cookies to always be empty (0 essential cookies from config).

Added gemini_cookie_* variants to the filter to support both formats. Didn't touched the __Secure-1PSID. Suggesting to remove them or change config.