### PR TITLE
Add bulk conversation deletion for Gemini WebAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ curl -X DELETE http://localhost:6969/v1/conversations/{conversation_id}
 
 This endpoint deletes Gemini WebAPI conversations created through local SQLite-backed conversation snapshots. Playwright and Atlas conversations are not supported.
 
+### Bulk Delete Gemini WebAPI Conversations
+
+```bash
+curl -X DELETE http://localhost:6969/v1/conversations
+```
+
+This endpoint best-effort deletes all locally persisted Gemini WebAPI conversation snapshots and their corresponding remote Gemini chats. Active conversations are skipped and reported in the response. Playwright and Atlas conversations are not supported.
+
 ### List Gemini WebAPI Conversations
 
 ```bash

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,6 +85,56 @@ Status codes:
 
 ---
 
+### DELETE `/v1/conversations`
+
+Best-effort deletes all locally persisted Gemini WebAPI conversations.
+
+This endpoint lists local Gemini WebAPI SQLite snapshots, deletes each corresponding remote Gemini chat, and then deletes the local snapshot. Active conversations are skipped and reported. Playwright and Atlas conversations are not supported.
+
+Successful response, including partial failures:
+
+```json
+{
+  "object": "conversation.bulk_delete",
+  "provider": "gemini",
+  "backend": "webapi",
+  "total": 3,
+  "deleted_count": 1,
+  "failed_count": 1,
+  "skipped_active_count": 1,
+  "results": [
+    {
+      "id": "deleted_conversation_id",
+      "status": "deleted",
+      "deleted": true
+    },
+    {
+      "id": "active_conversation_id",
+      "status": "skipped_active",
+      "deleted": false,
+      "error": "Conversation is currently in use"
+    },
+    {
+      "id": "failed_conversation_id",
+      "status": "failed",
+      "deleted": false,
+      "error": "Remote Gemini delete failed"
+    }
+  ]
+}
+```
+
+Status codes:
+
+| Status | Meaning |
+| ------ | ------- |
+| `200` | Bulk operation produced a report, even if individual conversations failed or were skipped. |
+| `401` | Gemini WebAPI authentication is missing or expired before the run starts. |
+| `503` | Gemini client, session registry, or snapshot repository is unavailable before the run starts. |
+| `500` | Snapshot listing failed before a per-conversation report could be produced. |
+
+---
+
 ### DELETE `/v1/conversations/{conversation_id}`
 
 Deletes a Gemini WebAPI conversation identified by the local `conversation_id`.

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -16,7 +16,7 @@ WebAI-to-API exposes multiple API surfaces to balance standard compatibility, le
 | Endpoint | Category | Recommended | Persistence | Streaming | Notes |
 | :--- | :--- | :---: | :--- | :---: | :--- |
 | `/v1/chat/completions` | Primary | Yes | Provider/backend-dependent | Yes | Authoritative OpenAI-compatible surface. |
-| `/v1/conversations` | Primary | Yes | Lists Gemini WebAPI snapshots | No | Lists local SQLite-backed Gemini WebAPI conversations only. |
+| `/v1/conversations` | Primary | Yes | Lists/deletes Gemini WebAPI snapshots | No | GET lists local snapshots; DELETE bulk-deletes Gemini WebAPI conversations. |
 | `/v1/conversations/{conversation_id}` | Primary | Yes | Deletes Gemini WebAPI snapshots | No | Gemini WebAPI-only conversation deletion. |
 | `/v1/models` | Primary | Yes | N/A | No | Discovery endpoint for all providers. |
 | `/v1/auth/status` | Primary | Yes | N/A | No | Real-time auth state and health diagnostics. |
@@ -69,7 +69,18 @@ A boolean field injected into the response metadata:
 - **Gemini Playwright**: Not included because Playwright conversations are provider-side URL-backed and not SQLite-backed WebAPI snapshots.
 - **Atlas**: Not included because Atlas requests are stateless in this runtime.
 
-### Deletion
+### Bulk Deletion
+
+`DELETE /v1/conversations` best-effort deletes all locally persisted Gemini WebAPI conversations.
+
+- **Gemini WebAPI**: The runtime lists SQLite snapshots through `SessionRegistry`, reserves each conversation with the per-conversation deletion tombstone, extracts the remote Gemini chat ID from `session_state.metadata[0]`, calls the Gemini WebAPI delete operation, then removes the local `SessionManager` and SQLite snapshot.
+- **Best Effort**: The operation is not atomic. Individual active, remote-failed, or cleanup-failed conversations are reported per item while the endpoint continues processing remaining snapshots.
+- **Status Semantics**: The endpoint returns `200 OK` whenever it can produce a bulk report, including partial failures. It does not use `207 Multi-Status`.
+- **Concurrency**: Active or already deleting conversations are skipped with per-item status `skipped_active`; they are not force deleted and the endpoint does not wait for them.
+- **Metadata Privacy**: Raw Gemini continuation metadata and remote Gemini chat IDs are not exposed in the response.
+- **Gemini Playwright and Atlas**: Not supported by this endpoint.
+
+### Single Deletion
 
 `DELETE /v1/conversations/{conversation_id}` deletes Gemini WebAPI conversations only.
 

--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -129,6 +129,22 @@ async def list_conversations():
 
 
 @router.delete(
+    "/v1/conversations",
+    tags=["Chat"],
+    summary="Bulk Delete Gemini WebAPI Conversations",
+    description="Deletes all locally persisted Gemini WebAPI conversations. Playwright and Atlas conversations are not supported."
+)
+async def delete_conversations():
+    provider, _ = ProviderFactory.get_provider(
+        OpenAIChatRequest(messages=[], provider="gemini")
+    )
+    delete_handler = getattr(provider, "delete_conversations", None)
+    if delete_handler is None:
+        raise HTTPException(status_code=400, detail="Bulk conversation deletion is not supported for this provider.")
+    return await delete_handler()
+
+
+@router.delete(
     "/v1/conversations/{conversation_id}",
     tags=["Chat"],
     summary="Delete Gemini WebAPI Conversation",

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -109,6 +109,9 @@ class GeminiProvider(BaseProvider):
             raise HTTPException(status_code=400, detail="Invalid conversation_id length.")
         return await self.webapi_adapter.delete_conversation(conversation_id)
 
+    async def delete_conversations(self) -> dict:
+        return await self.webapi_adapter.delete_conversations()
+
     async def list_conversations(self) -> dict:
         return await self.webapi_adapter.list_conversations()
 

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -39,6 +39,29 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
     def __init__(self, provider):
         self.provider = provider
 
+    def _get_available_gemini_client(self):
+        try:
+            gemini_client = get_gemini_client()
+        except GeminiClientNotInitializedError as e:
+            raise HTTPException(status_code=503, detail=str(e))
+
+        account_status = getattr(gemini_client.client, "account_status", None)
+        status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
+        if status_name != "AVAILABLE":
+            logger.warning(f"Gemini client account status is '{status_name}'.")
+            if status_name == "UNAUTHENTICATED":
+                raise HTTPException(
+                    status_code=401,
+                    detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            raise HTTPException(
+                status_code=401 if status_name == "UNKNOWN" else 503,
+                detail=f"Gemini client is not ready (status: {status_name}).",
+            )
+
+        return gemini_client
+
     async def list_conversations(self) -> dict:
         registry = get_gemini_chat_registry()
         if not registry or not registry.repository:
@@ -84,26 +107,119 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
             logger.error(f"Error listing Gemini WebAPI conversations: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Error listing Gemini conversations: {str(e)}") from e
 
-    async def delete_conversation(self, conversation_id: str) -> dict:
-        try:
-            gemini_client = get_gemini_client()
-        except GeminiClientNotInitializedError as e:
-            raise HTTPException(status_code=503, detail=str(e))
+    async def delete_conversations(self) -> dict:
+        gemini_client = self._get_available_gemini_client()
 
-        account_status = getattr(gemini_client.client, "account_status", None)
-        status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
-        if status_name != "AVAILABLE":
-            logger.warning(f"Gemini client account status is '{status_name}'.")
-            if status_name == "UNAUTHENTICATED":
+        registry = get_gemini_chat_registry()
+        if not registry or not registry.repository:
+            raise HTTPException(status_code=503, detail="Session registry is not initialized.")
+
+        try:
+            snapshots = await registry.list_conversation_snapshots(self.provider.provider_name)
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error listing Gemini WebAPI conversations for bulk delete: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Error listing Gemini conversations: {str(e)}") from e
+
+        results = []
+        deleted_count = 0
+        failed_count = 0
+        skipped_active_count = 0
+
+        for snapshot in snapshots:
+            conversation_id = snapshot.conversation_id
+            local_cleanup_started = False
+            try:
+                await registry.begin_delete_session(conversation_id)
+            except ConversationInUseError as e:
+                skipped_active_count += 1
+                results.append({
+                    "id": conversation_id,
+                    "status": "skipped_active",
+                    "deleted": False,
+                    "error": str(e),
+                })
+                continue
+
+            try:
+                if snapshot.provider_name != self.provider.provider_name:
+                    raise StateIntegrityError("Snapshot provider does not match registry provider.")
+                if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION:
+                    raise StateIntegrityError(f"Unsupported snapshot schema version: {snapshot.schema_version}")
+
+                validated_state = self.provider.validate_session_recovery(
+                    snapshot.session_state,
+                    {"conversation_id": conversation_id},
+                )
+                metadata = validated_state.get("metadata")
+                remote_cid = metadata[0]
+
+                await gemini_client.client.delete_chat(remote_cid)
+                local_cleanup_started = True
+                await registry.complete_delete_session(conversation_id)
+
+                deleted_count += 1
+                results.append({
+                    "id": conversation_id,
+                    "status": "deleted",
+                    "deleted": True,
+                })
+            except AuthError as e:
+                if not local_cleanup_started:
+                    await registry.abort_delete_session(conversation_id)
                 raise HTTPException(
                     status_code=401,
                     detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
                     headers={"WWW-Authenticate": "Bearer"},
-                )
-            raise HTTPException(
-                status_code=401 if status_name == "UNKNOWN" else 503,
-                detail=f"Gemini client is not ready (status: {status_name}).",
-            )
+                ) from e
+            except (GeminiTimeoutError, APIError) as e:
+                if not local_cleanup_started:
+                    await registry.abort_delete_session(conversation_id)
+                failed_count += 1
+                logger.error(f"Error deleting Gemini WebAPI conversation {conversation_id}: {e}", exc_info=True)
+                results.append({
+                    "id": conversation_id,
+                    "status": "failed",
+                    "deleted": False,
+                    "error": "Gemini remote delete failed.",
+                })
+            except StateIntegrityError as e:
+                if not local_cleanup_started:
+                    await registry.abort_delete_session(conversation_id)
+                failed_count += 1
+                logger.error(f"Invalid Gemini WebAPI conversation snapshot {conversation_id}: {e}", exc_info=True)
+                results.append({
+                    "id": conversation_id,
+                    "status": "failed",
+                    "deleted": False,
+                    "error": str(e),
+                })
+            except Exception as e:
+                if not local_cleanup_started:
+                    await registry.abort_delete_session(conversation_id)
+                failed_count += 1
+                logger.error(f"Error deleting Gemini WebAPI conversation {conversation_id}: {e}", exc_info=True)
+                results.append({
+                    "id": conversation_id,
+                    "status": "failed",
+                    "deleted": False,
+                    "error": str(e),
+                })
+
+        return {
+            "object": "conversation.bulk_delete",
+            "provider": self.provider.provider_name,
+            "backend": "webapi",
+            "total": len(snapshots),
+            "deleted_count": deleted_count,
+            "failed_count": failed_count,
+            "skipped_active_count": skipped_active_count,
+            "results": results,
+        }
+
+    async def delete_conversation(self, conversation_id: str) -> dict:
+        gemini_client = self._get_available_gemini_client()
 
         registry = get_gemini_chat_registry()
         if not registry or not registry.repository:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -124,3 +124,29 @@ async def test_list_conversations_endpoint_gemini_empty(mocker):
     assert response.status_code == 200
     assert response.json() == mock_response
     mock_gemini.list_conversations.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_endpoint_gemini(mocker):
+    """Verify DELETE /v1/conversations delegates to Gemini bulk deletion."""
+    mock_response = {
+        "object": "conversation.bulk_delete",
+        "provider": "gemini",
+        "backend": "webapi",
+        "total": 0,
+        "deleted_count": 0,
+        "failed_count": 0,
+        "skipped_active_count": 0,
+        "results": [],
+    }
+    mock_gemini = mocker.Mock(spec=GeminiProvider)
+    mock_gemini.delete_conversations = mocker.AsyncMock(return_value=mock_response)
+
+    mocker.patch("app.services.factory.ProviderFactory.get_provider", return_value=(mock_gemini, ""))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.delete("/v1/conversations")
+
+    assert response.status_code == 200
+    assert response.json() == mock_response
+    mock_gemini.delete_conversations.assert_called_once_with()

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -2,12 +2,14 @@ import pytest
 import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import call
 from fastapi import HTTPException
-from gemini_webapi.exceptions import APIError
+from gemini_webapi.exceptions import APIError, AuthError
 from app.services.providers.base_repository import ConversationSnapshot
 from app.services.providers.exceptions import ConversationInUseError
 from app.services.providers.gemini.provider import GeminiProvider
 from app.services.providers.gemini.session_manager import SessionRegistry
+from app.services.providers.sqlite_repository import SQLiteConversationRepository
 
 @pytest.fixture
 def provider():
@@ -310,6 +312,262 @@ async def test_list_conversations_registry_unavailable_returns_503(mocker, provi
         await provider.list_conversations()
 
     assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_empty_list_returns_report(mocker, provider):
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=[])
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    result = await provider.delete_conversations()
+
+    assert result == {
+        "object": "conversation.bulk_delete",
+        "provider": "gemini",
+        "backend": "webapi",
+        "total": 0,
+        "deleted_count": 0,
+        "failed_count": 0,
+        "skipped_active_count": 0,
+        "results": [],
+    }
+    gemini_client.client.delete_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_success_deletes_all_inactive_snapshots(mocker, provider):
+    snapshots = [
+        make_delete_snapshot("conv-a", "remote-a"),
+        make_delete_snapshot("conv-b", "remote-b"),
+    ]
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=snapshots)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["total"] == 2
+    assert result["deleted_count"] == 2
+    assert result["failed_count"] == 0
+    assert result["skipped_active_count"] == 0
+    assert result["results"] == [
+        {"id": "conv-a", "status": "deleted", "deleted": True},
+        {"id": "conv-b", "status": "deleted", "deleted": True},
+    ]
+    gemini_client.client.delete_chat.assert_has_awaits([
+        call("remote-a"),
+        call("remote-b"),
+    ])
+    mock_registry.complete_delete_session.assert_has_awaits([
+        call("conv-a"),
+        call("conv-b"),
+    ])
+    assert "remote-a" not in json.dumps(result)
+    assert "remote-b" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_success_removes_sqlite_snapshots(mocker, tmp_path, provider):
+    db_file = tmp_path / "test_snapshots.db"
+    repository = SQLiteConversationRepository(db_path=str(db_file))
+    await repository.initialize()
+    snapshots = [
+        make_delete_snapshot("conv-a", "remote-a"),
+        make_delete_snapshot("conv-b", "remote-b"),
+    ]
+    for snapshot in snapshots:
+        await repository.save_snapshot(snapshot)
+
+    gemini_client = make_delete_client(mocker)
+    registry = SessionRegistry(gemini_client, repository=repository)
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["deleted_count"] == 2
+    assert await repository.list_snapshots("gemini") == []
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_skips_active_and_continues(mocker, provider):
+    snapshots = [
+        make_delete_snapshot("conv-active", "remote-active"),
+        make_delete_snapshot("conv-ok", "remote-ok"),
+    ]
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=snapshots)
+    mock_registry.begin_delete_session = mocker.AsyncMock(side_effect=[
+        ConversationInUseError("Conversation is currently in use"),
+        None,
+    ])
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["deleted_count"] == 1
+    assert result["failed_count"] == 0
+    assert result["skipped_active_count"] == 1
+    assert result["results"][0]["status"] == "skipped_active"
+    assert result["results"][0]["deleted"] is False
+    assert result["results"][1] == {"id": "conv-ok", "status": "deleted", "deleted": True}
+    gemini_client.client.delete_chat.assert_awaited_once_with("remote-ok")
+    mock_registry.abort_delete_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_remote_api_error_records_failed_and_continues(mocker, provider):
+    snapshots = [
+        make_delete_snapshot("conv-fail", "remote-fail"),
+        make_delete_snapshot("conv-ok", "remote-ok"),
+    ]
+    gemini_client = make_delete_client(mocker)
+
+    async def delete_chat(remote_cid):
+        if remote_cid == "remote-fail":
+            raise APIError("remote failed")
+
+    gemini_client.client.delete_chat = mocker.AsyncMock(side_effect=delete_chat)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=snapshots)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["deleted_count"] == 1
+    assert result["failed_count"] == 1
+    assert result["skipped_active_count"] == 0
+    assert result["results"][0]["id"] == "conv-fail"
+    assert result["results"][0]["status"] == "failed"
+    assert result["results"][0]["deleted"] is False
+    assert result["results"][1] == {"id": "conv-ok", "status": "deleted", "deleted": True}
+    mock_registry.abort_delete_session.assert_called_once_with("conv-fail")
+    mock_registry.complete_delete_session.assert_called_once_with("conv-ok")
+    assert "remote-fail" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_auth_error_aborts_bulk_run(mocker, provider):
+    snapshots = [
+        make_delete_snapshot("conv-auth", "remote-auth"),
+        make_delete_snapshot("conv-later", "remote-later"),
+    ]
+    gemini_client = make_delete_client(mocker)
+    gemini_client.client.delete_chat.side_effect = AuthError("auth expired")
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(return_value=snapshots)
+    mock_registry.begin_delete_session = mocker.AsyncMock()
+    mock_registry.complete_delete_session = mocker.AsyncMock()
+    mock_registry.abort_delete_session = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversations()
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+    gemini_client.client.delete_chat.assert_awaited_once_with("remote-auth")
+    mock_registry.abort_delete_session.assert_called_once_with("conv-auth")
+    mock_registry.complete_delete_session.assert_not_called()
+    mock_registry.begin_delete_session.assert_awaited_once_with("conv-auth")
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_local_cleanup_failure_records_failed_and_clears_tombstone(mocker, provider):
+    snapshot = make_delete_snapshot("conv-cleanup", "remote-cleanup")
+    gemini_client = make_delete_client(mocker)
+    repository = mocker.Mock()
+    repository.list_snapshots = mocker.AsyncMock(return_value=[snapshot])
+    repository.delete_snapshot = mocker.AsyncMock(side_effect=RuntimeError("sqlite unavailable"))
+    registry = SessionRegistry(gemini_client, repository=repository)
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["deleted_count"] == 0
+    assert result["failed_count"] == 1
+    assert result["results"][0]["id"] == "conv-cleanup"
+    assert result["results"][0]["status"] == "failed"
+    assert "conv-cleanup" not in registry._deleting
+    gemini_client.client.delete_chat.assert_called_once_with("remote-cleanup")
+    repository.delete_snapshot.assert_called_once_with("conv-cleanup")
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_tombstone_cleared_after_remote_failure(mocker, provider):
+    snapshot = make_delete_snapshot("conv-remote-fail", "remote-fail")
+    gemini_client = make_delete_client(mocker)
+    gemini_client.client.delete_chat.side_effect = APIError("remote failed")
+    repository = mocker.Mock()
+    repository.list_snapshots = mocker.AsyncMock(return_value=[snapshot])
+    repository.delete_snapshot = mocker.AsyncMock()
+    registry = SessionRegistry(gemini_client, repository=repository)
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=registry)
+
+    result = await provider.delete_conversations()
+
+    assert result["failed_count"] == 1
+    assert "conv-remote-fail" not in registry._deleting
+    repository.delete_snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_listing_failure_returns_500(mocker, provider):
+    gemini_client = make_delete_client(mocker)
+    mock_registry = mocker.Mock()
+    mock_registry.repository = mocker.Mock()
+    mock_registry.list_conversation_snapshots = mocker.AsyncMock(side_effect=RuntimeError("sqlite unavailable"))
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversations()
+
+    assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_delete_conversations_unauthenticated_returns_same_status_as_single_delete(mocker, provider):
+    gemini_client = make_delete_client(mocker, status_name="UNAUTHENTICATED")
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=gemini_client)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.delete_conversations()
+
+    assert exc_info.value.status_code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR adds `DELETE /v1/conversations` for best-effort bulk deletion of all locally persisted Gemini WebAPI conversations and their corresponding remote Gemini chats.

## Key Changes

* Added `DELETE /v1/conversations`.
* Implemented Gemini WebAPI bulk deletion via `GeminiProvider.delete_conversations()` and `GeminiWebAPIAdapter.delete_conversations()`.
* Reuses existing SQLite snapshot listing and per-conversation deletion tombstones.
* Skips active conversations and reports them as `skipped_active`.
* Continues processing on per-item remote/API failures and returns a detailed deletion report.
* Treats authentication failure as a global `401` error.
* Updated README and API contract documentation.
* Added tests for success, empty results, active skips, remote failures, cleanup failures, auth failure, and endpoint delegation.

## Testing

* Tests run: `pytest tests/test_sqlite_repository.py tests/test_gemini_provider.py tests/test_endpoints.py`
* Result: passed — `46 passed`
* Compile check: `python -m compileall -q src/app/services/providers src/app/endpoints/chat.py` — passed

## Notes

* This endpoint is scoped to Gemini WebAPI SQLite-backed conversations only.
* Playwright and Atlas conversations are not included.
* The operation is best-effort and non-atomic; partial failures are reported per conversation.
* Remote Gemini chat IDs are not exposed in the response.

## Related Issue

Related to #51. This PR implements the manual cleanup path requested in the issue by adding bulk deletion for Gemini WebAPI conversations. It does not yet implement automatic deletion after each response.