### PR TITLE
Implement Gemini WebAPI conversation deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ curl -X POST http://localhost:6969/v1/chat/completions \
   }'
 ```
 
+### Delete Gemini WebAPI Conversation
+
+```bash
+curl -X DELETE http://localhost:6969/v1/conversations/{conversation_id}
+```
+
+This endpoint deletes Gemini WebAPI conversations created through local SQLite-backed conversation snapshots. Playwright and Atlas conversations are not supported.
+
 ### Playwright Backend
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,38 @@ Returns the list of available models and providers.
 
 ---
 
+### DELETE `/v1/conversations/{conversation_id}`
+
+Deletes a Gemini WebAPI conversation identified by the local `conversation_id`.
+
+This endpoint supports Gemini WebAPI conversations only. Gemini Playwright URL-backed conversations and Atlas requests are not supported by this delete endpoint.
+
+Successful response:
+
+```json
+{
+  "id": "conversation_id",
+  "object": "conversation.deleted",
+  "deleted": true,
+  "provider": "gemini",
+  "backend": "webapi"
+}
+```
+
+Status codes:
+
+| Status | Meaning |
+| ------ | ------- |
+| `200` | Remote Gemini delete and local cleanup completed. |
+| `400` | Invalid `conversation_id`. |
+| `401` | Gemini WebAPI authentication is missing or expired. |
+| `404` | No local WebAPI snapshot exists for the `conversation_id`. |
+| `409` | The conversation is active or already being deleted. |
+| `503` | Gemini client or session registry is unavailable. |
+| `500` | Remote Gemini deletion or local repository cleanup failed. |
+
+---
+
 ## Authentication API
 
 ### GET `/v1/auth/status`

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -16,6 +16,7 @@ WebAI-to-API exposes multiple API surfaces to balance standard compatibility, le
 | Endpoint | Category | Recommended | Persistence | Streaming | Notes |
 | :--- | :--- | :---: | :--- | :---: | :--- |
 | `/v1/chat/completions` | Primary | Yes | Provider/backend-dependent | Yes | Authoritative OpenAI-compatible surface. |
+| `/v1/conversations/{conversation_id}` | Primary | Yes | Deletes Gemini WebAPI snapshots | No | Gemini WebAPI-only conversation deletion. |
 | `/v1/models` | Primary | Yes | N/A | No | Discovery endpoint for all providers. |
 | `/v1/auth/status` | Primary | Yes | N/A | No | Real-time auth state and health diagnostics. |
 | `/v1/auth/login` | Primary | Yes | N/A | No | Trigger for browser-based login workflows. |
@@ -56,6 +57,15 @@ A boolean field injected into the response metadata:
   - `true`: An in-memory `PersistentTab` for the conversation was reused.
   - `false`: No in-memory tab was reused. The backend may still resume the provider-side Gemini thread by navigating to the conversation URL.
 - **Stateless providers**: This field may be absent or provider-defined because no local conversation state is maintained.
+
+### Deletion
+
+`DELETE /v1/conversations/{conversation_id}` deletes Gemini WebAPI conversations only.
+
+- **Gemini WebAPI**: The runtime reads the SQLite snapshot, extracts the remote Gemini chat ID from `session_state.metadata[0]`, calls the Gemini WebAPI delete operation, removes the in-memory `SessionManager`, and deletes the SQLite snapshot.
+- **Gemini Playwright**: Not supported by this endpoint. Playwright conversation IDs are provider-side URL identifiers and are not SQLite-backed WebAPI snapshots.
+- **Atlas**: Not supported because Atlas requests are stateless in this runtime.
+- **Concurrency**: Active or already deleting conversations return `409 Conflict`.
 
 ## 5. Persistence Guarantees
 

--- a/docs/specs/lifecycle-and-recovery.md
+++ b/docs/specs/lifecycle-and-recovery.md
@@ -114,6 +114,7 @@ If the registry finds an active `SessionManager` for the given token, it reuses 
 * **Persistent Recovery**: The system utilizes a SQLite-backed repository to persist session snapshots. If a session is lost from memory (e.g., pruned due to TTL or after a server restart), the `SessionRegistry` can automatically restore the session state from the database using the supplied `conversation_id`.
 * **Durable Continuity**: For Gemini WebAPI, long-running threads can remain continuous across process restarts or container recycling, provided the `conversation_id` is preserved by the client and the corresponding SQLite snapshot exists.
 * **Missing Snapshot Behavior**: If an existing `conversation_id` is not present in memory and no valid snapshot exists, the request fails explicitly. The current implementation does not silently rebuild an existing WebAPI conversation from incoming message history.
+* **Deletion**: Gemini WebAPI deletion reserves the local `conversation_id` in `SessionRegistry` before remote deletion begins. This tombstone blocks concurrent reuse or SQLite restoration while the remote Gemini chat is being deleted and local state is being removed.
 
 ### 7.5 Gemini Playwright URL-Backed Continuity
 

--- a/docs/specs/provider-contract.md
+++ b/docs/specs/provider-contract.md
@@ -192,3 +192,9 @@ Provider implementations define their own recovery mechanism and must document t
   * For Gemini WebAPI, returns `true` when an existing or restored `ChatSession` was reused.
   * For Gemini Playwright, returns `true` when an existing in-memory `PersistentTab` was reused. URL-backed provider-side recovery after a restart may still report `false` because no in-memory tab was reused.
   * Stateless providers may omit the field or define backend-specific semantics.
+
+### 11.2 Gemini WebAPI Conversation Deletion
+
+Gemini WebAPI deletion is scoped to locally persisted SQLite snapshots. The adapter extracts the remote Gemini chat ID from `session_state["metadata"][0]`, calls the Gemini WebAPI client's `delete_chat(remote_cid)`, and then removes the local `SessionRegistry` entry and SQLite snapshot.
+
+Deletion MUST NOT restore a `ChatSession` solely to discover the remote chat ID. Deletion MUST reject active or already deleting conversations with `409 Conflict`. Gemini Playwright and stateless providers do not implement this deletion contract.

--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -110,3 +110,19 @@ async def chat_completions(request: OpenAIChatRequest, http_request: Request):
 
     # Delegate implementation-heavy work to the provider
     return await provider.chat_completions(request)
+
+
+@router.delete(
+    "/v1/conversations/{conversation_id}",
+    tags=["Chat"],
+    summary="Delete Gemini WebAPI Conversation",
+    description="Deletes a Gemini WebAPI conversation by local conversation_id. Playwright and Atlas conversations are not supported."
+)
+async def delete_conversation(conversation_id: str):
+    provider, _ = ProviderFactory.get_provider(
+        OpenAIChatRequest(messages=[], provider="gemini")
+    )
+    delete_handler = getattr(provider, "delete_conversation", None)
+    if delete_handler is None:
+        raise HTTPException(status_code=400, detail="Conversation deletion is not supported for this provider.")
+    return await delete_handler(conversation_id)

--- a/src/app/services/providers/exceptions.py
+++ b/src/app/services/providers/exceptions.py
@@ -18,3 +18,8 @@ class StateIntegrityError(SessionRecoveryError):
 class ProviderThreadExpiredError(SessionRecoveryError):
     """Raised when the remote provider reports that the conversation thread has expired."""
     pass
+
+
+class ConversationInUseError(SessionRecoveryError):
+    """Raised when a conversation is active or already being deleted."""
+    pass

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -104,6 +104,11 @@ class GeminiProvider(BaseProvider):
         # 3. Delegate to adapter
         return await adapter.chat_completions(request, cid, is_new_conversation, tools_prompt)
 
+    async def delete_conversation(self, conversation_id: str) -> dict:
+        if len(conversation_id) > 128:
+            raise HTTPException(status_code=400, detail="Invalid conversation_id length.")
+        return await self.webapi_adapter.delete_conversation(conversation_id)
+
     async def list_models(self) -> List[dict]:
         from app.services.providers.gemini.shared import get_gemini_models
         return get_gemini_models()

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -9,7 +9,11 @@ from app.config import get_default_conversation_snapshot_db
 from app.logger import logger
 from app.services.providers.gemini.client import get_gemini_client, GeminiClientNotInitializedError
 from app.services.providers.base_repository import ConversationSnapshot, IConversationRepository, ProviderCapability
-from app.services.providers.exceptions import SnapshotNotFoundError, StateIntegrityError
+from app.services.providers.exceptions import (
+    ConversationInUseError,
+    SnapshotNotFoundError,
+    StateIntegrityError,
+)
 from app.utils.tokens import generate_opaque_token
 
 # Configuration constants
@@ -187,6 +191,7 @@ class SessionRegistry:
         self.client = client
         self.repository = repository
         self._sessions: Dict[str, SessionManager] = {}
+        self._deleting: set[str] = set()
         self._lock = asyncio.Lock() # Registry-level lock for atomic lookup-or-create
 
     async def update_client(self, client):
@@ -212,6 +217,9 @@ class SessionRegistry:
     ) -> SessionManager:
         """Retrieve, restore, or create a session manager. Triggers passive cleanup."""
         async with self._lock:
+            if conversation_id in self._deleting:
+                raise ConversationInUseError(f"Conversation is currently being deleted: {conversation_id}")
+
             # 1. Passive Cleanup if capacity exceeded
             if len(self._sessions) >= MAX_SESSIONS:
                 self._prune_sessions()
@@ -233,6 +241,45 @@ class SessionRegistry:
                 self._sessions[conversation_id] = SessionManager(self.client)
             
             return self._sessions[conversation_id]
+
+    async def begin_delete_session(self, conversation_id: str) -> None:
+        """
+        Reserve a conversation for deletion and block concurrent reuse.
+
+        The tombstone is intentionally held across remote delete I/O by the
+        caller, while the registry lock is only held for local state checks.
+        """
+        async with self._lock:
+            if conversation_id in self._deleting:
+                raise ConversationInUseError(f"Conversation is currently being deleted: {conversation_id}")
+
+            manager = self._sessions.get(conversation_id)
+            if manager and (manager.lock.locked() or manager.active_streams > 0):
+                raise ConversationInUseError(f"Conversation is currently in use: {conversation_id}")
+
+            self._deleting.add(conversation_id)
+
+    async def complete_delete_session(self, conversation_id: str) -> None:
+        """
+        Remove local in-memory and persistent state for a reserved deletion.
+
+        The deletion tombstone is always cleared so failed local cleanup does
+        not permanently block the conversation ID.
+        """
+        try:
+            if self.repository:
+                await self.repository.delete_snapshot(conversation_id)
+
+            async with self._lock:
+                self._sessions.pop(conversation_id, None)
+        finally:
+            async with self._lock:
+                self._deleting.discard(conversation_id)
+
+    async def abort_delete_session(self, conversation_id: str) -> None:
+        """Release a deletion reservation after a pre-cleanup failure."""
+        async with self._lock:
+            self._deleting.discard(conversation_id)
 
     async def save_session_snapshot(self, conversation_id: str, provider_adapter: Any, manager: SessionManager) -> None:
         """

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -3,11 +3,19 @@ import json
 from typing import Any, List, Optional
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
-from gemini_webapi.exceptions import APIError
+from gemini_webapi.exceptions import APIError, AuthError, TimeoutError as GeminiTimeoutError
 
 from app.services.providers.gemini.client import get_gemini_client, GeminiClientNotInitializedError
-from app.services.providers.gemini.session_manager import get_gemini_chat_registry
-from app.services.providers.exceptions import SessionRecoveryError, SnapshotNotFoundError
+from app.services.providers.gemini.session_manager import (
+    SNAPSHOT_SCHEMA_VERSION,
+    get_gemini_chat_registry,
+)
+from app.services.providers.exceptions import (
+    ConversationInUseError,
+    SessionRecoveryError,
+    SnapshotNotFoundError,
+    StateIntegrityError,
+)
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
 from app.services.providers.gemini.shared import (
     convert_to_openai_format, 
@@ -30,6 +38,95 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
 
     def __init__(self, provider):
         self.provider = provider
+
+    async def delete_conversation(self, conversation_id: str) -> dict:
+        try:
+            gemini_client = get_gemini_client()
+        except GeminiClientNotInitializedError as e:
+            raise HTTPException(status_code=503, detail=str(e))
+
+        account_status = getattr(gemini_client.client, "account_status", None)
+        status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
+        if status_name != "AVAILABLE":
+            logger.warning(f"Gemini client account status is '{status_name}'.")
+            if status_name == "UNAUTHENTICATED":
+                raise HTTPException(
+                    status_code=401,
+                    detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            raise HTTPException(
+                status_code=401 if status_name == "UNKNOWN" else 503,
+                detail=f"Gemini client is not ready (status: {status_name}).",
+            )
+
+        registry = get_gemini_chat_registry()
+        if not registry or not registry.repository:
+            raise HTTPException(status_code=503, detail="Session registry is not initialized.")
+
+        try:
+            await registry.begin_delete_session(conversation_id)
+        except ConversationInUseError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
+
+        local_cleanup_started = False
+        try:
+            snapshot = await registry.repository.get_snapshot(conversation_id)
+            if snapshot is None:
+                raise SnapshotNotFoundError(f"Conversation snapshot not found: {conversation_id}")
+
+            if snapshot.provider_name != self.provider.provider_name:
+                raise StateIntegrityError("Snapshot provider does not match registry provider.")
+            if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION:
+                raise StateIntegrityError(f"Unsupported snapshot schema version: {snapshot.schema_version}")
+
+            validated_state = self.provider.validate_session_recovery(
+                snapshot.session_state,
+                {"conversation_id": conversation_id},
+            )
+            metadata = validated_state.get("metadata")
+            remote_cid = metadata[0]
+
+            await gemini_client.client.delete_chat(remote_cid)
+            local_cleanup_started = True
+            await registry.complete_delete_session(conversation_id)
+            return {
+                "id": conversation_id,
+                "object": "conversation.deleted",
+                "deleted": True,
+                "provider": self.provider.provider_name,
+                "backend": "webapi",
+            }
+        except SnapshotNotFoundError:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            raise HTTPException(status_code=404, detail="The provided conversation_id was not found.")
+        except HTTPException:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            raise
+        except AuthError as e:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            raise HTTPException(
+                status_code=401,
+                detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
+                headers={"WWW-Authenticate": "Bearer"},
+            ) from e
+        except GeminiTimeoutError as e:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            raise HTTPException(status_code=503, detail=f"Gemini delete request timed out: {str(e)}") from e
+        except APIError as e:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            logger.error(f"Error deleting Gemini WebAPI conversation remotely: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error deleting Gemini conversation: {str(e)}") from e
+        except Exception as e:
+            if not local_cleanup_started:
+                await registry.abort_delete_session(conversation_id)
+            logger.error(f"Error deleting Gemini WebAPI conversation: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error deleting Gemini conversation: {str(e)}") from e
 
     async def chat_completions(self, request: OpenAIChatRequest, cid: str, is_new_conversation: bool, tools_prompt: str) -> Any:
         try:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -78,3 +78,26 @@ async def test_chat_completions_endpoint_atlas(mocker):
     assert response.status_code == 200
     assert response.json() == mock_response
     mock_atlas.chat_completions.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_endpoint_gemini(mocker):
+    """Verify /v1/conversations/{conversation_id} delegates to Gemini deletion."""
+    mock_response = {
+        "id": "conv-delete",
+        "object": "conversation.deleted",
+        "deleted": True,
+        "provider": "gemini",
+        "backend": "webapi",
+    }
+    mock_gemini = mocker.Mock(spec=GeminiProvider)
+    mock_gemini.delete_conversation = mocker.AsyncMock(return_value=mock_response)
+
+    mocker.patch("app.services.factory.ProviderFactory.get_provider", return_value=(mock_gemini, ""))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.delete("/v1/conversations/conv-delete")
+
+    assert response.status_code == 200
+    assert response.json() == mock_response
+    mock_gemini.delete_conversation.assert_called_once_with("conv-delete")

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,13 +1,42 @@
 import pytest
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from fastapi import HTTPException
 from gemini_webapi.exceptions import APIError
+from app.services.providers.base_repository import ConversationSnapshot
+from app.services.providers.exceptions import ConversationInUseError
 from app.services.providers.gemini.provider import GeminiProvider
+from app.services.providers.gemini.session_manager import SessionRegistry
 
 @pytest.fixture
 def provider():
     return GeminiProvider()
+
+
+def make_delete_snapshot(conversation_id="conv-delete", remote_cid="c_remote_delete"):
+    return ConversationSnapshot(
+        conversation_id=conversation_id,
+        provider_name="gemini",
+        session_state={
+            "provider_state_version": 1,
+            "metadata": [remote_cid, "r_delete", "rc_delete", None, None, None, None, None, None, "ctx"],
+            "gem_id": None,
+            "model_name": "gemini-3-flash",
+        },
+        schema_version=1,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def make_delete_client(mocker, status_name="AVAILABLE"):
+    delete_chat = mocker.AsyncMock()
+    return SimpleNamespace(
+        client=SimpleNamespace(
+            account_status=SimpleNamespace(name=status_name),
+            delete_chat=delete_chat,
+        )
+    )
 
 def test_parse_tool_call_valid(provider):
     """Verify _parse_tool_call correctly extracts tool calls from text."""
@@ -59,6 +88,135 @@ def test_convert_to_openai_format_with_tool_call(provider):
     assert result["choices"][0]["finish_reason"] == "tool_calls"
     assert result["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "test_tool"
     assert json.loads(result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]) == {"arg": 1}
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_success(mocker, provider):
+    snapshot = make_delete_snapshot()
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository.get_snapshot = mocker.AsyncMock(return_value=snapshot)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    result = await provider.delete_conversation("conv-delete")
+
+    assert result == {
+        "id": "conv-delete",
+        "object": "conversation.deleted",
+        "deleted": True,
+        "provider": "gemini",
+        "backend": "webapi",
+    }
+    mock_registry.begin_delete_session.assert_called_once_with("conv-delete")
+    gemini_client.client.delete_chat.assert_called_once_with("c_remote_delete")
+    mock_registry.complete_delete_session.assert_called_once_with("conv-delete")
+    mock_registry.abort_delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_missing_snapshot_returns_404(mocker, provider):
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository.get_snapshot = mocker.AsyncMock(return_value=None)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversation("missing-conv")
+
+    assert exc_info.value.status_code == 404
+    mock_registry.abort_delete_session.assert_called_once_with("missing-conv")
+    gemini_client.client.delete_chat.assert_not_called()
+    mock_registry.complete_delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_active_session_returns_409(mocker, provider):
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.begin_delete_session = mocker.AsyncMock(
+        side_effect=ConversationInUseError("Conversation is currently in use: conv-active")
+    )
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversation("conv-active")
+
+    assert exc_info.value.status_code == 409
+    gemini_client.client.delete_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_unauthenticated_returns_401(mocker, provider):
+    gemini_client = make_delete_client(mocker, status_name="UNAUTHENTICATED")
+    mock_registry = mocker.Mock()
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversation("conv-delete")
+
+    assert exc_info.value.status_code == 401
+    mock_registry.begin_delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_gemini_api_error_returns_500_and_aborts(mocker, provider):
+    snapshot = make_delete_snapshot()
+    gemini_client = make_delete_client(mocker)
+    gemini_client.client.delete_chat.side_effect = APIError("Batch execution failed with status code 500")
+    mock_registry = mocker.Mock()
+    mock_registry.repository.get_snapshot = mocker.AsyncMock(return_value=snapshot)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversation("conv-delete")
+
+    assert exc_info.value.status_code == 500
+    mock_registry.abort_delete_session.assert_called_once_with("conv-delete")
+    mock_registry.complete_delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_repository_failure_returns_500_and_clears_tombstone(mocker, provider):
+    snapshot = make_delete_snapshot()
+    gemini_client = make_delete_client(mocker)
+    repository = mocker.Mock()
+    repository.get_snapshot = mocker.AsyncMock(return_value=snapshot)
+    repository.delete_snapshot = mocker.AsyncMock(side_effect=RuntimeError("sqlite unavailable"))
+    registry = SessionRegistry(gemini_client, repository=repository)
+    manager = await registry.get_session("conv-delete")
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversation("conv-delete")
+
+    assert exc_info.value.status_code == 500
+    assert "conv-delete" not in registry._deleting
+    assert registry._sessions["conv-delete"] is manager
+    gemini_client.client.delete_chat.assert_called_once_with("c_remote_delete")
+    repository.delete_snapshot.assert_called_once_with("conv-delete")
 
 
 @pytest.mark.asyncio

--- a/tests/test_persistent_conversation_layer.py
+++ b/tests/test_persistent_conversation_layer.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 from fastapi import HTTPException
 
 from app.schemas.request import OpenAIChatRequest
-from app.services.providers.exceptions import SnapshotNotFoundError, StateIntegrityError
+from app.services.providers.exceptions import (
+    ConversationInUseError,
+    SnapshotNotFoundError,
+    StateIntegrityError,
+)
 from app.services.providers.gemini.provider import GeminiProvider
 from app.services.providers.sqlite_repository import SQLiteConversationRepository
 from app.services.providers.gemini.session_manager import SessionRegistry
@@ -131,6 +135,54 @@ async def test_provider_returns_recovery_error_for_missing_snapshot(tmp_path, mo
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.detail == "The provided conversation_id was not found."
+
+
+@pytest.mark.asyncio
+async def test_registry_tombstone_blocks_concurrent_get_session(tmp_path):
+    repo = SQLiteConversationRepository(str(tmp_path / "snapshots.db"))
+    await repo.initialize()
+
+    registry = SessionRegistry(MockGeminiClient(), repository=repo)
+    await registry.begin_delete_session("conv-deleting")
+
+    with pytest.raises(ConversationInUseError):
+        await registry.get_session(
+            "conv-deleting",
+            GeminiProvider(),
+            allow_create=False,
+            model="gemini-3-flash",
+        )
+
+    await registry.abort_delete_session("conv-deleting")
+    assert "conv-deleting" not in registry._deleting
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_delete_rejects_active_locked_session(tmp_path):
+    repo = SQLiteConversationRepository(str(tmp_path / "snapshots.db"))
+    await repo.initialize()
+
+    registry = SessionRegistry(MockGeminiClient(), repository=repo)
+    manager = await registry.get_session("conv-active")
+    await manager.lock.acquire()
+    try:
+        with pytest.raises(ConversationInUseError):
+            await registry.begin_delete_session("conv-active")
+    finally:
+        manager.lock.release()
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_delete_rejects_active_stream_session(tmp_path):
+    repo = SQLiteConversationRepository(str(tmp_path / "snapshots.db"))
+    await repo.initialize()
+
+    registry = SessionRegistry(MockGeminiClient(), repository=repo)
+    manager = await registry.get_session("conv-streaming")
+    manager.active_streams = 1
+
+    with pytest.raises(ConversationInUseError):
+        await registry.begin_delete_session("conv-streaming")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds support for deleting persisted Gemini WebAPI conversations through a dedicated API endpoint.

This PR introduces a complete deletion flow that removes both the remote Gemini conversation and its associated local persistence state. The implementation includes endpoint support, provider-level orchestration, concurrency-safe deletion semantics, persistence cleanup, documentation updates, and comprehensive test coverage.

**Related to #51**

This PR implements the manual conversation deletion foundation requested in #51. It does not fully close the issue because automatic post-response conversation cleanup ("Auto Remove") is still pending.

## Key Changes

### API Surface

* Added `DELETE /v1/conversations/{conversation_id}`.
* Returns a structured deletion response on success.
* Supports Gemini WebAPI conversations only.

### Gemini WebAPI Deletion Flow

* Added `delete_conversation()` support to the Gemini provider layer.
* Added WebAPI adapter implementation that:

  * Resolves the persisted conversation snapshot.
  * Extracts the underlying Gemini conversation identifier.
  * Deletes the remote Gemini conversation.
  * Removes local persistence state.

### Concurrency Safety

* Introduced a deletion tombstone mechanism in `SessionRegistry`.
* Prevents concurrent reuse of a conversation while deletion is in progress.
* Returns `409 Conflict` when deletion is attempted on an active conversation.
* Avoids holding registry locks across remote network operations.

### Persistence Cleanup

* Removes SQLite-backed conversation snapshots after successful remote deletion.
* Preserves in-memory session state if local persistence cleanup fails.
* Ensures deletion tombstones are cleaned up on all success and failure paths.

### Documentation

* Updated README.
* Updated API documentation.
* Updated API contract and provider specifications.
* Documented conversation deletion behavior and limitations.

## Testing

Tests run:

```bash
pytest tests/test_endpoints.py \
       tests/test_gemini_provider.py \
       tests/test_persistent_conversation_layer.py \
       tests/test_sqlite_repository.py
```

Result:

```text
41 passed
```

Additional verification:

```bash
python -m compileall -q src/app/services/providers/gemini src/app/endpoints/chat.py
```

Result:

```text
passed
```

## Notes

* This endpoint only supports Gemini WebAPI conversations.
* Playwright conversations are not affected and are not currently supported.
* Atlas conversations are not affected and are not currently supported.
* Conversation deletion removes both the remote Gemini conversation and its local persistence snapshot.
* Related to #51; automatic post-response deletion remains future work.
