### PR TITLE
Harden and synchronize Gemini Playwright model selection and discovery

### DIFF
--- a/docs/specs/provider-contract.md
+++ b/docs/specs/provider-contract.md
@@ -112,6 +112,20 @@ Providers must implement the following logic in their `chat_completions` impleme
 - Use the adapter's `submit_prompt` method.
 - Verify submission success via bridge signals before proceeding to stream generation.
 
+#### Gemini Playwright Model Selection
+
+Gemini Playwright adapters MAY support UI-level model selection. When implemented, the following requirements apply:
+
+Requirements:
+
+- Requested models MUST be validated before prompt submission.
+- Model selection MUST occur while holding `session.submit_lock`.
+- Browser-native adapters own the low-level UI interaction required to perform model selection.
+- Unsupported, unavailable, or subscription-gated models MUST fail explicitly.
+- Silent fallback to another Gemini model is forbidden.
+- Providers MUST verify that the selected model matches the requested model before prompt submission.
+- Model selection depends on the Gemini web UI and may require selector updates if the provider interface changes.
+
 ### 7.4 Mandatory Cleanup
 - **Async Shield Rationale**: All teardown logic MUST be wrapped in `asyncio.shield`. This prevents task cancellation from interrupting the cleanup sequence, which would otherwise cause critical resource leaks (stale locks, semaphore permits, or callback registry entries).
 - **Idempotency Invariant**: Cleanup paths and `ManagedPage.close()` MUST be idempotent. Teardown logic must be safe for multiple concurrent or sequential executions during task cancellation races.

--- a/src/app/services/browser/adapters/gemini_adapter.py
+++ b/src/app/services/browser/adapters/gemini_adapter.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional, Any
 from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 from app.services.browser.base_adapter import BaseProviderAdapter
-from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS, MODEL_PICKER_FALLBACK_SELECTORS
 from app.logger import logger
 from app.services.browser.errors import TransientSessionError, ModelNotFoundError, GatedModelError
 
@@ -110,12 +110,6 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         Locate the model picker button using primary and fallback selectors.
         """
         primary = SELECTORS["MODEL_PICKER"]
-        fallbacks = [
-            'button[aria-label*="Select model"]',
-            'button:has-text("Gemini")',
-            '[data-test-id="model-selector"]',
-            '.input-area-switch-label'
-        ]
         
         # Try primary first
         picker = page.locator(primary).first
@@ -123,7 +117,7 @@ class GeminiProviderAdapter(BaseProviderAdapter):
             return picker
             
         # Try fallbacks
-        for selector in fallbacks:
+        for selector in MODEL_PICKER_FALLBACK_SELECTORS:
             picker = page.locator(selector).first
             if await picker.count() > 0:
                 return picker

--- a/src/app/services/browser/adapters/gemini_adapter.py
+++ b/src/app/services/browser/adapters/gemini_adapter.py
@@ -1,11 +1,11 @@
 import asyncio
 import re
 from typing import Optional, Any
-from playwright.async_api import Page
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 from app.services.browser.base_adapter import BaseProviderAdapter
 from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
 from app.logger import logger
-from app.services.browser.errors import TransientSessionError
+from app.services.browser.errors import TransientSessionError, ModelNotFoundError, GatedModelError
 
 class GeminiProviderAdapter(BaseProviderAdapter):
     """
@@ -104,3 +104,101 @@ class GeminiProviderAdapter(BaseProviderAdapter):
                 break
                 
         return confirmed
+
+    async def get_active_model(self, page: Page) -> Optional[str]:
+        """
+        Detect the currently active Gemini model from the UI.
+        Returns the simplified label (e.g., 'Flash', 'Pro') or None if undetected.
+        """
+        picker = page.locator(SELECTORS["MODEL_PICKER"]).first
+        if await picker.count() == 0:
+            return None
+        
+        # Try to extract from aria-label first (most reliable)
+        aria_label = await picker.get_attribute("aria-label")
+        if aria_label and "currently " in aria_label:
+            return aria_label.split("currently ")[-1].strip()
+        
+        # Fallback to button text
+        text = await picker.inner_text()
+        if text:
+            return text.strip()
+            
+        return None
+
+    async def select_model(self, page: Page, requested_model_label: str, state: Optional[Any] = None) -> None:
+        """
+        Explicitly select a Gemini model via the UI picker.
+        Fails fast if the model is not found or selection verification fails.
+        """
+        active_model = await self.get_active_model(page)
+        if active_model and requested_model_label.lower() in active_model.lower():
+            logger.debug(f"Model selection no-op: '{active_model}' already active.", extra={"request_id": getattr(state, "request_id", "unknown")})
+            return
+
+        logger.info(f"Switching Gemini model: '{active_model}' -> '{requested_model_label}'", extra={"request_id": getattr(state, "request_id", "unknown")})
+        
+        picker = page.locator(SELECTORS["MODEL_PICKER"]).first
+        if await picker.count() == 0:
+            raise TransientSessionError("Gemini model picker not found in the UI.")
+
+        # 1. Open Picker
+        await picker.click()
+        
+        # 2. Wait for options to become visible (replaces asyncio.sleep)
+        try:
+            await page.locator(SELECTORS["MODEL_OPTION"]).first.wait_for(state="visible", timeout=3000)
+        except PlaywrightTimeoutError:
+            raise TransientSessionError("Gemini model options menu failed to open or items are not visible.")
+        
+        # 3. Find and click option
+        options = page.locator(SELECTORS["MODEL_OPTION"])
+        option_count = await options.count()
+        
+        target_option = None
+        found_labels = []
+        for i in range(option_count):
+            opt = options.nth(i)
+            label = await opt.inner_text()
+            found_labels.append(label.strip().replace("\n", " "))
+            if requested_model_label.lower() in label.lower():
+                target_option = opt
+                break
+        
+        if not target_option:
+            # Check for paywalls or gated models in the content
+            page_content = await page.content()
+            if "Try Gemini Advanced" in page_content and requested_model_label.lower() == "pro":
+                raise GatedModelError(
+                    f"Requested model '{requested_model_label}' is gated behind a Gemini Advanced subscription."
+                )
+            
+            raise ModelNotFoundError(
+                f"Requested Gemini model '{requested_model_label}' not found in the picker menu. "
+                f"Available options: {found_labels}"
+            )
+
+        await target_option.click()
+        
+        # 4. Verify Selection (polling with short timeout)
+        verification_timeout = 3.0
+        poll_interval = 0.5
+        elapsed = 0.0
+        success = False
+        last_found = None
+        
+        while elapsed < verification_timeout:
+            new_active = await self.get_active_model(page)
+            last_found = new_active
+            if new_active and requested_model_label.lower() in new_active.lower():
+                success = True
+                break
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+        if not success:
+            raise TransientSessionError(
+                f"Gemini model selection verification failed. Requested: '{requested_model_label}', Found: '{last_found}'"
+            )
+        
+        logger.info(f"Gemini model successfully switched to '{last_found}'", extra={"request_id": getattr(state, "request_id", "unknown")})

--- a/src/app/services/browser/adapters/gemini_adapter.py
+++ b/src/app/services/browser/adapters/gemini_adapter.py
@@ -105,13 +105,38 @@ class GeminiProviderAdapter(BaseProviderAdapter):
                 
         return confirmed
 
+    async def _find_model_picker(self, page: Page) -> Optional[Any]:
+        """
+        Locate the model picker button using primary and fallback selectors.
+        """
+        primary = SELECTORS["MODEL_PICKER"]
+        fallbacks = [
+            'button[aria-label*="Select model"]',
+            'button:has-text("Gemini")',
+            '[data-test-id="model-selector"]',
+            '.input-area-switch-label'
+        ]
+        
+        # Try primary first
+        picker = page.locator(primary).first
+        if await picker.count() > 0:
+            return picker
+            
+        # Try fallbacks
+        for selector in fallbacks:
+            picker = page.locator(selector).first
+            if await picker.count() > 0:
+                return picker
+                
+        return None
+
     async def get_active_model(self, page: Page) -> Optional[str]:
         """
         Detect the currently active Gemini model from the UI.
         Returns the simplified label (e.g., 'Flash', 'Pro') or None if undetected.
         """
-        picker = page.locator(SELECTORS["MODEL_PICKER"]).first
-        if await picker.count() == 0:
+        picker = await self._find_model_picker(page)
+        if not picker:
             return None
         
         # Try to extract from aria-label first (most reliable)
@@ -122,27 +147,76 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         # Fallback to button text
         text = await picker.inner_text()
         if text:
-            return text.strip()
+            # Often contains version numbers like "3.5 Flash", we want to see if our label is in it
+            return text.strip().replace("\n", " ")
             
         return None
+
+    def is_correct_model_match(self, requested_label: str, ui_label: str) -> bool:
+        """
+        Helper to determine if a UI label matches a requested model label,
+        handling collisions like 'Flash' vs 'Flash-Lite'.
+        """
+        req = requested_label.lower().strip()
+        ui = ui_label.lower().strip()
+        
+        # Space/Hyphen normalization
+        req_norm = req.replace("-", " ")
+        ui_norm = ui.replace("-", " ")
+        
+        # Basic substring check
+        if req not in ui and req_norm not in ui_norm:
+            return False
+            
+        # Collision prevention: 'Flash' should NOT match 'Flash-Lite'
+        # If request is 'Flash' (no 'lite') but UI has 'lite', it's NOT a match.
+        if "flash" in req and "lite" not in req and "lite" in ui:
+            return False
+            
+        return True
 
     async def select_model(self, page: Page, requested_model_label: str, state: Optional[Any] = None) -> None:
         """
         Explicitly select a Gemini model via the UI picker.
         Fails fast if the model is not found or selection verification fails.
         """
+        # Polling/Wait for picker to appear (UI stabilization)
+        max_wait = 5.0
+        interval = 0.5
+        elapsed = 0.0
+        picker = None
+        
+        while elapsed < max_wait:
+            picker = await self._find_model_picker(page)
+            if picker:
+                break
+            await asyncio.sleep(interval)
+            elapsed += interval
+
+        if not picker:
+            # Diagnostics for the error message
+            title = await page.title()
+            url = page.url
+            buttons = await page.query_selector_all('button')
+            labels = []
+            for btn in buttons[:10]: # limit noise
+                label = await btn.get_attribute("aria-label")
+                if label: labels.append(label)
+            
+            raise TransientSessionError(
+                f"Gemini model picker not found in the UI. "
+                f"URL: {url}, Title: '{title}', Candidate labels: {labels}"
+            )
+
         active_model = await self.get_active_model(page)
-        if active_model and requested_model_label.lower() in active_model.lower():
+        if active_model and self.is_correct_model_match(requested_model_label, active_model):
             logger.debug(f"Model selection no-op: '{active_model}' already active.", extra={"request_id": getattr(state, "request_id", "unknown")})
             return
 
         logger.info(f"Switching Gemini model: '{active_model}' -> '{requested_model_label}'", extra={"request_id": getattr(state, "request_id", "unknown")})
         
-        picker = page.locator(SELECTORS["MODEL_PICKER"]).first
-        if await picker.count() == 0:
-            raise TransientSessionError("Gemini model picker not found in the UI.")
-
-        # 1. Open Picker
+        # Ensure picker is in view and ready
+        await picker.scroll_into_view_if_needed()
         await picker.click()
         
         # 2. Wait for options to become visible (replaces asyncio.sleep)
@@ -155,28 +229,71 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         options = page.locator(SELECTORS["MODEL_OPTION"])
         option_count = await options.count()
         
-        target_option = None
-        found_labels = []
+        # Normalize requested label
+        req_lower = requested_model_label.lower().strip()
+        req_norm = req_lower.replace("-", " ")
+        
+        candidates = []
         for i in range(option_count):
             opt = options.nth(i)
-            label = await opt.inner_text()
-            found_labels.append(label.strip().replace("\n", " "))
-            if requested_model_label.lower() in label.lower():
-                target_option = opt
-                break
-        
-        if not target_option:
-            # Check for paywalls or gated models in the content
+            label = (await opt.inner_text()).strip().replace("\n", " ")
+            if not label:
+                continue
+                
+            label_lower = label.lower()
+            label_norm = label_lower.replace("-", " ")
+            
+            # Check for any kind of match
+            is_match = req_lower in label_lower or req_norm in label_norm
+            if not is_match:
+                continue
+                
+            # Score the match
+            score = 0
+            # Priority 1: Exact label match (highest)
+            if req_lower == label_lower or req_norm == label_norm:
+                score += 100
+            
+            # Priority 2: Collision Prevention (very important)
+            # If we want 'Flash' but NOT 'Lite', and the label has 'Lite', penalize heavily
+            is_lite_request = "lite" in req_lower
+            is_lite_label = "lite" in label_lower
+            if not is_lite_request and is_lite_label:
+                score -= 50
+            elif is_lite_request and is_lite_label:
+                score += 20
+                
+            # Priority 3: Contains the exact version requested (if any)
+            # (Future-proofing for when we might want to be more specific)
+            
+            candidates.append({
+                "index": i,
+                "label": label,
+                "score": score,
+                "locator": opt
+            })
+
+        if not candidates:
+            # Diagnostics for the error message
             page_content = await page.content()
             if "Try Gemini Advanced" in page_content and requested_model_label.lower() == "pro":
                 raise GatedModelError(
                     f"Requested model '{requested_model_label}' is gated behind a Gemini Advanced subscription."
                 )
             
+            # Re-collect labels for the error message
+            found_labels = []
+            for i in range(option_count):
+                found_labels.append(await options.nth(i).inner_text())
+
             raise ModelNotFoundError(
                 f"Requested Gemini model '{requested_model_label}' not found in the picker menu. "
                 f"Available options: {found_labels}"
             )
+
+        # Sort candidates by score (descending)
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        target_option = candidates[0]["locator"]
 
         await target_option.click()
         
@@ -190,7 +307,7 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         while elapsed < verification_timeout:
             new_active = await self.get_active_model(page)
             last_found = new_active
-            if new_active and requested_model_label.lower() in new_active.lower():
+            if new_active and self.is_correct_model_match(requested_model_label, new_active):
                 success = True
                 break
             await asyncio.sleep(poll_interval)

--- a/src/app/services/browser/adapters/scripts/gemini_scripts.py
+++ b/src/app/services/browser/adapters/scripts/gemini_scripts.py
@@ -15,6 +15,13 @@ SELECTORS = {
     "MODEL_OPTION": '[role="menuitem"], [role="option"], .mat-mdc-menu-item'
 }
 
+MODEL_PICKER_FALLBACK_SELECTORS = [
+    'button[aria-label*="Select model"]',
+    'button:has-text("Gemini")',
+    '[data-test-id="model-selector"]',
+    '.input-area-switch-label',
+]
+
 POLL_INTERVAL_MS = 50
 COMPLETION_CHECK_MS = 100
 

--- a/src/app/services/browser/adapters/scripts/gemini_scripts.py
+++ b/src/app/services/browser/adapters/scripts/gemini_scripts.py
@@ -10,7 +10,9 @@ SELECTORS = {
     "INPUT": 'div[contenteditable="true"][role="textbox"], textarea.gds-body-l, textarea[placeholder*="Gemini"]',
     "SEND_BUTTON": 'button.send-button, button[aria-label*="Send message"], [data-test-id="send-button"]',
     "STOP_BUTTON": 'button[aria-label*="Stop"], .stop-button',
-    "RESPONSE_CONTAINER": 'message-content, .message-content, [data-test-id="message-content"]'
+    "RESPONSE_CONTAINER": 'message-content, .message-content, [data-test-id="message-content"]',
+    "MODEL_PICKER": 'button[aria-label*="Open mode picker"]',
+    "MODEL_OPTION": '[role="menuitem"], [role="option"], .mat-mdc-menu-item'
 }
 
 POLL_INTERVAL_MS = 50

--- a/src/app/services/browser/errors.py
+++ b/src/app/services/browser/errors.py
@@ -49,3 +49,11 @@ class QueueOverflowError(RequestError):
 class ConversationBusyError(RequestError):
     """Raised when a request is made for a conversation that is already active with another request."""
     pass
+
+class ModelNotFoundError(RequestError):
+    """Raised when a requested model is not found in the provider's UI."""
+    pass
+
+class GatedModelError(RequestError):
+    """Raised when a requested model is gated behind a subscription (paywall)."""
+    pass

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -25,19 +25,13 @@ from app.services.browser.errors import (
     GatedModelError
 )
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
-from app.services.providers.gemini.shared import convert_to_openai_format
+from app.services.providers.gemini.shared import (
+    convert_to_openai_format, 
+    PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
+)
 from app.logger import logger
 from app.config import CONFIG
 from app.schemas.request import OpenAIChatRequest
-
-# Normalization mapping: OpenAI ID -> Gemini UI Label
-# Only include runtime-verified mappings as of June 2026.
-PLAYWRIGHT_GEMINI_MODEL_UI_LABELS = {
-    "gemini-3-pro": "Pro",
-    "gemini-1.5-pro": "Pro",
-    "gemini-3-flash": "Flash",
-    "gemini-1.5-flash": "Flash",
-}
 
 @dataclass(frozen=True)
 class PlaywrightAdapterConfig:
@@ -276,26 +270,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                 check_generation()
                 
                 # 5.a Explicit Model Selection
-                # Map OpenAI model IDs to Gemini UI labels
-                model_id = request.model
-                if model_id.startswith("playwright/"):
-                    model_id = model_id[len("playwright/"):]
-                
-                target_label = PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.get(model_id.lower())
-                if target_label:
-                    if state.active_tab: state.active_tab.heartbeat("model_selection")
-                    try:
-                        await adapter.select_model(page, target_label, state)
-                    except GatedModelError as e:
-                        raise HTTPException(status_code=403, detail=str(e))
-                    except ModelNotFoundError as e:
-                        raise HTTPException(status_code=400, detail=str(e))
-                elif model_id and model_id != "gemini":
-                    # If an unknown model is requested (not 'gemini' default), fail fast
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Requested model '{model_id}' has no known Playwright UI mapping. Supported: {list(PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys())}"
-                    )
+                await self._orchestrate_model_selection(adapter, page, request.model, state)
 
                 confirmed = await adapter.submit_prompt(page, prompt, state)
 

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -20,13 +20,24 @@ from app.services.browser.errors import (
     BrowserGenerationMismatchError,
     LeaseInvalidatedError,
     QueueOverflowError,
-    ConversationBusyError
+    ConversationBusyError,
+    ModelNotFoundError,
+    GatedModelError
 )
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
 from app.services.providers.gemini.shared import convert_to_openai_format
 from app.logger import logger
 from app.config import CONFIG
 from app.schemas.request import OpenAIChatRequest
+
+# Normalization mapping: OpenAI ID -> Gemini UI Label
+# Only include runtime-verified mappings as of June 2026.
+PLAYWRIGHT_GEMINI_MODEL_UI_LABELS = {
+    "gemini-3-pro": "Pro",
+    "gemini-1.5-pro": "Pro",
+    "gemini-3-flash": "Flash",
+    "gemini-1.5-flash": "Flash",
+}
 
 @dataclass(frozen=True)
 class PlaywrightAdapterConfig:
@@ -263,6 +274,29 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
 
             async with session.submit_lock:
                 check_generation()
+                
+                # 5.a Explicit Model Selection
+                # Map OpenAI model IDs to Gemini UI labels
+                model_id = request.model
+                if model_id.startswith("playwright/"):
+                    model_id = model_id[len("playwright/"):]
+                
+                target_label = PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.get(model_id.lower())
+                if target_label:
+                    if state.active_tab: state.active_tab.heartbeat("model_selection")
+                    try:
+                        await adapter.select_model(page, target_label, state)
+                    except GatedModelError as e:
+                        raise HTTPException(status_code=403, detail=str(e))
+                    except ModelNotFoundError as e:
+                        raise HTTPException(status_code=400, detail=str(e))
+                elif model_id and model_id != "gemini":
+                    # If an unknown model is requested (not 'gemini' default), fail fast
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Requested model '{model_id}' has no known Playwright UI mapping. Supported: {list(PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys())}"
+                    )
+
                 confirmed = await adapter.submit_prompt(page, prompt, state)
 
             if not confirmed:
@@ -490,5 +524,32 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
     def _validate_tab_generation(self, tab: Any, current_generation: int, message: Optional[str] = None):
         if tab:
             BrowserGenerationMismatchError.validate(tab.browser_generation, current_generation)
+
+    async def _orchestrate_model_selection(self, browser_adapter: GeminiProviderAdapter, page: Page, model_id: str, state: PlaywrightRequestState):
+        """
+        Coordinates model selection logic before prompt submission.
+        Maps OpenAI model IDs to Gemini UI labels and handles selection errors.
+        """
+        if not model_id:
+            return
+
+        if model_id.startswith("playwright/"):
+            model_id = model_id[len("playwright/"):]
+        
+        target_label = PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.get(model_id.lower())
+        if target_label:
+            if state.active_tab: state.active_tab.heartbeat("model_selection")
+            try:
+                await browser_adapter.select_model(page, target_label, state)
+            except GatedModelError as e:
+                raise HTTPException(status_code=403, detail=str(e))
+            except ModelNotFoundError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+        elif model_id != "gemini":
+            # If an unknown model is requested (not 'gemini' default), fail fast
+            raise HTTPException(
+                status_code=400,
+                detail=f"Requested model '{model_id}' has no known Playwright UI mapping. Supported: {list(PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys())}"
+            )
 
     async def close(self) -> None: pass

--- a/src/app/services/providers/gemini/shared.py
+++ b/src/app/services/providers/gemini/shared.py
@@ -114,11 +114,22 @@ def convert_to_openai_format(response_text: str, model: str, stream: bool = Fals
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
 
+# Normalization mapping for Playwright backend: OpenAI ID -> Gemini UI Label
+# Keep ONLY runtime-verified and fully implemented direct-select models.
+# NOTE: "Thinking" models are deferred until submenu handling is implemented.
+PLAYWRIGHT_GEMINI_MODEL_UI_LABELS = {
+    "gemini-3.1-pro": "Pro",
+    "gemini-3.5-flash": "Flash",
+    "gemini-3.1-flash-lite": "Flash-Lite",
+}
+
 def get_gemini_models() -> List[dict]:
     """Return the canonical list of supported Gemini models in OpenAI format."""
     from gemini_webapi.constants import Model
     ts = int(time.time())
-    return [
+    
+    # 1. Standard WebAPI Models
+    models = [
         {
             "id": model.model_name,
             "object": "model",
@@ -128,6 +139,17 @@ def get_gemini_models() -> List[dict]:
         for model in Model
         if model != Model.UNSPECIFIED
     ]
+    
+    # 2. Playwright-native Models
+    for model_id in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys():
+        models.append({
+            "id": f"playwright/{model_id}",
+            "object": "model",
+            "created": ts,
+            "owned_by": "google",
+        })
+    
+    return models
 
 def format_files(files: Optional[List[Union[str, Path]]]) -> Optional[List[Path]]:
     """Convert a list of file paths (strings or Path objects) to Path objects."""

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -6,9 +6,9 @@ from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter, 
     PlaywrightRequestState, 
-    PLAYWRIGHT_GEMINI_MODEL_UI_LABELS,
     PlaywrightAdapterConfig
 )
+from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.errors import TransientSessionError, GatedModelError, ModelNotFoundError
 from app.services.browser.auth_types import AuthStatus
@@ -25,6 +25,8 @@ def mock_page():
     page.content = AsyncMock()
     page.wait_for_selector = AsyncMock()
     page.goto = AsyncMock()
+    page.title = AsyncMock(return_value="Gemini")
+    page.query_selector_all = AsyncMock(return_value=[])
     
     async def fake_evaluate(*args, **kwargs):
         return None
@@ -38,10 +40,18 @@ def mock_page():
 def adapter():
     return GeminiProviderAdapter()
 
+def mock_locator_element():
+    el = MagicMock()
+    el.count = AsyncMock(return_value=1)
+    el.get_attribute = AsyncMock(return_value=None)
+    el.inner_text = AsyncMock(return_value="")
+    el.click = AsyncMock()
+    el.scroll_into_view_if_needed = AsyncMock()
+    return el
+
 @pytest.mark.asyncio
 async def test_get_active_model_via_aria_label(adapter, mock_page):
-    mock_picker = MagicMock()
-    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker = mock_locator_element()
     mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
     
     mock_loc = MagicMock()
@@ -53,8 +63,7 @@ async def test_get_active_model_via_aria_label(adapter, mock_page):
 
 @pytest.mark.asyncio
 async def test_get_active_model_via_text_fallback(adapter, mock_page):
-    mock_picker = MagicMock()
-    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker = mock_locator_element()
     mock_picker.get_attribute = AsyncMock(return_value=None)
     mock_picker.inner_text = AsyncMock(return_value="Pro")
     
@@ -66,12 +75,36 @@ async def test_get_active_model_via_text_fallback(adapter, mock_page):
     assert model == "Pro"
 
 @pytest.mark.asyncio
+async def test_find_model_picker_fallbacks(adapter, mock_page):
+    # Setup: Primary fails, first fallback succeeds
+    mock_primary = MagicMock()
+    mock_primary.count = AsyncMock(return_value=0)
+    mock_primary.first = MagicMock()
+    mock_primary.first.count = AsyncMock(return_value=0)
+    
+    mock_fallback_el = mock_locator_element()
+    mock_fallback_loc = MagicMock()
+    mock_fallback_loc.count = AsyncMock(return_value=1)
+    mock_fallback_loc.first = mock_fallback_el
+    
+    def locator_side_effect(selector):
+        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        if selector == SELECTORS["MODEL_PICKER"]:
+            return mock_primary
+        if selector == 'button[aria-label*="Select model"]':
+            return mock_fallback_loc
+        return MagicMock()
+
+    mock_page.locator.side_effect = locator_side_effect
+    
+    picker = await adapter._find_model_picker(mock_page)
+    assert picker == mock_fallback_el
+
+@pytest.mark.asyncio
 async def test_select_model_no_op_when_already_active(adapter, mock_page):
     # Setup: Active model is 'Flash'
-    mock_picker = MagicMock()
-    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker = mock_locator_element()
     mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
-    mock_picker.click = AsyncMock()
     
     mock_loc = MagicMock()
     mock_loc.first = mock_picker
@@ -86,10 +119,8 @@ async def test_select_model_no_op_when_already_active(adapter, mock_page):
 @pytest.mark.asyncio
 async def test_select_model_success(adapter, mock_page):
     # Initial model 'Flash', then 'Pro'
-    mock_picker = MagicMock()
-    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker = mock_locator_element()
     mock_picker.get_attribute = AsyncMock(side_effect=["Open mode picker, currently Flash", "Open mode picker, currently Pro"])
-    mock_picker.click = AsyncMock()
     
     mock_picker_loc = MagicMock()
     mock_picker_loc.first = mock_picker
@@ -126,12 +157,34 @@ async def test_select_model_success(adapter, mock_page):
     assert opt_pro.click.call_count == 1
 
 @pytest.mark.asyncio
+async def test_select_model_diagnostics_on_failure(adapter, mock_page):
+    # Setup: No picker found
+    mock_loc = MagicMock()
+    mock_loc.count = AsyncMock(return_value=0)
+    mock_loc.first = MagicMock()
+    mock_loc.first.count = AsyncMock(return_value=0)
+    mock_page.locator.return_value = mock_loc
+    
+    mock_page.title = AsyncMock(return_value="Gemini App Title")
+    mock_page.url = "https://gemini.google.com/app/123"
+    
+    mock_btn = MagicMock()
+    mock_btn.get_attribute = AsyncMock(return_value="Help")
+    mock_page.query_selector_all.return_value = [mock_btn]
+    
+    with pytest.raises(TransientSessionError) as excinfo:
+        await adapter.select_model(mock_page, "Pro")
+    
+    assert "Gemini model picker not found" in str(excinfo.value)
+    assert "Gemini App Title" in str(excinfo.value)
+    assert "https://gemini.google.com/app/123" in str(excinfo.value)
+    assert "['Help']" in str(excinfo.value)
+
+@pytest.mark.asyncio
 async def test_select_model_fails_when_gated_advanced(adapter, mock_page):
     # Initial model 'Flash'
-    mock_picker = MagicMock()
-    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker = mock_locator_element()
     mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
-    mock_picker.click = AsyncMock()
     
     mock_picker_loc = MagicMock()
     mock_picker_loc.first = mock_picker
@@ -164,11 +217,129 @@ async def test_select_model_fails_when_gated_advanced(adapter, mock_page):
 @pytest.mark.asyncio
 async def test_model_mapping_constant_validity():
     """Verify that the mapping constant only contains verified labels."""
-    supported_labels = ["Pro", "Flash"]
+    supported_labels = ["Pro", "Flash", "Flash-Lite"]
     for label in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.values():
         assert label in supported_labels
 
-# --- New Orchestration Unit Tests ---
+@pytest.mark.asyncio
+async def test_select_model_collision_prevention_flash_vs_lite(adapter, mock_page):
+    """Verify that requesting 'Flash' doesn't accidentally pick 'Flash-Lite'."""
+    # Setup: 'Flash-Lite' is the first option, '3.5 Flash' is the second
+    mock_picker = mock_locator_element()
+    mock_picker.get_attribute.side_effect = ["Open mode picker, currently Pro", "Open mode picker, currently Gemini 1.5 Flash"]
+    
+    mock_picker_loc = MagicMock()
+    mock_picker_loc.first = mock_picker
+    
+    mock_options = MagicMock()
+    mock_options.count = AsyncMock(return_value=2)
+    mock_options.first.wait_for = AsyncMock()
+    
+    opt_lite = MagicMock()
+    opt_lite.inner_text = AsyncMock(return_value="Gemini 1.5 Flash-Lite")
+    opt_lite.click = AsyncMock()
+    
+    opt_flash = MagicMock()
+    opt_flash.inner_text = AsyncMock(return_value="Gemini 1.5 Flash")
+    opt_flash.click = AsyncMock()
+    
+    mock_options.nth.side_effect = [opt_lite, opt_flash, opt_lite, opt_flash]
+    
+    # Route locator calls
+    def locator_side_effect(selector):
+        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        if selector == SELECTORS["MODEL_PICKER"]:
+            return mock_picker_loc
+        if selector == SELECTORS["MODEL_OPTION"]:
+            return mock_options
+        return MagicMock()
+
+    mock_page.locator.side_effect = locator_side_effect
+    
+    # Requesting 'Flash'
+    await adapter.select_model(mock_page, "Flash")
+    
+    # Verify '3.5 Flash' (opt_flash) was clicked, NOT 'Flash-Lite'
+    assert opt_flash.click.call_count == 1
+    assert opt_lite.click.call_count == 0
+
+@pytest.mark.asyncio
+async def test_get_gemini_models_discovery_consistency():
+    """Verify that get_gemini_models returns exactly the verified playwright models."""
+    from app.services.providers.gemini.shared import get_gemini_models
+    
+    models = get_gemini_models()
+    model_ids = [m["id"] for m in models]
+    
+    # 1. Verify exactly these models exist
+    verified_playwright_models = [
+        "playwright/gemini-3.1-pro",
+        "playwright/gemini-3.5-flash",
+        "playwright/gemini-3.1-flash-lite"
+    ]
+    for model_id in verified_playwright_models:
+        assert model_id in model_ids, f"Expected {model_id} to be advertised"
+        
+    # 2. Verify specific unverified aliases are NOT advertised
+    unverified = [
+        "playwright/gemini-3-pro",
+        "playwright/gemini-3-thinking",
+        "playwright/gemini-1.5-pro"
+    ]
+    for model_id in unverified:
+        assert model_id not in model_ids, f"Did NOT expect {model_id} to be advertised"
+
+# --- Orchestration Unit Tests ---
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_versioned_aliases():
+    """Verify ONLY restricted versioned aliases map correctly."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_browser_adapter.select_model = AsyncMock()
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state.active_tab = MagicMock()
+    
+    # Verified Models
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, mock_page, "playwright/gemini-3.5-flash", mock_state
+    )
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, mock_page, "playwright/gemini-3.1-pro", mock_state
+    )
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, mock_page, "playwright/gemini-3.1-flash-lite", mock_state
+    )
+    
+    assert mock_browser_adapter.select_model.call_count == 3
+    mock_browser_adapter.select_model.assert_any_call(mock_page, "Flash", mock_state)
+    mock_browser_adapter.select_model.assert_any_call(mock_page, "Pro", mock_state)
+    mock_browser_adapter.select_model.assert_any_call(mock_page, "Flash-Lite", mock_state)
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_unsupported_aliases_fail():
+    """Verify that unverified legacy aliases fail fast with HTTP 400."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    
+    unsupported = [
+        "playwright/gemini-3-pro",
+        "playwright/gemini-1.5-pro",
+        "playwright/gemini-3-flash",
+        "playwright/gemini-1.5-flash",
+        "playwright/gemini-3-flash-lite",
+        "playwright/gemini-1.5-flash-lite",
+        "playwright/gemini-3-thinking"
+    ]
+    
+    for model in unsupported:
+        with pytest.raises(HTTPException) as excinfo:
+            await adapter._orchestrate_model_selection(mock_browser_adapter, mock_page, model, mock_state)
+        assert excinfo.value.status_code == 400
+        assert "no known Playwright UI mapping" in excinfo.value.detail
 
 @pytest.mark.asyncio
 async def test_orchestrate_model_selection_unknown_model_fails_400():
@@ -205,7 +376,7 @@ async def test_orchestrate_model_selection_gated_model_maps_403():
         await adapter._orchestrate_model_selection(
             mock_browser_adapter, 
             mock_page, 
-            "playwright/gemini-3-pro", 
+            "playwright/gemini-3.1-pro", 
             mock_state
         )
     
@@ -226,7 +397,7 @@ async def test_orchestrate_model_selection_not_found_maps_400():
         await adapter._orchestrate_model_selection(
             mock_browser_adapter, 
             mock_page, 
-            "playwright/gemini-3-pro", 
+            "playwright/gemini-3.1-pro", 
             mock_state
         )
     
@@ -246,7 +417,7 @@ async def test_orchestrate_model_selection_success():
     await adapter._orchestrate_model_selection(
         mock_browser_adapter, 
         mock_page, 
-        "playwright/gemini-3-flash", 
+        "playwright/gemini-3.5-flash", 
         mock_state
     )
     

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -1,0 +1,254 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from fastapi import HTTPException
+from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
+from app.services.providers.gemini.playwright_adapter import (
+    GeminiPlaywrightAdapter, 
+    PlaywrightRequestState, 
+    PLAYWRIGHT_GEMINI_MODEL_UI_LABELS,
+    PlaywrightAdapterConfig
+)
+from app.schemas.request import OpenAIChatRequest
+from app.services.browser.errors import TransientSessionError, GatedModelError, ModelNotFoundError
+from app.services.browser.auth_types import AuthStatus
+
+@pytest.fixture
+def mock_page():
+    page = MagicMock()
+    page._gemini_callbacks = {}
+    page.locator = MagicMock()
+    # Ensure all common awaited methods are AsyncMock
+    page.click = AsyncMock()
+    page.inner_text = AsyncMock()
+    page.get_attribute = AsyncMock()
+    page.content = AsyncMock()
+    page.wait_for_selector = AsyncMock()
+    page.goto = AsyncMock()
+    
+    async def fake_evaluate(*args, **kwargs):
+        return None
+    page.evaluate = AsyncMock(side_effect=fake_evaluate)
+    
+    page.on = MagicMock()
+    page.url = "https://gemini.google.com/app"
+    return page
+
+@pytest.fixture
+def adapter():
+    return GeminiProviderAdapter()
+
+@pytest.mark.asyncio
+async def test_get_active_model_via_aria_label(adapter, mock_page):
+    mock_picker = MagicMock()
+    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
+    
+    mock_loc = MagicMock()
+    mock_loc.first = mock_picker
+    mock_page.locator.return_value = mock_loc
+    
+    model = await adapter.get_active_model(mock_page)
+    assert model == "Flash"
+
+@pytest.mark.asyncio
+async def test_get_active_model_via_text_fallback(adapter, mock_page):
+    mock_picker = MagicMock()
+    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker.get_attribute = AsyncMock(return_value=None)
+    mock_picker.inner_text = AsyncMock(return_value="Pro")
+    
+    mock_loc = MagicMock()
+    mock_loc.first = mock_picker
+    mock_page.locator.return_value = mock_loc
+    
+    model = await adapter.get_active_model(mock_page)
+    assert model == "Pro"
+
+@pytest.mark.asyncio
+async def test_select_model_no_op_when_already_active(adapter, mock_page):
+    # Setup: Active model is 'Flash'
+    mock_picker = MagicMock()
+    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
+    mock_picker.click = AsyncMock()
+    
+    mock_loc = MagicMock()
+    mock_loc.first = mock_picker
+    mock_page.locator.return_value = mock_loc
+    
+    # Requesting 'Flash' should no-op
+    await adapter.select_model(mock_page, "Flash")
+    
+    # Verify picker was not clicked
+    assert mock_picker.click.call_count == 0
+
+@pytest.mark.asyncio
+async def test_select_model_success(adapter, mock_page):
+    # Initial model 'Flash', then 'Pro'
+    mock_picker = MagicMock()
+    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker.get_attribute = AsyncMock(side_effect=["Open mode picker, currently Flash", "Open mode picker, currently Pro"])
+    mock_picker.click = AsyncMock()
+    
+    mock_picker_loc = MagicMock()
+    mock_picker_loc.first = mock_picker
+    
+    # Options menu
+    mock_options = MagicMock()
+    mock_options.count = AsyncMock(return_value=2)
+    mock_options.first.wait_for = AsyncMock()
+    
+    opt_flash = MagicMock()
+    opt_flash.inner_text = AsyncMock(return_value="3.5 Flash")
+    
+    opt_pro = MagicMock()
+    opt_pro.inner_text = AsyncMock(return_value="3.1 Pro")
+    opt_pro.click = AsyncMock()
+    
+    mock_options.nth.side_effect = [opt_flash, opt_pro]
+    
+    # Route locator calls
+    def locator_side_effect(selector):
+        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        if selector == SELECTORS["MODEL_PICKER"]:
+            return mock_picker_loc
+        if selector == SELECTORS["MODEL_OPTION"]:
+            return mock_options
+        return MagicMock()
+
+    mock_page.locator.side_effect = locator_side_effect
+    
+    await adapter.select_model(mock_page, "Pro")
+    
+    # Verify picker was clicked and target option was clicked
+    assert mock_picker.click.call_count == 1
+    assert opt_pro.click.call_count == 1
+
+@pytest.mark.asyncio
+async def test_select_model_fails_when_gated_advanced(adapter, mock_page):
+    # Initial model 'Flash'
+    mock_picker = MagicMock()
+    mock_picker.count = AsyncMock(return_value=1)
+    mock_picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
+    mock_picker.click = AsyncMock()
+    
+    mock_picker_loc = MagicMock()
+    mock_picker_loc.first = mock_picker
+    
+    mock_options = MagicMock()
+    mock_options.count = AsyncMock(return_value=1)
+    mock_options.first.wait_for = AsyncMock()
+    opt_flash = MagicMock()
+    opt_flash.inner_text = AsyncMock(return_value="3.5 Flash")
+    mock_options.nth.return_value = opt_flash
+    
+    # Route locator calls
+    def locator_side_effect(selector):
+        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        if selector == SELECTORS["MODEL_PICKER"]:
+            return mock_picker_loc
+        if selector == SELECTORS["MODEL_OPTION"]:
+            return mock_options
+        return MagicMock()
+
+    mock_page.locator.side_effect = locator_side_effect
+    mock_page.content.return_value = "... Try Gemini Advanced ..."
+    
+    # VERIFY: Should raise GatedModelError, NOT HTTPException
+    with pytest.raises(GatedModelError) as excinfo:
+        await adapter.select_model(mock_page, "Pro")
+    
+    assert "gated behind a Gemini Advanced subscription" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_model_mapping_constant_validity():
+    """Verify that the mapping constant only contains verified labels."""
+    supported_labels = ["Pro", "Flash"]
+    for label in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.values():
+        assert label in supported_labels
+
+# --- New Orchestration Unit Tests ---
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_unknown_model_fails_400():
+    """Verify Task A requirement 1-3: Unknown model fails with HTTP 400 before interaction."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    
+    with pytest.raises(HTTPException) as excinfo:
+        await adapter._orchestrate_model_selection(
+            mock_browser_adapter, 
+            mock_page, 
+            "playwright/unknown-model", 
+            mock_state
+        )
+    
+    assert excinfo.value.status_code == 400
+    assert "no known Playwright UI mapping" in excinfo.value.detail
+    # Verify no interaction occurred
+    assert mock_browser_adapter.select_model.call_count == 0
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_gated_model_maps_403():
+    """Verify Task C requirement: GatedModelError maps to HTTP 403."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_browser_adapter.select_model = AsyncMock(side_effect=GatedModelError("Paywall"))
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state.active_tab = MagicMock()
+    
+    with pytest.raises(HTTPException) as excinfo:
+        await adapter._orchestrate_model_selection(
+            mock_browser_adapter, 
+            mock_page, 
+            "playwright/gemini-3-pro", 
+            mock_state
+        )
+    
+    assert excinfo.value.status_code == 403
+    assert "Paywall" in excinfo.value.detail
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_not_found_maps_400():
+    """Verify Task C requirement: ModelNotFoundError maps to HTTP 400."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_browser_adapter.select_model = AsyncMock(side_effect=ModelNotFoundError("Not in menu"))
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state.active_tab = MagicMock()
+    
+    with pytest.raises(HTTPException) as excinfo:
+        await adapter._orchestrate_model_selection(
+            mock_browser_adapter, 
+            mock_page, 
+            "playwright/gemini-3-pro", 
+            mock_state
+        )
+    
+    assert excinfo.value.status_code == 400
+    assert "Not in menu" in excinfo.value.detail
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_success():
+    """Verify successful orchestration path."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_browser_adapter.select_model = AsyncMock()
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state.active_tab = MagicMock()
+    
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, 
+        mock_page, 
+        "playwright/gemini-3-flash", 
+        mock_state
+    )
+    
+    mock_browser_adapter.select_model.assert_called_once_with(mock_page, "Flash", mock_state)
+    mock_state.active_tab.heartbeat.assert_called_with("model_selection")

--- a/tools/audit_ui.py
+++ b/tools/audit_ui.py
@@ -1,0 +1,182 @@
+# Manual audit script only.
+# Not part of automated tests.
+# Requires runtime/auth/gemini.json and live Gemini UI.
+
+import asyncio
+import os
+import sys
+from playwright.async_api import async_playwright
+
+async def audit():
+    async with async_playwright() as p:
+        # Load storage state
+        storage_state = "runtime/auth/gemini.json"
+        if not os.path.exists(storage_state):
+            print(f"Error: {storage_state} not found.")
+            return
+
+        print(f"Using storage state: {storage_state}")
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context(storage_state=storage_state)
+        page = await context.new_page()
+
+        print("Navigating to Gemini...")
+        try:
+            await page.goto("https://gemini.google.com/app", wait_until="domcontentloaded", timeout=30000)
+            print(f"Current URL: {page.url}")
+        except Exception as e:
+            print(f"Navigation failed: {e}")
+            await browser.close()
+            return
+
+        # Wait for the input to be visible (auth check)
+        try:
+            print(f"Page title: {await page.title()}")
+            # Re-using selectors from production
+            input_selector = 'div[contenteditable="true"][role="textbox"], textarea.gds-body-l, textarea[placeholder*="Gemini"]'
+            await page.wait_for_selector(input_selector, timeout=20000)
+            print("Successfully authenticated and reached Gemini app.")
+            
+            # Diagnostic: Take a look at the DOM structure
+            body_html = await page.evaluate("() => document.body.innerHTML.substring(0, 1000)")
+            # print(f"Body snippet: {body_html}")
+            
+        except Exception as e:
+            print(f"Failed to reach Gemini app or auth expired: {e}")
+            print(f"Current URL: {page.url}")
+            # print(f"Page content snippet: {(await page.content())[:1000]}")
+            await browser.close()
+            return
+
+        print("\n--- Model Selector Audit ---")
+        
+        # Give it a bit more time for dynamic content
+        await asyncio.sleep(5)
+        
+        selectors_to_check = [
+            'button[aria-label*="Select model"]',
+            '[data-test-id="model-selector"]',
+            '.input-area-switch-label',
+            'button[aria-haspopup="menu"]',
+            'button:has-text("Gemini")',
+            'button'
+        ]
+        
+        found_any = False
+        for selector in selectors_to_check:
+            try:
+                locator = page.locator(selector)
+                count = await locator.count()
+                if count > 0:
+                    print(f"Found {count} elements for selector: {selector}")
+                    for i in range(count):
+                        el = locator.nth(i)
+                        text = (await el.inner_text()).replace("\n", " ")
+                        aria_label = await el.get_attribute("aria-label")
+                        print(f"  [{i}] Text: '{text.strip()}', Aria-Label: '{aria_label}'")
+                    found_any = True
+            except:
+                pass
+        
+        if not found_any:
+            print("No common model selectors found via static selectors.")
+            # Let's try to find any button that might be it
+            buttons = await page.query_selector_all('button')
+            print(f"Total buttons on page: {len(buttons)}")
+            for btn in buttons:
+                label = await btn.get_attribute("aria-label")
+                if label and "Gemini" in label:
+                    print(f"Potential button: label='{label}'")
+
+        # 2. Try to find the active model name in the UI
+        print("\n--- Active Model Detection ---")
+        # Often displayed near the top or in the input area
+        potential_model_displays = page.locator('button[aria-label*="Select model"], .model-name, .mode-title, .active-model')
+        count = await potential_model_displays.count()
+        if count == 0:
+             # Try searching by text
+             gemini_mentions = page.locator('*:has-text("Gemini")')
+             # print(f"Found {await gemini_mentions.count()} elements mentioning Gemini")
+        else:
+            for i in range(count):
+                 print(f"Potential model display: {(await potential_model_displays.nth(i).inner_text()).strip()}")
+
+        # 3. Try to click and list menu items if found
+        selector = 'button[aria-label*="Open mode picker"]'
+        
+        if await page.locator(selector).count() > 0:
+            print(f"\nAttempting to open model menu via {selector}...")
+            await page.click(selector)
+            await asyncio.sleep(3) # wait for menu
+            
+            # Look for menu items
+            menu_items = page.locator('[role="menuitem"], [role="option"], .mat-mdc-menu-item, .model-item, [role="listbox"] > *')
+            item_count = await menu_items.count()
+            print(f"Found {item_count} menu items.")
+            
+            target_model_text = "3.1 Pro"
+            clicked = False
+            for i in range(item_count):
+                item = menu_items.nth(i)
+                text = await item.inner_text()
+                if target_model_text in text:
+                    print(f"Found target model '{target_model_text}' in item: '{text.strip()}'. Clicking...")
+                    await item.click()
+                    clicked = True
+                    break
+            
+            if clicked:
+                await asyncio.sleep(2)
+                new_text = await page.locator(selector).inner_text()
+                print(f"Model picker button text after click: '{new_text.strip()}'")
+                
+                # Try sending a prompt
+                print("\nSending prompt 'hi'...")
+                await page.locator(input_selector).first.fill("hi")
+                await page.keyboard.press("Enter")
+                
+                print("Waiting for response to finish (polling for send button to be enabled)...")
+                send_button_selector = 'button[aria-label*="Send message"]'
+                # Poll for up to 30 seconds
+                for _ in range(30):
+                    is_enabled = await page.locator(send_button_selector).is_enabled()
+                    if is_enabled:
+                        print("Response finished.")
+                        break
+                    await asyncio.sleep(1)
+                
+                # Check if selector is still active
+                is_disabled = await page.locator(selector).is_disabled()
+                print(f"Model selector is disabled after response finished: {is_disabled}")
+                
+                if not is_disabled:
+                    print("Attempting to switch model AGAIN after response...")
+                    await page.click(selector)
+                    await asyncio.sleep(2)
+                    
+                    menu_items = page.locator('[role="menuitem"], [role="option"], .mat-mdc-menu-item, .model-item, [role="listbox"] > *')
+                    print(f"Found {await menu_items.count()} menu items after response.")
+                    
+                    # Try switching back to Flash
+                    target_back = "3.5 Flash"
+                    clicked_back = False
+                    for i in range(await menu_items.count()):
+                        item = menu_items.nth(i)
+                        text = await item.inner_text()
+                        if target_back in text:
+                            print(f"Switching back to '{target_back}'...")
+                            await item.click()
+                            clicked_back = True
+                            break
+                    
+                    if clicked_back:
+                        await asyncio.sleep(2)
+                        final_text = await page.locator(selector).inner_text()
+                        print(f"Model picker button text after second switch: '{final_text.strip()}'")
+        else:
+            print("\nCould not find a clickable model selector.")
+        
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(audit())


### PR DESCRIPTION
## Summary

This PR hardens Gemini Playwright model selection, adds precise UI targeting for verified Pro/Flash/Flash-Lite models, and synchronizes `/v1/models` discovery with runtime-supported Playwright models.

## Key Changes

- **Precise Model Selection**: Added scoring-based UI model matching to prevent collisions such as Flash matching Flash-Lite.
- **Restricted Model Matrix**: Limited Playwright Gemini support to `gemini-3.1-pro`, `gemini-3.5-flash`, and `gemini-3.1-flash-lite`.
- **Discovery Synchronization**: Updated `/v1/models` to advertise only verified `playwright/` Gemini models.
- **Fail-Fast Errors**: Unsupported aliases fail with 400, unavailable verified models fail with 400, and Gemini Advanced paywalls fail with 403.
- **Improved UI Diagnostics**: Added fallback picker selectors and diagnostic context when model picker detection fails.
- **Selector Refactor**: Centralized model picker fallback selectors in `gemini_scripts.py`.
- **Testing and Auditing**: Added `tests/test_gemini_model_selection.py` and manual `tools/audit_ui.py`.

## Testing

- `PYTHONPATH=src pytest tests/test_gemini_model_selection.py`
- Result: `16 passed`

## Notes

- Gemini Thinking is intentionally excluded because it requires submenu handling for Standard/Extended modes.