### PR TITLE
Add Gemini WebAPI conversation listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ curl -X DELETE http://localhost:6969/v1/conversations/{conversation_id}
 
 This endpoint deletes Gemini WebAPI conversations created through local SQLite-backed conversation snapshots. Playwright and Atlas conversations are not supported.
 
+### List Gemini WebAPI Conversations
+
+```bash
+curl http://localhost:6969/v1/conversations
+```
+
+This endpoint lists locally persisted Gemini WebAPI conversation snapshots from SQLite. It does not restore conversations or call Gemini remote APIs. Playwright and Atlas conversations are not included.
+
 ### Playwright Backend
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,45 @@ Returns the list of available models and providers.
 
 ---
 
+### GET `/v1/conversations`
+
+Lists locally persisted Gemini WebAPI conversations stored in SQLite.
+
+This endpoint supports Gemini WebAPI conversations only. It does not restore `ChatSession` objects, call Gemini remote APIs, or include Playwright URL-backed conversations or Atlas requests.
+
+Successful response:
+
+```json
+{
+  "object": "list",
+  "provider": "gemini",
+  "backend": "webapi",
+  "count": 1,
+  "data": [
+    {
+      "id": "conversation_id",
+      "object": "conversation",
+      "provider": "gemini",
+      "backend": "webapi",
+      "model": "gemini-3-flash",
+      "gem_id": null,
+      "updated_at": "2026-06-02T12:34:56+00:00",
+      "schema_version": 1
+    }
+  ]
+}
+```
+
+Status codes:
+
+| Status | Meaning |
+| ------ | ------- |
+| `200` | Local SQLite snapshots were listed. |
+| `503` | Session registry or snapshot repository is unavailable. |
+| `500` | Snapshot data is invalid/corrupt or repository listing failed. |
+
+---
+
 ### DELETE `/v1/conversations/{conversation_id}`
 
 Deletes a Gemini WebAPI conversation identified by the local `conversation_id`.

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -16,6 +16,7 @@ WebAI-to-API exposes multiple API surfaces to balance standard compatibility, le
 | Endpoint | Category | Recommended | Persistence | Streaming | Notes |
 | :--- | :--- | :---: | :--- | :---: | :--- |
 | `/v1/chat/completions` | Primary | Yes | Provider/backend-dependent | Yes | Authoritative OpenAI-compatible surface. |
+| `/v1/conversations` | Primary | Yes | Lists Gemini WebAPI snapshots | No | Lists local SQLite-backed Gemini WebAPI conversations only. |
 | `/v1/conversations/{conversation_id}` | Primary | Yes | Deletes Gemini WebAPI snapshots | No | Gemini WebAPI-only conversation deletion. |
 | `/v1/models` | Primary | Yes | N/A | No | Discovery endpoint for all providers. |
 | `/v1/auth/status` | Primary | Yes | N/A | No | Real-time auth state and health diagnostics. |
@@ -57,6 +58,16 @@ A boolean field injected into the response metadata:
   - `true`: An in-memory `PersistentTab` for the conversation was reused.
   - `false`: No in-memory tab was reused. The backend may still resume the provider-side Gemini thread by navigating to the conversation URL.
 - **Stateless providers**: This field may be absent or provider-defined because no local conversation state is maintained.
+
+### Listing
+
+`GET /v1/conversations` lists Gemini WebAPI conversations persisted in local SQLite snapshots only.
+
+- **Gemini WebAPI**: The runtime reads SQLite snapshots through `SessionRegistry` and `SQLiteConversationRepository`, validates snapshot schema and provider-owned `session_state`, and returns public local metadata such as `conversation_id`, `updated_at`, `model_name`, `gem_id`, provider, backend, and schema version.
+- **No Remote Calls**: Listing does not restore `ChatSession` objects and does not call Gemini remote APIs.
+- **Metadata Privacy**: Raw Gemini continuation metadata and remote Gemini chat IDs are not exposed.
+- **Gemini Playwright**: Not included because Playwright conversations are provider-side URL-backed and not SQLite-backed WebAPI snapshots.
+- **Atlas**: Not included because Atlas requests are stateless in this runtime.
 
 ### Deletion
 

--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -112,6 +112,22 @@ async def chat_completions(request: OpenAIChatRequest, http_request: Request):
     return await provider.chat_completions(request)
 
 
+@router.get(
+    "/v1/conversations",
+    tags=["Chat"],
+    summary="List Gemini WebAPI Conversations",
+    description="Lists locally persisted Gemini WebAPI conversations stored in SQLite. Playwright and Atlas conversations are not included."
+)
+async def list_conversations():
+    provider, _ = ProviderFactory.get_provider(
+        OpenAIChatRequest(messages=[], provider="gemini")
+    )
+    list_handler = getattr(provider, "list_conversations", None)
+    if list_handler is None:
+        raise HTTPException(status_code=400, detail="Conversation listing is not supported for this provider.")
+    return await list_handler()
+
+
 @router.delete(
     "/v1/conversations/{conversation_id}",
     tags=["Chat"],

--- a/src/app/services/providers/base_repository.py
+++ b/src/app/services/providers/base_repository.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 class ProviderCapability(Enum):
     PERSISTENT_RECOVERY = auto()
@@ -42,6 +42,14 @@ class IConversationRepository(ABC):
     async def delete_snapshot(self, conversation_id: str) -> None:
         """
         Delete a conversation snapshot by conversation_id.
+        """
+        pass
+
+    @abstractmethod
+    async def list_snapshots(self, provider_name: Optional[str] = None) -> List[ConversationSnapshot]:
+        """
+        List conversation snapshots, optionally filtered by provider name.
+        Results are ordered by most recently updated first.
         """
         pass
 

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -109,6 +109,9 @@ class GeminiProvider(BaseProvider):
             raise HTTPException(status_code=400, detail="Invalid conversation_id length.")
         return await self.webapi_adapter.delete_conversation(conversation_id)
 
+    async def list_conversations(self) -> dict:
+        return await self.webapi_adapter.list_conversations()
+
     async def list_models(self) -> List[dict]:
         from app.services.providers.gemini.shared import get_gemini_models
         return get_gemini_models()

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -317,6 +317,12 @@ class SessionRegistry:
         cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_PERIOD_DAYS)
         return await self.repository.prune_stale_snapshots(cutoff)
 
+    async def list_conversation_snapshots(self, provider_name: str = "gemini") -> List[ConversationSnapshot]:
+        """List persisted conversation snapshots for the requested provider."""
+        if not self.repository:
+            raise SnapshotNotFoundError("Conversation snapshot repository is not initialized.")
+        return await self.repository.list_snapshots(provider_name)
+
     async def _restore_session(
         self,
         conversation_id: str,

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -39,6 +39,51 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
     def __init__(self, provider):
         self.provider = provider
 
+    async def list_conversations(self) -> dict:
+        registry = get_gemini_chat_registry()
+        if not registry or not registry.repository:
+            raise HTTPException(status_code=503, detail="Session registry is not initialized.")
+
+        try:
+            snapshots = await registry.list_conversation_snapshots(self.provider.provider_name)
+            data = []
+            for snapshot in snapshots:
+                if snapshot.provider_name != self.provider.provider_name:
+                    raise StateIntegrityError("Snapshot provider does not match registry provider.")
+                if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION:
+                    raise StateIntegrityError(f"Unsupported snapshot schema version: {snapshot.schema_version}")
+
+                validated_state = self.provider.validate_session_recovery(
+                    snapshot.session_state,
+                    {"conversation_id": snapshot.conversation_id},
+                )
+                data.append({
+                    "id": snapshot.conversation_id,
+                    "object": "conversation",
+                    "provider": self.provider.provider_name,
+                    "backend": "webapi",
+                    "model": validated_state.get("model_name"),
+                    "gem_id": validated_state.get("gem_id"),
+                    "updated_at": snapshot.updated_at.isoformat(),
+                    "schema_version": snapshot.schema_version,
+                })
+
+            return {
+                "object": "list",
+                "provider": self.provider.provider_name,
+                "backend": "webapi",
+                "count": len(data),
+                "data": data,
+            }
+        except HTTPException:
+            raise
+        except StateIntegrityError as e:
+            logger.error(f"Invalid Gemini WebAPI conversation snapshot: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Invalid conversation snapshot: {str(e)}") from e
+        except Exception as e:
+            logger.error(f"Error listing Gemini WebAPI conversations: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error listing Gemini conversations: {str(e)}") from e
+
     async def delete_conversation(self, conversation_id: str) -> dict:
         try:
             gemini_client = get_gemini_client()

--- a/src/app/services/providers/sqlite_repository.py
+++ b/src/app/services/providers/sqlite_repository.py
@@ -4,7 +4,7 @@ import json
 import asyncio
 import os
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 from app.config import get_default_conversation_snapshot_db
 from app.logger import logger
 from app.services.providers.base_repository import IConversationRepository, ConversationSnapshot
@@ -39,6 +39,22 @@ class SQLiteConversationRepository(IConversationRepository):
             cursor.execute(query, params)
             return cursor.fetchone()
 
+    def _row_to_snapshot(self, row: tuple) -> ConversationSnapshot:
+        try:
+            state_dict = json.loads(row[2])
+            updated_dt = datetime.fromisoformat(row[4])
+            return ConversationSnapshot(
+                conversation_id=row[0],
+                provider_name=row[1],
+                session_state=state_dict,
+                schema_version=row[3],
+                updated_at=updated_dt
+            )
+        except Exception as e:
+            conversation_id = row[0] if row else "<unknown>"
+            logger.error(f"Error deserializing conversation snapshot {conversation_id}: {e}", exc_info=True)
+            raise StateIntegrityError(f"Corrupted conversation snapshot: {conversation_id}") from e
+
     async def initialize(self) -> None:
         """Create database tables and set WAL mode."""
         await asyncio.to_thread(self.initialize_sync)
@@ -72,19 +88,7 @@ class SQLiteConversationRepository(IConversationRepository):
             )
             if not row:
                 return None
-            try:
-                state_dict = json.loads(row[2])
-                updated_dt = datetime.fromisoformat(row[4])
-                return ConversationSnapshot(
-                    conversation_id=row[0],
-                    provider_name=row[1],
-                    session_state=state_dict,
-                    schema_version=row[3],
-                    updated_at=updated_dt
-                )
-            except Exception as e:
-                logger.error(f"Error deserializing conversation snapshot {conversation_id}: {e}", exc_info=True)
-                raise StateIntegrityError(f"Corrupted conversation snapshot: {conversation_id}") from e
+            return self._row_to_snapshot(row)
         return await asyncio.to_thread(_get)
 
     async def save_snapshot(self, snapshot: ConversationSnapshot) -> None:
@@ -116,6 +120,34 @@ class SQLiteConversationRepository(IConversationRepository):
                 (conversation_id,)
             )
         await asyncio.to_thread(_delete)
+
+    async def list_snapshots(self, provider_name: Optional[str] = None) -> List[ConversationSnapshot]:
+        """List conversation snapshots ordered by updated_at descending."""
+        def _list():
+            self._ensure_parent_dir()
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                if provider_name is None:
+                    cursor.execute(
+                        """
+                        SELECT conversation_id, provider_name, session_state, schema_version, updated_at
+                        FROM conversation_snapshots
+                        ORDER BY updated_at DESC
+                        """
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        SELECT conversation_id, provider_name, session_state, schema_version, updated_at
+                        FROM conversation_snapshots
+                        WHERE provider_name = ?
+                        ORDER BY updated_at DESC
+                        """,
+                        (provider_name,)
+                    )
+                return [self._row_to_snapshot(row) for row in cursor.fetchall()]
+
+        return await asyncio.to_thread(_list)
 
     async def prune_stale_snapshots(self, cutoff: datetime) -> int:
         """Delete snapshots older than cutoff and return the number of rows deleted."""

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -101,3 +101,26 @@ async def test_delete_conversation_endpoint_gemini(mocker):
     assert response.status_code == 200
     assert response.json() == mock_response
     mock_gemini.delete_conversation.assert_called_once_with("conv-delete")
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_endpoint_gemini_empty(mocker):
+    """Verify /v1/conversations delegates to Gemini conversation listing."""
+    mock_response = {
+        "object": "list",
+        "provider": "gemini",
+        "backend": "webapi",
+        "count": 0,
+        "data": [],
+    }
+    mock_gemini = mocker.Mock(spec=GeminiProvider)
+    mock_gemini.list_conversations = mocker.AsyncMock(return_value=mock_response)
+
+    mocker.patch("app.services.factory.ProviderFactory.get_provider", return_value=(mock_gemini, ""))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/v1/conversations")
+
+    assert response.status_code == 200
+    assert response.json() == mock_response
+    mock_gemini.list_conversations.assert_called_once_with()

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -220,6 +220,99 @@ async def test_delete_conversation_repository_failure_returns_500_and_clears_tom
 
 
 @pytest.mark.asyncio
+async def test_list_conversations_returns_persisted_conversation_fields(mocker, provider):
+    updated_at = datetime(2026, 6, 2, 12, 30, tzinfo=timezone.utc)
+    snapshot = ConversationSnapshot(
+        conversation_id="conv-list",
+        provider_name="gemini",
+        session_state={
+            "provider_state_version": 1,
+            "metadata": ["remote-cid-secret", "rid", "rcid", None, None, None, None, None, None, "ctx"],
+            "gem_id": "gem-123",
+            "model_name": "gemini-3-flash",
+        },
+        schema_version=1,
+        updated_at=updated_at,
+    )
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=[snapshot])
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+    get_client = mocker.patch(
+        "app.services.providers.gemini.webapi_adapter.get_gemini_client",
+        side_effect=AssertionError("list_conversations must not call Gemini remote client"),
+    )
+    deserialize = mocker.patch.object(
+        provider,
+        "deserialize_session_state",
+        side_effect=AssertionError("list_conversations must not restore ChatSession"),
+    )
+
+    result = await provider.list_conversations()
+
+    assert result == {
+        "object": "list",
+        "provider": "gemini",
+        "backend": "webapi",
+        "count": 1,
+        "data": [
+            {
+                "id": "conv-list",
+                "object": "conversation",
+                "provider": "gemini",
+                "backend": "webapi",
+                "model": "gemini-3-flash",
+                "gem_id": "gem-123",
+                "updated_at": updated_at.isoformat(),
+                "schema_version": 1,
+            }
+        ],
+    }
+    assert "metadata" not in result["data"][0]
+    assert "remote-cid-secret" not in json.dumps(result)
+    mock_registry.list_conversation_snapshots.assert_called_once_with("gemini")
+    get_client.assert_not_called()
+    deserialize.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_corrupt_snapshot_returns_500(mocker, provider):
+    snapshot = ConversationSnapshot(
+        conversation_id="conv-corrupt",
+        provider_name="gemini",
+        session_state={
+            "provider_state_version": 1,
+            "metadata": ["remote-cid-only"],
+            "gem_id": None,
+            "model_name": "gemini-3-flash",
+        },
+        schema_version=1,
+        updated_at=datetime.now(timezone.utc),
+    )
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=[snapshot])
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.list_conversations()
+
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_registry_unavailable_returns_503(mocker, provider):
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.list_conversations()
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
 async def test_chat_completions_stateful_buffered(mocker, provider):
     """Verify chat_completions retrieves SessionManager and executes stateful buffered response."""
     from app.schemas.request import OpenAIChatRequest

--- a/tests/test_sqlite_repository.py
+++ b/tests/test_sqlite_repository.py
@@ -1,7 +1,7 @@
 # tests/test_sqlite_repository.py
 import pytest
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from app.services.providers.base_repository import ConversationSnapshot
 from app.services.providers.exceptions import StateIntegrityError
 from app.services.providers.sqlite_repository import SQLiteConversationRepository
@@ -102,3 +102,69 @@ async def test_repository_raises_state_integrity_error_for_corrupted_json(tmp_pa
 
     with pytest.raises(StateIntegrityError):
         await repo.get_snapshot("corrupt-json")
+
+
+@pytest.mark.asyncio
+async def test_repository_list_snapshots_sorted_by_updated_at_desc(tmp_path):
+    db_file = tmp_path / "test_snapshots.db"
+    repo = SQLiteConversationRepository(db_path=str(db_file))
+    await repo.initialize()
+
+    base_time = datetime.now(timezone.utc)
+    snapshots = [
+        ConversationSnapshot(
+            conversation_id="old",
+            provider_name="gemini",
+            session_state={"metadata": ["cid-old", "rid", "rcid"], "model_name": "flash"},
+            schema_version=1,
+            updated_at=base_time - timedelta(minutes=2),
+        ),
+        ConversationSnapshot(
+            conversation_id="new",
+            provider_name="gemini",
+            session_state={"metadata": ["cid-new", "rid", "rcid"], "model_name": "pro"},
+            schema_version=1,
+            updated_at=base_time,
+        ),
+        ConversationSnapshot(
+            conversation_id="middle",
+            provider_name="gemini",
+            session_state={"metadata": ["cid-middle", "rid", "rcid"], "model_name": "flash"},
+            schema_version=1,
+            updated_at=base_time - timedelta(minutes=1),
+        ),
+    ]
+
+    for snapshot in snapshots:
+        await repo.save_snapshot(snapshot)
+
+    listed = await repo.list_snapshots()
+
+    assert [snapshot.conversation_id for snapshot in listed] == ["new", "middle", "old"]
+
+
+@pytest.mark.asyncio
+async def test_repository_list_snapshots_filters_by_provider_name(tmp_path):
+    db_file = tmp_path / "test_snapshots.db"
+    repo = SQLiteConversationRepository(db_path=str(db_file))
+    await repo.initialize()
+
+    now = datetime.now(timezone.utc)
+    await repo.save_snapshot(ConversationSnapshot(
+        conversation_id="gemini-conv",
+        provider_name="gemini",
+        session_state={"metadata": ["cid", "rid", "rcid"], "model_name": "flash"},
+        schema_version=1,
+        updated_at=now,
+    ))
+    await repo.save_snapshot(ConversationSnapshot(
+        conversation_id="other-conv",
+        provider_name="other",
+        session_state={"metadata": ["cid", "rid", "rcid"], "model_name": "other"},
+        schema_version=1,
+        updated_at=now,
+    ))
+
+    listed = await repo.list_snapshots("gemini")
+
+    assert [snapshot.conversation_id for snapshot in listed] == ["gemini-conv"]


### PR DESCRIPTION
## Summary

This PR adds a new endpoint for listing persisted Gemini WebAPI conversations.

The endpoint enumerates locally stored SQLite conversation snapshots without restoring `ChatSession` instances or making remote Gemini API calls.

## Key Changes

* Added `GET /v1/conversations` endpoint.
* Implemented conversation listing in `GeminiWebAPIAdapter`.
* Added snapshot enumeration support to `SQLiteConversationRepository`.
* Added provider and session registry integration for conversation listing.
* Updated API documentation and contract specifications.
* Added endpoint, provider, and repository test coverage.

## Testing

* Tests run:

  * `pytest tests/test_endpoints.py`
  * `pytest tests/test_gemini_provider.py`
  * `pytest tests/test_sqlite_repository.py`

* Result:

  * 35 tests passed

## Notes

* Listing is limited to Gemini WebAPI SQLite-backed conversation snapshots.
* Listing does not restore `ChatSession` objects.
* Listing does not call Gemini remote APIs.
* Raw Gemini continuation metadata and provider-side conversation identifiers are not exposed.
* Playwright and Atlas conversations are not included.
