### PR TITLE
Restore Playwright bootstrap authentication and harden verify_login

### DIFF
--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -480,10 +480,31 @@ class ProviderSession:
         if self.name == "gemini":
             from app.services.browser.auth_loader import GeminiAuthStateLoader
             from app.services.providers.gemini.auth_selector import GeminiAuthSelector
-            auth_candidate = GeminiAuthSelector.first_playwright_storage_candidate()
+            allow_unauthenticated_bootstrap_context = (
+                getattr(self.engine, "is_bootstrap", False)
+                and self.enable_persistence
+            )
+            if allow_unauthenticated_bootstrap_context:
+                auth_candidate = next(
+                    (
+                        candidate
+                        for candidate in GeminiAuthSelector.iter_candidates()
+                        if candidate.supports_playwright_storage
+                    ),
+                    None,
+                )
+            else:
+                auth_candidate = GeminiAuthSelector.first_playwright_storage_candidate()
             if auth_candidate:
                 context_args["storage_state"] = GeminiAuthStateLoader.translate_to_playwright(
                     auth_candidate.auth_data
+                )
+            elif allow_unauthenticated_bootstrap_context:
+                logger.info(
+                    "ProviderSession(%s): Initializing unauthenticated bootstrap context "
+                    "for explicit login state creation.",
+                    self.name,
+                    extra={"generation": self.engine.browser_generation}
                 )
             else:
                 raise RuntimeError(

--- a/tests/test_auth_endpoints.py
+++ b/tests/test_auth_endpoints.py
@@ -267,10 +267,13 @@ async def test_run_login_flow_success(mocker):
     mock_engine.__aenter__ = AsyncMock(return_value=mock_engine)
     mock_engine.__aexit__ = AsyncMock(return_value=False)  # DO NOT suppress exceptions
 
-    mocker.patch('app.services.browser.engine.get_browser_engine', return_value=mock_engine)
+    get_engine = mocker.patch('app.services.browser.engine.get_browser_engine', return_value=mock_engine)
 
     await auth_mgr.run_login_flow()
 
+    get_engine.assert_called_once_with(headless=False, is_bootstrap=True)
+    mock_engine.get_page.assert_called_once_with("gemini", enable_persistence=True)
+    mock_engine.get_session.assert_called_once_with("gemini", enable_persistence=True)
     mock_session.save_state.assert_called_once()
     mock_page_wrapper.close.assert_called_once()
 

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -18,7 +18,7 @@ def auth_candidate(auth_data, source_type="gemini_config", is_legacy=False):
     )
 
 
-def make_engine():
+def make_engine(is_bootstrap=False):
     context = MagicMock()
     context.on = MagicMock()
     context.new_page = AsyncMock(return_value=MagicMock())
@@ -31,6 +31,7 @@ def make_engine():
     engine.browser = browser
     engine.browser_generation = 3
     engine.is_shutting_down = False
+    engine.is_bootstrap = is_bootstrap
     return engine, browser
 
 
@@ -120,3 +121,90 @@ async def test_gemini_setup_fails_without_auth(mocker):
     
     assert "Gemini Playwright backend requires a valid storage state" in str(excinfo.value)
     assert "python verify_login.py" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_gemini_bootstrap_setup_allows_missing_auth_with_persistence(mocker):
+    engine, browser = make_engine(is_bootstrap=True)
+    selector = mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    mocker.patch.object(session, "close_resources", AsyncMock())
+    mocker.patch.object(session, "_eviction_loop", AsyncMock())
+    mocker.patch.object(session, "_reaper_loop", AsyncMock())
+
+    await session._setup()
+
+    selector.assert_called_once()
+    assert "storage_state" not in browser.new_context.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_gemini_bootstrap_setup_uses_existing_storage_candidate(mocker):
+    auth_data = {
+        "cookies": [
+            {"name": "__Secure-1PSID", "value": "psid", "domain": ".google.com"},
+        ],
+        "origins": [],
+    }
+    storage_state = {"cookies": auth_data["cookies"], "origins": []}
+    engine, browser = make_engine(is_bootstrap=True)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([auth_candidate(auth_data, source_type="json_store")]),
+    )
+    translate = mocker.patch(
+        "app.services.browser.auth_loader.GeminiAuthStateLoader.translate_to_playwright",
+        return_value=storage_state,
+    )
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    mocker.patch.object(session, "close_resources", AsyncMock())
+    mocker.patch.object(session, "_eviction_loop", AsyncMock())
+    mocker.patch.object(session, "_reaper_loop", AsyncMock())
+
+    await session._setup()
+
+    translate.assert_called_once_with(auth_data)
+    assert browser.new_context.call_args.kwargs["storage_state"] == storage_state
+
+
+@pytest.mark.asyncio
+async def test_gemini_setup_enable_persistence_without_bootstrap_still_requires_auth(mocker):
+    engine, browser = make_engine(is_bootstrap=False)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    mocker.patch.object(session, "close_resources", AsyncMock())
+    mocker.patch.object(session, "_eviction_loop", AsyncMock())
+    mocker.patch.object(session, "_reaper_loop", AsyncMock())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await session._setup()
+
+    assert "Gemini Playwright backend requires a valid storage state" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_gemini_bootstrap_without_persistence_still_requires_auth(mocker):
+    engine, browser = make_engine(is_bootstrap=True)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    session = ProviderSession(engine, "gemini", enable_persistence=False)
+    mocker.patch.object(session, "close_resources", AsyncMock())
+    mocker.patch.object(session, "_eviction_loop", AsyncMock())
+    mocker.patch.object(session, "_reaper_loop", AsyncMock())
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await session._setup()
+
+    assert "Gemini Playwright backend requires a valid storage state" in str(excinfo.value)

--- a/tests/test_verify_login.py
+++ b/tests/test_verify_login.py
@@ -1,0 +1,113 @@
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import verify_login
+
+
+class AsyncEngineContext:
+    def __init__(self, engine):
+        self.engine = engine
+
+    async def __aenter__(self):
+        return self.engine
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.engine.close()
+        return False
+
+
+async def never_enter():
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_completion_signal_returns_when_engine_starts_shutdown():
+    engine = MagicMock()
+    engine.is_shutting_down = False
+
+    page = MagicMock()
+    page.is_closed.return_value = False
+
+    session = MagicMock()
+    session.is_alive = True
+
+    async def trigger_shutdown():
+        await asyncio.sleep(0.01)
+        engine.is_shutting_down = True
+
+    shutdown_task = asyncio.create_task(trigger_shutdown())
+    try:
+        result = await verify_login._wait_for_completion_signal(
+            engine,
+            page,
+            session,
+            stdin_waiter=never_enter,
+        )
+    finally:
+        await shutdown_task
+
+    assert result == "engine_shutdown"
+
+
+@pytest.mark.asyncio
+async def test_completion_signal_returns_when_page_closes():
+    engine = MagicMock()
+    engine.is_shutting_down = False
+
+    page = MagicMock()
+    page.is_closed.return_value = True
+
+    session = MagicMock()
+    session.is_alive = True
+
+    result = await verify_login._wait_for_completion_signal(
+        engine,
+        page,
+        session,
+        stdin_waiter=never_enter,
+    )
+
+    assert result == "page_closed"
+
+
+@pytest.mark.asyncio
+async def test_verify_login_releases_page_when_browser_completion_signal_fires(mocker):
+    page = MagicMock()
+    page.goto = AsyncMock()
+
+    page_wrapper = MagicMock()
+    page_wrapper.page = page
+    page_wrapper.close = AsyncMock()
+
+    session = MagicMock()
+    session.state_path = "runtime/auth/gemini.json"
+    session.is_alive = True
+    session.save_state = AsyncMock()
+
+    engine = MagicMock()
+    engine.get_page = AsyncMock(return_value=page_wrapper)
+    engine.get_session = AsyncMock(return_value=session)
+    engine.close = AsyncMock()
+
+    mocker.patch.object(
+        verify_login,
+        "get_browser_engine",
+        AsyncMock(return_value=AsyncEngineContext(engine)),
+    )
+    mocker.patch.object(
+        verify_login,
+        "_wait_for_completion_signal",
+        AsyncMock(return_value="engine_shutdown"),
+    )
+
+    await verify_login.verify_login()
+
+    engine.get_page.assert_called_once_with("gemini", enable_persistence=True)
+    engine.get_session.assert_called_once_with("gemini", enable_persistence=True)
+    page_wrapper.close.assert_called_once()
+    engine.close.assert_called_once()

--- a/verify_login.py
+++ b/verify_login.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import sys
 import re
+from contextlib import suppress
 
 # Add src to sys.path to allow imports
 sys.path.append(os.path.join(os.getcwd(), "src"))
@@ -10,6 +11,64 @@ from app.services.browser.engine import get_browser_engine
 from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
 from playwright.async_api import Error as PlaywrightError
 from app.logger import logger
+
+
+async def _wait_for_stdin_enter():
+    """
+    Wait for ENTER without occupying the default executor with a blocking
+    stdin read. This lets browser/page shutdown win the bootstrap wait race.
+    """
+    loop = asyncio.get_running_loop()
+    done = loop.create_future()
+    fd = sys.stdin.fileno()
+
+    def on_stdin_ready():
+        with suppress(Exception):
+            loop.remove_reader(fd)
+        if not done.done():
+            sys.stdin.readline()
+            done.set_result("enter")
+
+    loop.add_reader(fd, on_stdin_ready)
+    try:
+        return await done
+    finally:
+        with suppress(Exception):
+            loop.remove_reader(fd)
+
+
+async def _wait_for_browser_shutdown(engine, page, session, poll_interval=0.25):
+    while True:
+        if engine.is_shutting_down:
+            return "engine_shutdown"
+        try:
+            if page.is_closed():
+                return "page_closed"
+        except PlaywrightError:
+            return "page_closed"
+        except Exception:
+            return "page_closed"
+        if not session.is_alive:
+            return "session_closed"
+        await asyncio.sleep(poll_interval)
+
+
+async def _wait_for_completion_signal(engine, page, session, stdin_waiter=None):
+    stdin_waiter = stdin_waiter or _wait_for_stdin_enter
+    wait_tasks = {
+        asyncio.create_task(stdin_waiter()): "stdin",
+        asyncio.create_task(_wait_for_browser_shutdown(engine, page, session)): "browser",
+    }
+
+    done, pending = await asyncio.wait(wait_tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    finished = done.pop()
+    return await finished
+
 
 async def verify_login():
     """
@@ -43,6 +102,7 @@ async def verify_login():
         print("2. Once you reach the chat interface, this utility will automatically detect it.")
         print("3. The persistent state will be saved atomically to the target file.")
         print("4. Press ENTER in this terminal to complete verification and close.")
+        print("   You may also close the browser window to finish after login is detected.")
         print("="*60 + "\n")
         
         login_detected = False
@@ -76,8 +136,7 @@ async def verify_login():
  
         # Wait for user to press Enter in a non-blocking way for the loop
         try:
-            # Using run_in_executor to not block the event loop while waiting for input
-            await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)
+            await _wait_for_completion_signal(engine, page, session)
         except KeyboardInterrupt:
             pass
         finally:


### PR DESCRIPTION
## Summary
This PR restores the first-time bootstrap authentication flow for the Playwright engine and hardens the `verify_login.py` utility to handle browser shutdown gracefully.

## Key Changes
- **Auth Bootstrap**: Restored the ability to initialize an unauthenticated browser context specifically for bootstrap purposes (first-time login).
- **Session Lifecycle**: Updated `ProviderSession` to allow unauthenticated Gemini contexts when `is_bootstrap` is set.
- **Utility Improvements**: Refactored `verify_login.py` to use non-blocking stdin reads and monitor browser/engine health during the login process.
- **Robustness**: Ensures the utility exits cleanly if the browser window is closed or the engine shuts down.
- **Testing**: Added comprehensive unit tests for the bootstrap flow and the login verification utility.

## Testing
- Tests run: Not verified
- Result: Unknown

## Notes
- ⚠ Test files were modified, but no test execution evidence was found.
