### PR TITLE
Refactor browser runtime ownership and introduce provider-agnostic execution architecture

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -37,7 +37,8 @@ async def lifespan(app: FastAPI):
     # Register Gemini Auth Strategy
     try:
         from app.services.providers.gemini.auth import GeminiAuthStrategy
-        get_auth_manager().set_strategy(GeminiAuthStrategy())
+        gemini_auth_strategy = GeminiAuthStrategy()
+        get_auth_manager().register_strategy(gemini_auth_strategy.provider_name, gemini_auth_strategy)
         logger.info("Gemini authentication strategy registered.")
     except Exception as e:
         logger.error(f"Failed to register Gemini auth strategy: {e}")

--- a/src/app/services/browser/auth_manager.py
+++ b/src/app/services/browser/auth_manager.py
@@ -60,6 +60,7 @@ class AuthManager:
     def __init__(self):
         if self._initialized:
             return
+        self._default_provider_name = "gemini"
         self.login_lock = asyncio.Lock()
         
         # Resolve auth lock backend from configuration
@@ -78,20 +79,74 @@ class AuthManager:
         if backend_name == "in_memory":
             self.coordination_lock = InMemoryAuthLock()
 
+        self._strategies: Dict[str, Any] = {}
         self._strategy = None
         self._cached_playwright_status = None
         self._cached_webapi_status = None
         self._cached_webapi_source = None
         self._last_validated = 0.0
+        self._cached_status_by_provider: Dict[str, Dict[str, Any]] = {}
         self._active_login_task: Optional[asyncio.Task] = None
+        self._active_login_tasks_by_provider: Dict[str, asyncio.Task] = {}
         self._legacy_fallback_active = False
         self._initialized = True
 
-    def set_strategy(self, strategy: Any) -> None:
+    def _resolve_provider_name(self, strategy: Any, provider_name: Optional[str] = None) -> str:
+        if provider_name:
+            return provider_name
+
+        candidate = getattr(strategy, "provider_name", None)
+        if callable(candidate):
+            candidate = candidate()
+        if isinstance(candidate, str) and candidate:
+            return candidate
+
+        return self._default_provider_name
+
+    def register_strategy(self, provider_name: str, strategy: Any) -> None:
         """
         Register a provider-specific authentication strategy.
         """
-        self._strategy = strategy
+        if not provider_name:
+            raise ValueError("provider_name is required.")
+
+        self._strategies[provider_name] = strategy
+        if provider_name == self._default_provider_name:
+            self._strategy = strategy
+
+    def set_strategy(self, strategy: Any) -> None:
+        """
+        Backward-compatible alias for registering the default Gemini strategy.
+        """
+        provider_name = self._resolve_provider_name(strategy)
+        self.register_strategy(provider_name, strategy)
+
+    def get_strategy(self, provider_name: Optional[str] = None) -> Any:
+        provider_name = provider_name or self._default_provider_name
+        if provider_name == self._default_provider_name and self._strategy is not None:
+            return self._strategy
+        return self._strategies.get(provider_name)
+
+    def _empty_provider_status(self) -> Dict[str, Any]:
+        return {
+            "playwright": AuthStatus.NO_SESSION,
+            "webapi": AuthStatus.INVALID,
+            "webapi_source": None,
+            "is_legacy": False,
+            "last_validated": 0.0,
+        }
+
+    def _sync_default_legacy_cache(self, snapshot: Dict[str, Any]) -> None:
+        self._cached_playwright_status = snapshot.get("playwright")
+        self._cached_webapi_status = snapshot.get("webapi")
+        self._cached_webapi_source = snapshot.get("webapi_source")
+        self._legacy_fallback_active = snapshot.get("is_legacy", False)
+        self._last_validated = time.time()
+
+    def _store_provider_snapshot(self, provider_name: str, snapshot: Dict[str, Any]) -> None:
+        self._cached_status_by_provider[provider_name] = dict(snapshot)
+        if provider_name == self._default_provider_name:
+            self._sync_default_legacy_cache(snapshot)
 
     @property
     def login_state(self) -> str:
@@ -119,45 +174,53 @@ class AuthManager:
             cls._instance = cls()
         return cls._instance
 
-    def refresh_playwright_status_lightweight(self) -> str:
+    def refresh_playwright_status_lightweight(self, provider_name: Optional[str] = None) -> str:
         """
         Lightweight check for Playwright session status.
         Delegates to the registered strategy.
         """
-        status = self.refresh_status()
+        status = self.refresh_status(provider_name)
         return status.get("playwright_status", AuthStatus.NO_SESSION)
 
-    def refresh_webapi_status_lightweight(self) -> str:
+    def refresh_webapi_status_lightweight(self, provider_name: Optional[str] = None) -> str:
         """
         Lightweight check for gemini-webapi connection status.
         Delegates to the registered strategy.
         """
-        status = self.refresh_status()
+        status = self.refresh_status(provider_name)
         return status.get("webapi_status", AuthStatus.INVALID)
 
-    def refresh_status(self) -> Dict[str, Any]:
+    def refresh_status(self, provider_name: Optional[str] = None) -> Dict[str, Any]:
         """
         Perform a lightweight refresh of both authentication pathways.
         Delegates to the registered strategy.
         """
-        if not self._strategy:
+        provider_name = provider_name or self._default_provider_name
+        strategy = self.get_strategy(provider_name)
+        if not strategy:
+            snapshot = self._empty_provider_status()
+            snapshot["last_validated"] = time.time()
+            self._store_provider_snapshot(provider_name, snapshot)
             return {
-                "playwright_status": AuthStatus.NO_SESSION,
-                "webapi_status": AuthStatus.INVALID,
-                "last_validated": time.time()
+                "playwright_status": snapshot["playwright"],
+                "webapi_status": snapshot["webapi"],
+                "last_validated": snapshot["last_validated"],
             }
 
-        res = self._strategy.refresh_status()
-        self._cached_playwright_status = res.get("playwright")
-        self._cached_webapi_status = res.get("webapi")
-        self._cached_webapi_source = res.get("webapi_source")
-        self._legacy_fallback_active = res.get("is_legacy", False)
-        self._last_validated = time.time()
+        res = strategy.refresh_status()
+        snapshot = {
+            "playwright": res.get("playwright", AuthStatus.NO_SESSION),
+            "webapi": res.get("webapi", AuthStatus.INVALID),
+            "webapi_source": res.get("webapi_source"),
+            "is_legacy": res.get("is_legacy", False),
+            "last_validated": time.time(),
+        }
+        self._store_provider_snapshot(provider_name, snapshot)
         
         return {
-            "playwright_status": self._cached_playwright_status,
-            "webapi_status": self._cached_webapi_status,
-            "last_validated": self._last_validated
+            "playwright_status": snapshot["playwright"],
+            "webapi_status": snapshot["webapi"],
+            "last_validated": snapshot["last_validated"]
         }
 
     def get_status(self) -> Dict[str, Any]:
@@ -165,9 +228,10 @@ class AuthManager:
         Get the current cached authentication status without performing expensive operations.
         """
         if self._cached_playwright_status is None or self._cached_webapi_status is None:
-            self.refresh_status()
+            self.refresh_status(self._default_provider_name)
 
-        state_path = self._strategy.get_state_path() if self._strategy else "N/A"
+        default_strategy = self.get_strategy(self._default_provider_name)
+        state_path = default_strategy.get_state_path() if default_strategy else "N/A"
 
         status_payload = {
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -191,28 +255,44 @@ class AuthManager:
 
         return status_payload
 
-    def mark_expired(self):
+    def get_provider_status(self, provider_name: Optional[str] = None) -> Dict[str, Any]:
+        provider_name = provider_name or self._default_provider_name
+        snapshot = self._cached_status_by_provider.get(provider_name)
+        if snapshot is None:
+            self.refresh_status(provider_name)
+            snapshot = self._cached_status_by_provider.get(provider_name, self._empty_provider_status())
+        return dict(snapshot)
+
+    def mark_expired(self, provider_name: Optional[str] = None):
         """
         Transition cached status to EXPIRED_SESSION. Called passively on request auth failures.
         """
+        provider_name = provider_name or self._default_provider_name
         logger.info("AuthManager: Playwright session marked as EXPIRED_SESSION passively.")
-        self._cached_playwright_status = AuthStatus.EXPIRED_SESSION
+        snapshot = self._cached_status_by_provider.get(provider_name, self._empty_provider_status())
+        snapshot["playwright"] = AuthStatus.EXPIRED_SESSION
+        self._store_provider_snapshot(provider_name, snapshot)
 
-    def start_login(self) -> None:
+    def start_login(self, provider_name: Optional[str] = None) -> None:
         """
         Triggers the on-demand bootstrap login workflow asynchronously in the background.
         Coordinates locks and active state machine.
         """
-        if not self._strategy:
+        provider_name = provider_name or self._default_provider_name
+        strategy = self.get_strategy(provider_name)
+        if not strategy:
             raise RuntimeError("No authentication strategy registered.")
             
         if not self.coordination_lock.acquire():
             raise ValueError("Authentication in progress.")
 
-        self._active_login_task = asyncio.create_task(self._run_login_task())
+        task = asyncio.create_task(self._run_login_task(provider_name))
+        self._active_login_tasks_by_provider[provider_name] = task
+        if provider_name == self._default_provider_name:
+            self._active_login_task = task
         logger.info("AuthManager: Asynchronous login workflow successfully triggered.")
 
-    async def _run_login_task(self) -> None:
+    async def _run_login_task(self, provider_name: str) -> None:
         async with self.login_lock:
             try:
                 if not self._check_display_available():
@@ -220,35 +300,48 @@ class AuthManager:
 
                 from app.services.browser.engine import get_browser_engine
                 bootstrap_engine = await get_browser_engine(headless=False, is_bootstrap=True)
+                strategy = self.get_strategy(provider_name)
+                if not strategy:
+                    raise RuntimeError("No authentication strategy registered.")
                 
                 async with bootstrap_engine as engine:
-                    await self._strategy.run_login_flow(engine)
+                    await strategy.run_login_flow(engine)
                 
-                self._cached_playwright_status = AuthStatus.VALID_SESSION
+                snapshot = self._cached_status_by_provider.get(provider_name, self._empty_provider_status())
+                snapshot["playwright"] = AuthStatus.VALID_SESSION
+                self._store_provider_snapshot(provider_name, snapshot)
                 
                 # Re-initialize the direct gemini-webapi client with the newly saved cookies
                 try:
-                    await self._strategy.run_post_login_recovery()
+                    await strategy.run_post_login_recovery()
                     logger.info("AuthManager: Instantly refreshing local authentication statuses...")
-                    self.refresh_status()
+                    self.refresh_status(provider_name)
                 except Exception as e:
                     logger.error(f"AuthManager: Post-login recovery failed: {e}")
-                    self._cached_webapi_status = AuthStatus.INVALID
+                    snapshot = self._cached_status_by_provider.get(provider_name, self._empty_provider_status())
+                    snapshot["webapi"] = AuthStatus.INVALID
+                    self._store_provider_snapshot(provider_name, snapshot)
             except Exception as e:
                 logger.error(f"AuthManager: Background login flow failed: {e}")
                 # Refresh status (which might be EXPIRED_SESSION or NO_SESSION)
-                self.refresh_status()
+                self.refresh_status(provider_name)
             finally:
-                self._active_login_task = None
-                self._last_validated = time.time()
+                self._active_login_tasks_by_provider.pop(provider_name, None)
+                if provider_name == self._default_provider_name:
+                    self._active_login_task = None
+                snapshot = self._cached_status_by_provider.get(provider_name, self._empty_provider_status())
+                snapshot["last_validated"] = time.time()
+                self._store_provider_snapshot(provider_name, snapshot)
                 self.coordination_lock.release()
 
-    async def run_login_flow(self) -> None:
+    async def run_login_flow(self, provider_name: Optional[str] = None) -> None:
         """
         Orchestrate the headful login workflow using core BrowserEngine primitives.
         Delegates to the registered strategy.
         """
-        if not self._strategy:
+        provider_name = provider_name or self._default_provider_name
+        strategy = self.get_strategy(provider_name)
+        if not strategy:
             raise RuntimeError("No authentication strategy registered.")
             
         if not self._check_display_available():
@@ -257,7 +350,7 @@ class AuthManager:
         from app.services.browser.engine import get_browser_engine
         bootstrap_engine = await get_browser_engine(headless=False, is_bootstrap=True)
         async with bootstrap_engine as engine:
-            await self._strategy.run_login_flow(engine)
+            await strategy.run_login_flow(engine)
 
     def _check_display_available(self) -> bool:
         """

--- a/src/app/services/browser/auth_manager.py
+++ b/src/app/services/browser/auth_manager.py
@@ -125,7 +125,22 @@ class AuthManager:
         provider_name = provider_name or self._default_provider_name
         if provider_name == self._default_provider_name and self._strategy is not None:
             return self._strategy
-        return self._strategies.get(provider_name)
+
+        strategy = self._strategies.get(provider_name)
+        if strategy is not None:
+            return strategy
+
+        if provider_name == self._default_provider_name:
+            try:
+                from app.services.providers.gemini.auth import GeminiAuthStrategy
+
+                strategy = GeminiAuthStrategy()
+                self.register_strategy(provider_name, strategy)
+                return strategy
+            except Exception as e:
+                logger.debug("AuthManager: Failed to lazily create default Gemini auth strategy: %s", e)
+
+        return None
 
     def _empty_provider_status(self) -> Dict[str, Any]:
         return {

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -71,6 +71,7 @@ class BrowserRequestExecutorHooks:
     provider_name: str
     session_name: str
     callback_name: str
+    bridge_callbacks_attr: str
     default_model: str
     create_browser_adapter: Callable[[], Any]
     get_browser_engine: Callable[[], Awaitable[Any]]
@@ -202,10 +203,14 @@ class BrowserRequestExecutor:
                             logger.warning(f"Bridge emit failure: {e}")
                             state.page_poisoned = True
 
-                    await session._setup_page_bridge(page)
-                    # Temporary Gemini-specific bridge callback registry retained for
-                    # backward compatibility. PR2 will generalize this shared runtime surface.
-                    page._gemini_callbacks[state.request_id] = bridge_callback
+                    await session._setup_page_bridge(
+                        page,
+                        binding_name=self.hooks.callback_name,
+                        callbacks_attr=self.hooks.bridge_callbacks_attr,
+                    )
+                    # Temporary Gemini-specific callback attribute may still be supplied
+                    # by provider hooks for compatibility while PR3 finishes bridge cleanup.
+                    getattr(page, self.hooks.bridge_callbacks_attr)[state.request_id] = bridge_callback
                     await self.hooks.sleep(0.01)
 
                     self._validate_tab_generation(
@@ -517,8 +522,9 @@ class BrowserRequestExecutor:
                     except BaseException:
                         pass
                 if lease:
-                    if hasattr(lease.page, "_gemini_callbacks"):
-                        lease.page._gemini_callbacks.pop(state.request_id, None)
+                    callbacks = getattr(lease.page, self.hooks.bridge_callbacks_attr, None)
+                    if callbacks is not None:
+                        callbacks.pop(state.request_id, None)
                     if not state.page_closed:
                         try:
                             await self.hooks.stop_observer(lease.page, state.request_id)

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -1,0 +1,567 @@
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from playwright.async_api import Error as PlaywrightError
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
+
+from app.config import CONFIG
+from app.logger import logger
+from app.schemas.request import OpenAIChatRequest
+from app.services.browser.errors import (
+    BrowserDisconnectedError,
+    BrowserGenerationMismatchError,
+    BrowserShuttingDownError,
+    ConversationBusyError,
+    LeaseInvalidatedError,
+    QueueOverflowError,
+    SessionNotAliveError,
+    TransientSessionError,
+)
+from app.services.browser.tab import ManagedPage
+
+
+@dataclass(frozen=True)
+class PlaywrightAdapterConfig:
+    """Consolidated configuration for browser-native request execution."""
+    navigation_timeout: int
+    ui_wait_timeout: int
+    chunk_timeout: int
+    total_request_timeout: int
+
+    @classmethod
+    def load(cls) -> "PlaywrightAdapterConfig":
+        return cls(
+            navigation_timeout=CONFIG["Playwright"].getint("navigation_timeout", 30000),
+            ui_wait_timeout=CONFIG["Playwright"].getint("ui_wait_timeout", 15000),
+            chunk_timeout=CONFIG["Playwright"].getint("chunk_timeout", 90),
+            total_request_timeout=CONFIG["Playwright"].getint("total_request_timeout", 120),
+        )
+
+
+@dataclass
+class PlaywrightRequestState:
+    """Shared state for a single browser-native request lifecycle."""
+    request_id: str
+    start_time: float
+    permit_acquired: bool = False
+    cleanup_started: bool = False
+    page_closed: bool = False
+    page_poisoned: bool = False
+    dropped_chunks: int = 0
+    max_queue_depth: int = 0
+    conversation_id: Optional[str] = None
+    reused_conversation: bool = False
+    active_tab: Optional[Any] = None
+    js_ready: asyncio.Event = field(default_factory=asyncio.Event)
+    submission_confirmed: asyncio.Event = field(default_factory=asyncio.Event)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    has_sent_text: bool = False
+    on_close_handler: Any = None
+    on_crash_handler: Any = None
+    queue_overflow: bool = False
+
+
+@dataclass(frozen=True)
+class BrowserRequestExecutorHooks:
+    provider_name: str
+    session_name: str
+    callback_name: str
+    default_model: str
+    create_browser_adapter: Callable[[], Any]
+    get_browser_engine: Callable[[], Awaitable[Any]]
+    sleep: Callable[[float], Awaitable[None]]
+    timeout: Callable[[float], Any]
+    navigate: Callable[[Page, PlaywrightRequestState, OpenAIChatRequest, PlaywrightAdapterConfig], Awaitable[None]]
+    wait_for_ready_ui: Callable[[Page, PlaywrightRequestState, PlaywrightAdapterConfig], Awaitable[None]]
+    start_observer: Callable[[Page, str, str], Awaitable[Any]]
+    stop_observer: Callable[[Page, str], Awaitable[None]]
+    stop_generation: Callable[[Page], Awaitable[None]]
+    extract_conversation_id: Callable[[str], Optional[str]]
+    convert_to_openai_format: Callable[[str, str, bool], dict]
+    orchestrate_model_selection: Callable[[Any, Page, str, PlaywrightRequestState], Awaitable[None]]
+
+
+class BrowserRequestExecutor:
+    """
+    Shared request-scoped browser execution lifecycle.
+
+    Provider-specific DOM behavior remains delegated through hooks.
+    """
+
+    def __init__(self, config: PlaywrightAdapterConfig, hooks: BrowserRequestExecutorHooks):
+        self.config = config
+        self.hooks = hooks
+
+    async def execute(self, request: OpenAIChatRequest) -> Any:
+        request_id = getattr(request, "_http_request_id", None) or str(uuid.uuid4()).replace("-", "_")
+        start_time = time.monotonic()
+
+        page_lease = None
+        observer_task = None
+        state = None
+        setup_success = False
+        session = None
+
+        max_retries = 3
+        backoff_delays = [1.0, 2.0, 4.0]
+
+        try:
+            from app.services.browser.auth_manager import get_auth_manager
+            from app.services.browser.auth_types import AuthStatus
+
+            auth_mgr = get_auth_manager()
+            if auth_mgr.coordination_lock.is_locked():
+                raise HTTPException(status_code=503, detail="Authentication in progress.")
+
+            if auth_mgr.refresh_playwright_status_lightweight() == AuthStatus.EXPIRED_SESSION:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Authentication expired.",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            engine = await self.hooks.get_browser_engine()
+            session = await engine.get_session(self.hooks.session_name)
+            browser_adapter = self.hooks.create_browser_adapter()
+            for attempt in range(1, max_retries + 1):
+                page_lease = None
+                observer_task = None
+                state = PlaywrightRequestState(request_id=request_id, start_time=start_time)
+
+                def on_close(_page):
+                    if state.cleanup_started:
+                        return
+                    logger.warning("Page close detected", extra={"request_id": state.request_id})
+                    state.page_poisoned = True
+                    if state.active_tab:
+                        state.active_tab.invalidate()
+
+                def on_crash(_page):
+                    if state.cleanup_started:
+                        return
+                    logger.warning("Page crash detected", extra={"request_id": state.request_id})
+                    state.page_poisoned = True
+                    if state.active_tab:
+                        state.active_tab.invalidate()
+
+                state.on_close_handler = on_close
+                state.on_crash_handler = on_crash
+
+                try:
+                    page_lease = await session.acquire_lease(
+                        conversation_id=request.conversation_id,
+                        request_id=state.request_id,
+                    )
+                    state.permit_acquired = True
+                    page = page_lease.page
+
+                    page.on("close", on_close)
+                    page.on("crash", on_crash)
+
+                    if page_lease.persistent_tab:
+                        state.active_tab = page_lease.persistent_tab
+                        state.reused_conversation = True
+                        state.conversation_id = request.conversation_id
+
+                    queue = asyncio.Queue(maxsize=100)
+
+                    async def bridge_callback(_source, payload):
+                        if state.cleanup_started:
+                            return
+                        if payload.get("type") == "ready":
+                            state.js_ready.set()
+                            return
+
+                        if payload.get("type") in ("started", "chunk", "rewrite", "done"):
+                            if not state.submission_confirmed.is_set():
+                                state.submission_confirmed.set()
+
+                        if payload.get("type") == "started":
+                            return
+
+                        try:
+                            queue.put_nowait(payload)
+                            state.max_queue_depth = max(state.max_queue_depth, queue.qsize())
+                        except asyncio.QueueFull:
+                            state.dropped_chunks += 1
+                            state.queue_overflow = True
+                            logger.error(
+                                f"Queue overflow during streaming: {state.dropped_chunks} chunks dropped",
+                                extra={
+                                    "request_id": state.request_id,
+                                    "dropped_chunks": state.dropped_chunks,
+                                    "max_queue_depth": state.max_queue_depth,
+                                },
+                            )
+                        except Exception as e:
+                            logger.warning(f"Bridge emit failure: {e}")
+                            state.page_poisoned = True
+
+                    await session._setup_page_bridge(page)
+                    # Temporary Gemini-specific bridge callback registry retained for
+                    # backward compatibility. PR2 will generalize this shared runtime surface.
+                    page._gemini_callbacks[state.request_id] = bridge_callback
+                    await self.hooks.sleep(0.01)
+
+                    self._validate_tab_generation(
+                        state.active_tab,
+                        engine.browser_generation,
+                        "Browser generation mismatch detected during prompt processing",
+                    )
+                    await self.hooks.navigate(page, state, request, self.config)
+                    await self.hooks.wait_for_ready_ui(page, state, self.config)
+
+                    if state.active_tab:
+                        state.active_tab.heartbeat("auth_check")
+                    self._validate_tab_generation(state.active_tab, engine.browser_generation)
+
+                    grace_timeout = 2.5
+                    poll_interval = 0.5
+                    elapsed = 0.0
+                    last_transient_error = None
+                    is_authenticated = False
+                    while elapsed < grace_timeout:
+                        try:
+                            is_authenticated = await browser_adapter.check_authentication(page)
+                            if is_authenticated:
+                                break
+                        except TransientSessionError as e:
+                            last_transient_error = e
+                        await self.hooks.sleep(poll_interval)
+                        elapsed += poll_interval
+
+                    self._validate_tab_generation(state.active_tab, engine.browser_generation)
+                    if not is_authenticated:
+                        if last_transient_error:
+                            raise last_transient_error
+                        raise SessionNotAliveError("Authentication expired.")
+
+                    if state.active_tab:
+                        state.active_tab.heartbeat("observer_injection")
+                    self._validate_tab_generation(state.active_tab, engine.browser_generation)
+                    observer_task = asyncio.create_task(
+                        self.hooks.start_observer(page, self.hooks.callback_name, state.request_id),
+                        name=f"observer_{state.request_id}",
+                    )
+
+                    try:
+                        async with self.hooks.timeout(5.0):
+                            await state.js_ready.wait()
+                    except asyncio.TimeoutError:
+                        raise TransientSessionError("JS Ready Signal Timeout during pre-submission phase.")
+
+                    break
+
+                except TransientSessionError:
+                    if page_lease or observer_task:
+                        await self._cleanup(observer_task, state, page_lease, session)
+                    if attempt == max_retries:
+                        raise
+                    await self.hooks.sleep(backoff_delays[attempt - 1])
+
+            prompt = request.messages[-1].get("content", "")
+
+            async with session.submit_lock:
+                self._validate_tab_generation(state.active_tab, engine.browser_generation)
+                await self.hooks.orchestrate_model_selection(browser_adapter, page, request.model, state)
+                confirmed = await browser_adapter.submit_prompt(page, prompt, state)
+
+            if not confirmed:
+                raise HTTPException(status_code=500, detail=f"{self.hooks.provider_name.title()} failed to accept the prompt.")
+
+            model = request.model or self.hooks.default_model
+            if request.stream:
+                setup_success = True
+                logger.info(
+                    f"Stream starting: {request_id}",
+                    extra={
+                        "request_id": request_id,
+                        "conversation_id": state.conversation_id,
+                        "provider": self.hooks.provider_name,
+                        "model": request.model,
+                    },
+                )
+                return StreamingResponse(
+                    self._sse_generator(queue, model, page, state, observer_task, engine, session, page_lease),
+                    media_type="text/event-stream",
+                )
+
+            resp = await self._get_buffered_response(queue, model, page, state, observer_task, engine, session, page_lease)
+            setup_success = True
+            return resp
+
+        except asyncio.CancelledError:
+            if state:
+                logger.warning(f"Request cancelled: {state.request_id}", extra={"request_id": state.request_id})
+            raise
+
+        except Exception as e:
+            poison_session_errors = (
+                SessionNotAliveError,
+                BrowserDisconnectedError,
+                BrowserGenerationMismatchError,
+            )
+            if isinstance(e, poison_session_errors) and session:
+                await session.handle_session_failure()
+
+            correlation_headers = {}
+            if state:
+                correlation_headers["X-Request-ID"] = state.request_id
+
+            if isinstance(e, SessionNotAliveError):
+                detail = str(e) if str(e) else "Authentication expired."
+                if "authentication expired" not in detail.lower():
+                    detail = f"Authentication expired. {detail}"
+                correlation_headers["WWW-Authenticate"] = "Bearer"
+                logger.error(
+                    f"Authentication failed: {detail}",
+                    extra={"request_id": state.request_id if state else "unknown"} if state else {},
+                )
+                raise HTTPException(status_code=401, detail=detail, headers=correlation_headers)
+
+            if isinstance(e, TransientSessionError):
+                logger.error(f"Transient session error: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(status_code=503, detail=str(e), headers=correlation_headers)
+
+            if isinstance(e, (asyncio.TimeoutError, PlaywrightTimeoutError)):
+                logger.error(f"Request timeout: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(status_code=504, detail="Request timed out.", headers=correlation_headers)
+
+            if isinstance(e, BrowserDisconnectedError):
+                logger.error(f"Browser disconnected: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(status_code=502, detail="Underlying browser process disconnected.", headers=correlation_headers)
+
+            if isinstance(e, BrowserGenerationMismatchError):
+                logger.error(f"Browser generation mismatch: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(status_code=503, detail="Browser generation rollover mismatch.", headers=correlation_headers)
+
+            if isinstance(e, PlaywrightError):
+                if "closed" in str(e).lower():
+                    logger.error(f"Browser session closed: {e}", extra={"request_id": state.request_id} if state else {})
+                    raise HTTPException(status_code=503, detail="Browser session unavailable.", headers=correlation_headers)
+                logger.error(f"Browser interaction failure: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(status_code=502, detail="Browser interaction failure.", headers=correlation_headers)
+
+            if isinstance(e, (BrowserShuttingDownError, LeaseInvalidatedError, QueueOverflowError, ConversationBusyError)):
+                logger.error(f"Runtime error: {e}", extra={"request_id": state.request_id} if state else {})
+                raise HTTPException(
+                    status_code=503 if not isinstance(e, (LeaseInvalidatedError, ConversationBusyError)) else 409,
+                    detail=str(e),
+                    headers=correlation_headers,
+                )
+
+            if isinstance(e, HTTPException):
+                raise
+
+            logger.error(
+                f"Unexpected error in {self.hooks.provider_name.title()} browser request executor: {e}",
+                exc_info=True,
+                extra={"request_id": state.request_id} if state else {},
+            )
+            raise HTTPException(status_code=500, detail="Internal server error.", headers=correlation_headers)
+
+        finally:
+            if not setup_success and (page_lease or observer_task):
+                await self._cleanup(observer_task, state, page_lease, session)
+
+    async def _sse_generator(
+        self,
+        queue: asyncio.Queue,
+        model: str,
+        page: Page,
+        state: PlaywrightRequestState,
+        observer_task: Optional[asyncio.Task],
+        engine: Any,
+        session: Any,
+        lease: ManagedPage,
+    ):
+        from app.utils.streaming import format_sse_chunk, get_done_chunk
+
+        request_id = state.request_id
+        stream_start_time = time.monotonic()
+        stream_cancelled = False
+
+        try:
+            if state.queue_overflow:
+                logger.error(
+                    f"Queue overflow detected at stream start: {state.dropped_chunks} chunks dropped",
+                    extra={
+                        "request_id": request_id,
+                        "dropped_chunks": state.dropped_chunks,
+                        "max_queue_depth": state.max_queue_depth,
+                    },
+                )
+                raise QueueOverflowError("Event queue saturated")
+
+            while True:
+                try:
+                    await self._register_conversation_if_available(page, state, session, lease)
+
+                    payload = await asyncio.wait_for(queue.get(), timeout=self.config.chunk_timeout)
+                    if payload.get("type") == "done":
+                        break
+
+                    if state.active_tab:
+                        self._validate_tab_generation(state.active_tab, engine.browser_generation)
+
+                    text_to_send = ""
+                    if payload.get("type") == "chunk":
+                        text_to_send = payload["delta"]
+                    elif payload.get("type") == "rewrite" and not state.has_sent_text:
+                        text_to_send = payload["full_text"]
+
+                    if text_to_send:
+                        state.has_sent_text = True
+                        chunk = self.hooks.convert_to_openai_format(text_to_send, model, True)
+                        if state.conversation_id:
+                            chunk["conversation_id"] = state.conversation_id
+                            chunk["reused_conversation"] = state.reused_conversation
+                        yield await format_sse_chunk(chunk)
+                except asyncio.TimeoutError:
+                    break
+
+            yield await get_done_chunk()
+
+        except (asyncio.CancelledError, GeneratorExit):
+            duration = time.monotonic() - stream_start_time
+            logger.warning(
+                f"Stream cancelled: {request_id}",
+                extra={"request_id": request_id, "duration": f"{duration:.2f}s", "reason": "client_disconnect"},
+            )
+            stream_cancelled = True
+            try:
+                await self.hooks.stop_generation(page)
+            except Exception:
+                pass
+            raise
+
+        finally:
+            if not stream_cancelled:
+                duration = time.monotonic() - stream_start_time
+                logger.info(
+                    f"Stream completed: {request_id}",
+                    extra={"request_id": request_id, "duration": f"{duration:.2f}s", "has_sent_text": state.has_sent_text},
+                )
+            await self._cleanup(observer_task, state, lease, session)
+
+    async def _get_buffered_response(
+        self,
+        queue: asyncio.Queue,
+        model: str,
+        page: Page,
+        state: PlaywrightRequestState,
+        observer_task: Optional[asyncio.Task],
+        engine: Any,
+        session: Any,
+        lease: ManagedPage,
+    ):
+        try:
+            full_text = ""
+            async with self.hooks.timeout(self.config.total_request_timeout):
+                while True:
+                    if state.queue_overflow:
+                        raise QueueOverflowError("Event queue saturated")
+                    await self._register_conversation_if_available(page, state, session, lease)
+
+                    payload = await queue.get()
+                    if payload.get("type") == "done":
+                        break
+
+                    if state.active_tab:
+                        self._validate_tab_generation(state.active_tab, engine.browser_generation)
+
+                    if payload.get("type") == "rewrite":
+                        full_text = payload["full_text"]
+                    if payload.get("type") == "chunk":
+                        full_text += payload["delta"]
+
+            res = self.hooks.convert_to_openai_format(full_text, model, False)
+            if state.conversation_id:
+                res["conversation_id"] = state.conversation_id
+                res["reused_conversation"] = state.reused_conversation
+            return res
+        finally:
+            await self._cleanup(observer_task, state, lease, session)
+
+    async def _register_conversation_if_available(self, page: Page, state: PlaywrightRequestState, session: Any, lease: ManagedPage):
+        if state.conversation_id or state.active_tab:
+            return
+        async with state.lock:
+            if state.conversation_id or state.active_tab:
+                return
+            conversation_id = self.hooks.extract_conversation_id(page.url)
+            if conversation_id:
+                state.conversation_id = conversation_id
+                state.active_tab = await session.register_conversation(conversation_id, lease)
+
+    async def _cleanup(self, observer_task: Optional[asyncio.Task], state: Optional[PlaywrightRequestState], lease: Optional[ManagedPage], session: Any):
+        if not state and not lease and not observer_task:
+            return
+        await asyncio.shield(self._do_cleanup(observer_task, state, lease, session))
+
+    async def _do_cleanup(self, observer_task, state, lease, session):
+        async with state.lock:
+            if state.cleanup_started and state.page_closed:
+                return
+            state.cleanup_started = True
+            try:
+                if observer_task and not observer_task.done():
+                    observer_task.cancel()
+                    try:
+                        await observer_task
+                    except BaseException:
+                        pass
+                if lease:
+                    if hasattr(lease.page, "_gemini_callbacks"):
+                        lease.page._gemini_callbacks.pop(state.request_id, None)
+                    if not state.page_closed:
+                        try:
+                            await self.hooks.stop_observer(lease.page, state.request_id)
+                        except Exception as e:
+                            logger.debug(
+                                "BrowserRequestExecutor: stop_observer cleanup failed for request_id=%s: %s",
+                                state.request_id,
+                                e,
+                            )
+                        try:
+                            if state.on_close_handler:
+                                lease.page.remove_listener("close", state.on_close_handler)
+                            if state.on_crash_handler:
+                                lease.page.remove_listener("crash", state.on_crash_handler)
+                        except Exception as e:
+                            logger.debug(
+                                "BrowserRequestExecutor: listener cleanup failed for request_id=%s: %s",
+                                state.request_id,
+                                e,
+                            )
+                    if not state.active_tab and not state.page_closed:
+                        try:
+                            conversation_id = self.hooks.extract_conversation_id(lease.page.url)
+                            if conversation_id:
+                                state.conversation_id = conversation_id
+                                state.active_tab = await session.register_conversation(conversation_id, lease)
+                        except Exception as e:
+                            logger.debug(
+                                "BrowserRequestExecutor: final conversation registration cleanup failed for request_id=%s: %s",
+                                state.request_id,
+                                e,
+                            )
+                    if state.page_poisoned and state.active_tab:
+                        state.active_tab.invalidate()
+                    await lease.close()
+                    state.page_closed = True
+            except Exception as e:
+                logger.warning(
+                    "BrowserRequestExecutor: cleanup encountered an unexpected error for request_id=%s: %s",
+                    state.request_id if state else "unknown",
+                    e,
+                )
+
+    def _validate_tab_generation(self, tab: Any, current_generation: int, message: Optional[str] = None):
+        if tab:
+            BrowserGenerationMismatchError.validate(tab.browser_generation, current_generation)

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -1,6 +1,7 @@
-import os
 import asyncio
 import json
+import inspect
+import os
 import time
 import weakref
 from collections import OrderedDict
@@ -979,22 +980,42 @@ class ProviderSession:
         tab._cleanup_task = task
         self._orphan_cleanup_tasks.add(task)
 
-    async def _setup_page_bridge(self, page: Page):
-        """Exposes a single permanent binding on the page to prevent memory leaks."""
-        if getattr(page, "_gemini_bridge_exposed", False):
+    async def _setup_page_bridge(
+        self,
+        page: Page,
+        binding_name: str = "__browser_bridge",
+        callbacks_attr: str = "_browser_bridge_callbacks",
+    ):
+        """Expose a permanent request bridge binding on the page for a provider."""
+        page_state = vars(page)
+        exposed_bindings = page_state.get("_browser_bridge_exposed_bindings")
+        if exposed_bindings is None:
+            exposed_bindings = set()
+            page._browser_bridge_exposed_bindings = exposed_bindings
+        if binding_name in exposed_bindings:
+            if callbacks_attr not in page_state:
+                setattr(page, callbacks_attr, {})
             return
-        
-        # Lock to serialize bridge setup on the same page
-        lock = getattr(page, "_gemini_bridge_lock", None)
+
+        # Lock to serialize bridge setup on the same page.
+        lock = page_state.get("_browser_bridge_lock")
         if lock is None:
             lock = asyncio.Lock()
-            page._gemini_bridge_lock = lock
+            page._browser_bridge_lock = lock
 
         async with lock:
-            if getattr(page, "_gemini_bridge_exposed", False):
+            page_state = vars(page)
+            exposed_bindings = page_state.get("_browser_bridge_exposed_bindings")
+            if exposed_bindings is None:
+                exposed_bindings = set()
+                page._browser_bridge_exposed_bindings = exposed_bindings
+            if binding_name in exposed_bindings:
+                if callbacks_attr not in page_state:
+                    setattr(page, callbacks_attr, {})
                 return
-            
-            page._gemini_callbacks = {}
+
+            if callbacks_attr not in page_state:
+                setattr(page, callbacks_attr, {})
             
             async def page_bridge(source, payload):
                 req_id = payload.get("requestId")
@@ -1007,7 +1028,7 @@ class ProviderSession:
                     extra={"request_id": req_id, "payload_type": payload.get("type")}
                 )
                 
-                callbacks = getattr(page, "_gemini_callbacks", {})
+                callbacks = vars(page).get(callbacks_attr, {})
                 callback = callbacks.get(req_id)
                 if not callback:
                     logger.error(
@@ -1031,6 +1052,8 @@ class ProviderSession:
                         exc_info=True,
                         extra={"request_id": req_id}
                     )
-                    
-            await page.expose_binding("__gemini_bridge", page_bridge)
-            page._gemini_bridge_exposed = True
+
+            expose_result = page.expose_binding(binding_name, page_bridge)
+            if inspect.isawaitable(expose_result):
+                await expose_result
+            exposed_bindings.add(binding_name)

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -478,43 +478,18 @@ class ProviderSession:
             "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
         }
 
-        if self.name == "gemini":
-            from app.services.browser.auth_loader import GeminiAuthStateLoader
-            from app.services.providers.gemini.auth_selector import GeminiAuthSelector
-            allow_unauthenticated_bootstrap_context = (
-                getattr(self.engine, "is_bootstrap", False)
-                and self.enable_persistence
+        from app.services.browser.auth_manager import get_auth_manager
+
+        auth_strategy = get_auth_manager().get_strategy(self.name)
+        if auth_strategy and hasattr(auth_strategy, "build_playwright_context_args"):
+            strategy_context_args = auth_strategy.build_playwright_context_args(
+                enable_persistence=self.enable_persistence,
+                is_bootstrap=getattr(self.engine, "is_bootstrap", False),
             )
-            if allow_unauthenticated_bootstrap_context:
-                auth_candidate = next(
-                    (
-                        candidate
-                        for candidate in GeminiAuthSelector.iter_candidates()
-                        if candidate.supports_playwright_storage
-                    ),
-                    None,
-                )
-            else:
-                auth_candidate = GeminiAuthSelector.first_playwright_storage_candidate()
-            if auth_candidate:
-                context_args["storage_state"] = GeminiAuthStateLoader.translate_to_playwright(
-                    auth_candidate.auth_data
-                )
-            elif allow_unauthenticated_bootstrap_context:
-                logger.info(
-                    "ProviderSession(%s): Initializing unauthenticated bootstrap context "
-                    "for explicit login state creation.",
-                    self.name,
-                    extra={"generation": self.engine.browser_generation}
-                )
-            else:
-                raise RuntimeError(
-                    "Gemini Playwright backend requires a valid storage state (runtime/auth/gemini.json). "
-                    "Please run 'python verify_login.py' to authenticate."
-                )
-        else:
-            if self._validate_state_file():
-                context_args["storage_state"] = self.state_path
+            if strategy_context_args:
+                context_args.update(strategy_context_args)
+        elif self._validate_state_file():
+            context_args["storage_state"] = self.state_path
 
         try:
             self.context = await self.engine.browser.new_context(**context_args)

--- a/src/app/services/factory.py
+++ b/src/app/services/factory.py
@@ -15,11 +15,52 @@ class ProviderFactory:
         "gemini": GeminiProvider,
         "atlas": AtlasProvider,
     }
+    _browser_registry = {
+        "gemini": GeminiProvider,
+    }
+    _default_browser_provider = "gemini"
 
     # Backward compatibility aliases
     _ALIASES = {
-        "playwright": "gemini",
+        "playwright": _default_browser_provider,
     }
+
+    @classmethod
+    def _resolve_browser_provider(cls, browser_provider_name: Optional[str]) -> str:
+        if browser_provider_name and browser_provider_name in cls._browser_registry:
+            return browser_provider_name
+        return cls._default_browser_provider
+
+    @classmethod
+    def _resolve_legacy_playwright_model(cls, model_name: str) -> tuple[str, str]:
+        """
+        Normalize the browser-native model namespace.
+
+        Supported forms:
+        - legacy: playwright/<model>
+        - provider-aware: playwright/<provider>/<model>
+        """
+        browser_provider_name = cls._default_browser_provider
+        normalized_model = f"playwright/{model_name.strip()}"
+
+        if "/" in model_name:
+            candidate_provider, actual_model = model_name.split("/", 1)
+            candidate_provider = candidate_provider.lower().strip()
+            if candidate_provider in cls._browser_registry:
+                browser_provider_name = candidate_provider
+                normalized_model = f"playwright/{candidate_provider}/{actual_model.strip()}"
+
+        return browser_provider_name, normalized_model
+
+    @classmethod
+    def register_provider(cls, provider_name: str, provider_cls: type[BaseProvider], *, browser_native: bool = False) -> None:
+        cls._registry[provider_name] = provider_cls
+        if browser_native:
+            cls._browser_registry[provider_name] = provider_cls
+
+    @classmethod
+    def register_browser_provider(cls, provider_name: str, provider_cls: type[BaseProvider]) -> None:
+        cls.register_provider(provider_name, provider_cls, browser_native=True)
 
     @classmethod
     def get_provider(cls, request: OpenAIChatRequest) -> tuple[BaseProvider, str]:
@@ -35,6 +76,8 @@ class ProviderFactory:
             provider_name = request.provider.lower().strip()
             if provider_name in cls._registry:
                 provider_key = provider_name
+            elif provider_name in cls._browser_registry:
+                provider_key = provider_name
             elif provider_name in cls._ALIASES:
                 provider_key = cls._ALIASES[provider_name]
         
@@ -45,11 +88,17 @@ class ProviderFactory:
             if prefix in cls._registry:
                 provider_key = prefix
                 model_name = actual_model.strip()
+            elif prefix in cls._browser_registry:
+                provider_key = prefix
+                model_name = f"playwright/{prefix}/{actual_model.strip()}"
             elif prefix in cls._ALIASES:
-                provider_key = cls._ALIASES[prefix]
-                # Note: We keep the original model_name (including prefix) 
-                # so the GeminiProvider can interpret it as a directive 
-                # to use the Playwright adapter.
+                browser_provider, normalized_model = cls._resolve_legacy_playwright_model(actual_model.strip())
+                provider_key = browser_provider
+                model_name = normalized_model
+            elif prefix == "playwright":
+                browser_provider, normalized_model = cls._resolve_legacy_playwright_model(actual_model.strip())
+                provider_key = browser_provider
+                model_name = normalized_model
 
         if provider_key not in cls._instances:
             cls._instances[provider_key] = cls._registry[provider_key]()

--- a/src/app/services/providers/gemini/auth.py
+++ b/src/app/services/providers/gemini/auth.py
@@ -11,6 +11,7 @@ class GeminiAuthStrategy:
     Gemini-specific authentication workflow strategy.
     Implements login flows, status checks, and recovery for Google Gemini.
     """
+    provider_name = "gemini"
 
     def get_state_path(self) -> str:
         auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
@@ -174,7 +175,7 @@ class GeminiAuthStrategy:
         from app.services.factory import ProviderFactory
         
         logger.info("GeminiAuthStrategy: Clearing and closing registered Gemini provider in ProviderFactory...")
-        await ProviderFactory.close_provider("gemini")
+        await ProviderFactory.close_provider(self.provider_name)
 
         logger.info("GeminiAuthStrategy: Re-initializing direct Gemini WebAPI client...")
         init_success = await init_gemini_client()

--- a/src/app/services/providers/gemini/auth.py
+++ b/src/app/services/providers/gemini/auth.py
@@ -13,6 +13,48 @@ class GeminiAuthStrategy:
     """
     provider_name = "gemini"
 
+    def build_playwright_context_args(self, *, enable_persistence: bool, is_bootstrap: bool) -> Dict[str, Any]:
+        """
+        Build Playwright context arguments for Gemini session bootstrap.
+
+        This owns Gemini-specific auth source selection and storage-state translation.
+        """
+        from app.services.providers.gemini.auth_selector import GeminiAuthSelector
+
+        allow_unauthenticated_bootstrap_context = is_bootstrap and enable_persistence
+        if allow_unauthenticated_bootstrap_context:
+            auth_candidate = next(
+                (
+                    candidate
+                    for candidate in GeminiAuthSelector.iter_candidates()
+                    if candidate.supports_playwright_storage
+                ),
+                None,
+            )
+        else:
+            auth_candidate = GeminiAuthSelector.first_playwright_storage_candidate()
+
+        if auth_candidate:
+            from app.services.browser.auth_loader import GeminiAuthStateLoader
+
+            return {
+                "storage_state": GeminiAuthStateLoader.translate_to_playwright(
+                    auth_candidate.auth_data
+                )
+            }
+
+        if allow_unauthenticated_bootstrap_context:
+            logger.info(
+                "GeminiAuthStrategy: Initializing unauthenticated bootstrap context "
+                "for explicit login state creation."
+            )
+            return {}
+
+        raise RuntimeError(
+            "Gemini Playwright backend requires a valid storage state (runtime/auth/gemini.json). "
+            "Please run 'python verify_login.py' to authenticate."
+        )
+
     def get_state_path(self) -> str:
         auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
         return os.path.join(auth_state_dir, "gemini.json")

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -135,6 +135,14 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         if model_id.startswith("playwright/"):
             model_id = model_id[len("playwright/"):]
 
+        provider_name = getattr(self.provider, "provider_name", None)
+        if not isinstance(provider_name, str) or not provider_name:
+            provider_name = "gemini"
+        if "/" in model_id:
+            namespace, actual_model = model_id.split("/", 1)
+            if namespace == provider_name:
+                model_id = actual_model
+
         target_label = PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.get(model_id.lower())
         if target_label:
             if state.active_tab:

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -1,519 +1,143 @@
 import asyncio
-import uuid
-import re
-import time
-from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any
+
 from fastapi import HTTPException
-from fastapi.responses import StreamingResponse
-from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError, Error as PlaywrightError
+from playwright.async_api import Error as PlaywrightError, Page, TimeoutError as PlaywrightTimeoutError
 
 from app.services.browser.engine import get_browser_engine
-from app.services.browser.tab import ManagedPage, TabStatus
 from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
-from app.services.browser.adapters.scripts.gemini_scripts import STREAM_EXTRACTOR_SCRIPT, STOP_OBSERVER_SCRIPT, SELECTORS
-from app.services.browser.errors import (
-    TransientSessionError,
-    SessionNotAliveError,
-    BrowserShuttingDownError,
-    BrowserDisconnectedError,
-    BrowserGenerationMismatchError,
-    LeaseInvalidatedError,
-    QueueOverflowError,
-    ConversationBusyError,
-    ModelNotFoundError,
-    GatedModelError
+from app.services.browser.adapters.scripts.gemini_scripts import (
+    SELECTORS,
+    STOP_OBSERVER_SCRIPT,
+    STREAM_EXTRACTOR_SCRIPT,
 )
+from app.services.browser.errors import GatedModelError, ModelNotFoundError, TransientSessionError
+from app.services.browser.request_executor import (
+    BrowserRequestExecutor,
+    BrowserRequestExecutorHooks,
+    PlaywrightAdapterConfig,
+    PlaywrightRequestState,
+)
+from app.services.browser.tab import TabStatus
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
-from app.services.providers.gemini.shared import (
-    convert_to_openai_format, 
-    PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
-)
-from app.logger import logger
-from app.config import CONFIG
-from app.schemas.request import OpenAIChatRequest
+from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS, convert_to_openai_format
 
-@dataclass(frozen=True)
-class PlaywrightAdapterConfig:
-    """Consolidated configuration for the Playwright adapter."""
-    navigation_timeout: int
-    ui_wait_timeout: int
-    chunk_timeout: int
-    total_request_timeout: int
-
-    @classmethod
-    def load(cls) -> "PlaywrightAdapterConfig":
-        return cls(
-            navigation_timeout=CONFIG["Playwright"].getint("navigation_timeout", 30000),
-            ui_wait_timeout=CONFIG["Playwright"].getint("ui_wait_timeout", 15000),
-            chunk_timeout=CONFIG["Playwright"].getint("chunk_timeout", 90),
-            total_request_timeout=CONFIG["Playwright"].getint("total_request_timeout", 120)
-        )
-
-@dataclass
-class PlaywrightRequestState:
-    """Shared state for a single request lifecycle in Playwright."""
-    request_id: str
-    start_time: float
-    permit_acquired: bool = False
-    cleanup_started: bool = False
-    page_closed: bool = False
-    page_poisoned: bool = False
-    dropped_chunks: int = 0
-    max_queue_depth: int = 0
-    conversation_id: Optional[str] = None
-    reused_conversation: bool = False
-    active_tab: Optional[Any] = None # PersistentTab
-    js_ready: asyncio.Event = field(default_factory=asyncio.Event)
-    submission_confirmed: asyncio.Event = field(default_factory=asyncio.Event)
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    has_sent_text: bool = False
-    on_close_handler: Any = None
-    on_crash_handler: Any = None
-    queue_overflow: bool = False
 
 class GeminiPlaywrightAdapter(GeminiBackendAdapter):
     """
-    Backend adapter for Google Gemini using the Playwright browser native runtime.
+    Compatibility wrapper for Gemini browser-native execution.
+
+    Shared request lifecycle authority lives in BrowserRequestExecutor.
     """
-    
+
     def __init__(self, provider):
         self.provider = provider
         self.config = PlaywrightAdapterConfig.load()
+        self.executor = BrowserRequestExecutor(
+            config=self.config,
+            hooks=BrowserRequestExecutorHooks(
+                provider_name="gemini",
+                session_name="gemini",
+                callback_name="__gemini_bridge",
+                default_model="playwright/gemini",
+                create_browser_adapter=self._create_browser_adapter,
+                get_browser_engine=self._get_browser_engine,
+                sleep=self._sleep,
+                timeout=self._timeout,
+                navigate=self._navigate,
+                wait_for_ready_ui=self._wait_for_ready_ui,
+                start_observer=self._start_observer,
+                stop_observer=self._stop_observer,
+                stop_generation=self._stop_generation,
+                extract_conversation_id=self._extract_conversation_id,
+                convert_to_openai_format=convert_to_openai_format,
+                orchestrate_model_selection=self._orchestrate_model_selection,
+            ),
+        )
 
-    async def chat_completions(self, request: OpenAIChatRequest, cid: str, is_new_conversation: bool, tools_prompt: str) -> Any:
-        # Use HTTP request_id if available (from middleware), otherwise generate
-        request_id = getattr(request, "_http_request_id", None) or str(uuid.uuid4()).replace("-", "_")
-        start_time = time.monotonic()
+    async def chat_completions(self, request, cid, is_new_conversation, tools_prompt) -> Any:
+        return await self.executor.execute(request)
 
-        page_lease = None
-        observer_task = None
-        state = None
-        setup_success = False
-        session = None
-        
-        max_retries = 3
-        backoff_delays = [1.0, 2.0, 4.0]
-        
-        try:
-            from app.services.browser.auth_manager import get_auth_manager
-            from app.services.browser.auth_types import AuthStatus
-            auth_mgr = get_auth_manager()
-            if auth_mgr.coordination_lock.is_locked():
-                raise HTTPException(status_code=503, detail="Authentication in progress.")
-            
-            if auth_mgr.refresh_playwright_status_lightweight() == AuthStatus.EXPIRED_SESSION:
-                raise HTTPException(
-                    status_code=401,
-                    detail="Authentication expired.",
-                    headers={"WWW-Authenticate": "Bearer"}
-                )
+    def _create_browser_adapter(self) -> GeminiProviderAdapter:
+        return GeminiProviderAdapter(ui_wait_timeout=self.config.ui_wait_timeout)
 
-            engine = await get_browser_engine()
-            session = await engine.get_session("gemini")
-            adapter = GeminiProviderAdapter(ui_wait_timeout=self.config.ui_wait_timeout)
-            for attempt in range(1, max_retries + 1):
-                page_lease = None
-                observer_task = None
-                state = PlaywrightRequestState(request_id=request_id, start_time=start_time)
-                
-                def on_close(p):
-                    if state.cleanup_started: return
-                    logger.warning("Page close detected", extra={"request_id": state.request_id})
-                    state.page_poisoned = True
-                    if state.active_tab: state.active_tab.invalidate()
+    async def _get_browser_engine(self):
+        return await get_browser_engine()
 
-                def on_crash(p):
-                    if state.cleanup_started: return
-                    logger.warning("Page crash detected", extra={"request_id": state.request_id})
-                    state.page_poisoned = True
-                    if state.active_tab: state.active_tab.invalidate()
+    async def _sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
 
-                state.on_close_handler = on_close
-                state.on_crash_handler = on_crash
-                
-                try:
-                    # 1. Acquire Lease
-                    page_lease = await session.acquire_lease(conversation_id=request.conversation_id, request_id=state.request_id)
-                    state.permit_acquired = True
-                    page = page_lease.page
+    def _timeout(self, delay: float):
+        return asyncio.timeout(delay)
 
-                    page.on("close", on_close)
-                    page.on("crash", on_crash)
-                    
-                    if page_lease.persistent_tab:
-                        state.active_tab = page_lease.persistent_tab
-                        state.reused_conversation = True
-                        state.conversation_id = request.conversation_id
-                    
-                    def check_generation():
-                        self._validate_tab_generation(state.active_tab, engine.browser_generation, "Browser generation mismatch detected during prompt processing")
-
-                    callback_name = "__gemini_bridge"
-                    queue = asyncio.Queue(maxsize=100)
-
-                    async def bridge_callback(source, payload):
-                        if state.cleanup_started: return
-                        if payload.get("type") == "ready":
-                            state.js_ready.set()
-                            return
-
-                        if payload.get("type") in ("started", "chunk", "rewrite", "done"):
-                            if not state.submission_confirmed.is_set():
-                                state.submission_confirmed.set()
-
-                        if payload.get("type") == "started":
-                            return
-
-                        try:
-                            queue.put_nowait(payload)
-                            state.max_queue_depth = max(state.max_queue_depth, queue.qsize())
-                        except asyncio.QueueFull:
-                            state.dropped_chunks += 1
-                            state.queue_overflow = True
-                            # Log queue overflow event (silent data loss detection)
-                            logger.error(
-                                f"Queue overflow during streaming: {state.dropped_chunks} chunks dropped",
-                                extra={"request_id": state.request_id, "dropped_chunks": state.dropped_chunks, "max_queue_depth": state.max_queue_depth}
-                            )
-                        except Exception as e:
-                            logger.warning(f"Bridge emit failure: {e}")
-                            state.page_poisoned = True
-
-                    await session._setup_page_bridge(page)
-                    page._gemini_callbacks[state.request_id] = bridge_callback
-                    await asyncio.sleep(0.01)
-                    
-                    # 2. Target Navigation
-                    check_generation()
-                    if state.reused_conversation:
-                        target_url = f"https://gemini.google.com/app/{state.conversation_id}"
-                        if page.url != target_url:
-                            if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                            await page.goto(target_url, wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
-                            if state.active_tab: state.active_tab.heartbeat("navigation_end")
-                    elif request.conversation_id:
-                        if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                        await page.goto(f"https://gemini.google.com/app/{request.conversation_id}", wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
-                        if state.active_tab: state.active_tab.heartbeat("navigation_end")
-                    else:
-                        if "gemini.google.com/app" not in page.url:
-                            if state.active_tab: state.active_tab.heartbeat("navigation_start")
-                            await page.goto("https://gemini.google.com/app", wait_until="domcontentloaded", timeout=self.config.navigation_timeout)
-                            if state.active_tab: state.active_tab.heartbeat("navigation_end")
-                    
-                    input_locator = page.locator(SELECTORS["INPUT"]).first
-                    if state.active_tab: state.active_tab.heartbeat("input_wait")
-                    try:
-                        check_generation()
-                        await input_locator.wait_for(state="visible", timeout=self.config.ui_wait_timeout)
-                        await asyncio.sleep(0.5)
-                    except (PlaywrightTimeoutError, PlaywrightError) as e:
-                        state.page_poisoned = True
-                        if state.active_tab:
-                            state.active_tab.status = TabStatus.DEAD
-                        raise TransientSessionError(f"Gemini input textbox acquisition failed: {e}") from e
-                    
-                    # 3. Outer Orchestration: Redirect grace period check
-                    if state.active_tab: state.active_tab.heartbeat("auth_check")
-                    check_generation()
-                    
-                    grace_timeout = 2.5
-                    poll_interval = 0.5
-                    elapsed = 0.0
-                    last_transient_error = None
-                    is_authenticated = False
-                    while elapsed < grace_timeout:
-                        try:
-                            is_authenticated = await adapter.check_authentication(page)
-                            if is_authenticated:
-                                break
-                        except TransientSessionError as e:
-                            last_transient_error = e
-                        await asyncio.sleep(poll_interval)
-                        elapsed += poll_interval
-                        
-                    check_generation()
-                    if not is_authenticated:
-                        if last_transient_error:
-                            raise last_transient_error
-                        raise SessionNotAliveError("Authentication expired.")
-
-                    # 4. Observer Injection
-                    if state.active_tab: state.active_tab.heartbeat("observer_injection")
-                    check_generation()
-                    observer_task = asyncio.create_task(
-                        page.evaluate(f"({STREAM_EXTRACTOR_SCRIPT})('{callback_name}', '{state.request_id}')"),
-                        name=f"observer_{state.request_id}"
-                    )
-
-                    try:
-                        async with asyncio.timeout(5.0):
-                            await state.js_ready.wait()
-                    except asyncio.TimeoutError:
-                        raise TransientSessionError("JS Ready Signal Timeout during pre-submission phase.")
-                    
-                    break
-                    
-                except TransientSessionError as e:
-                    if page_lease or observer_task:
-                        await self._cleanup(observer_task, state, page_lease, session)
-                    if attempt == max_retries:
-                        raise
-                    await asyncio.sleep(backoff_delays[attempt - 1])
-
-            # 5. Hardened Prompt Submission
-            prompt = request.messages[-1].get("content", "")
-            confirmed = False
-
-            async with session.submit_lock:
-                check_generation()
-                
-                # 5.a Explicit Model Selection
-                await self._orchestrate_model_selection(adapter, page, request.model, state)
-
-                confirmed = await adapter.submit_prompt(page, prompt, state)
-
-            if not confirmed:
-                raise HTTPException(status_code=500, detail="Gemini failed to accept the prompt.")
-            
-            is_stream = request.stream if request.stream is not None else False
-            if is_stream:
-                setup_success = True
-                logger.info(
-                    f"Stream starting: {request_id}",
-                    extra={
-                        "request_id": request_id,
-                        "conversation_id": state.conversation_id,
-                        "provider": "gemini",
-                        "model": request.model
-                    }
-                )
-                return StreamingResponse(
-                    self._sse_generator(queue, request.model or "playwright/gemini", page, state, observer_task, engine, session, page_lease),
-                    media_type="text/event-stream"
-                )
-            else:
-                resp = await self._get_buffered_response(queue, request.model or "playwright/gemini", page, state, observer_task, engine, session, page_lease)
-                setup_success = True
-                return resp
-
-        except asyncio.CancelledError:
-            # Log cancellation for observability
-            if state:
-                logger.warning(f"Request cancelled: {state.request_id}", extra={"request_id": state.request_id})
-            raise
-
-        except Exception as e:
-            # Map internal Playwright and provider errors to appropriate HTTP status codes
-            poison_session_errors = (SessionNotAliveError, BrowserDisconnectedError, BrowserGenerationMismatchError)
-            if isinstance(e, poison_session_errors) and session:
-                await session.handle_session_failure()
-
-            # Build correlation header for error responses
-            correlation_headers = {}
-            if state:
-                correlation_headers["X-Request-ID"] = state.request_id
-
-            if isinstance(e, SessionNotAliveError):
-                detail = str(e) if str(e) else "Authentication expired."
-                if "authentication expired" not in detail.lower():
-                    detail = f"Authentication expired. {detail}"
-                correlation_headers["WWW-Authenticate"] = "Bearer"
-                logger.error(f"Authentication failed: {detail}", extra={"request_id": state.request_id if state else "unknown"} if state else {})
-                raise HTTPException(status_code=401, detail=detail, headers=correlation_headers)
-
-            if isinstance(e, TransientSessionError):
-                logger.error(f"Transient session error: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=503, detail=str(e), headers=correlation_headers)
-
-            if isinstance(e, (asyncio.TimeoutError, PlaywrightTimeoutError)):
-                logger.error(f"Request timeout: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=504, detail="Request timed out.", headers=correlation_headers)
-
-            if isinstance(e, BrowserDisconnectedError):
-                logger.error(f"Browser disconnected: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=502, detail="Underlying browser process disconnected.", headers=correlation_headers)
-
-            if isinstance(e, BrowserGenerationMismatchError):
-                logger.error(f"Browser generation mismatch: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=503, detail="Browser generation rollover mismatch.", headers=correlation_headers)
-
-            if isinstance(e, PlaywrightError):
-                if "closed" in str(e).lower():
-                    logger.error(f"Browser session closed: {e}", extra={"request_id": state.request_id} if state else {})
-                    raise HTTPException(status_code=503, detail="Browser session unavailable.", headers=correlation_headers)
-                logger.error(f"Browser interaction failure: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=502, detail="Browser interaction failure.", headers=correlation_headers)
-
-            if isinstance(e, (BrowserShuttingDownError, LeaseInvalidatedError, QueueOverflowError, ConversationBusyError)):
-                logger.error(f"Runtime error: {e}", extra={"request_id": state.request_id} if state else {})
-                raise HTTPException(status_code=503 if not isinstance(e, (LeaseInvalidatedError, ConversationBusyError)) else 409, detail=str(e), headers=correlation_headers)
-
-            if isinstance(e, HTTPException): raise
-
-            logger.error(f"Unexpected error in GeminiPlaywrightAdapter: {e}", exc_info=True, extra={"request_id": state.request_id} if state else {})
-            raise HTTPException(status_code=500, detail="Internal server error.", headers=correlation_headers)
-
-        finally:
-            if not setup_success:
-                if page_lease or observer_task:
-                    await self._cleanup(observer_task, state, page_lease, session)
-
-    async def _sse_generator(self, queue: asyncio.Queue, model: str, page: Page, state: PlaywrightRequestState, observer_task: Optional[asyncio.Task], engine: Any, session: Any, lease: ManagedPage):
-        from app.utils.streaming import format_sse_chunk, get_done_chunk
-        request_id = state.request_id
-        stream_start_time = time.monotonic()
-        stream_cancelled = False
-
-        try:
-            # Check for queue overflow at stream start (silent data loss detection)
-            if state.queue_overflow:
-                logger.error(
-                    f"Queue overflow detected at stream start: {state.dropped_chunks} chunks dropped",
-                    extra={"request_id": request_id, "dropped_chunks": state.dropped_chunks, "max_queue_depth": state.max_queue_depth}
-                )
-                raise QueueOverflowError("Event queue saturated")
-
-            while True:
-                try:
-                    if not state.conversation_id and not state.active_tab:
-                        async with state.lock:
-                            if not state.conversation_id and not state.active_tab:
-                                match = re.search(r"/app/([a-z0-9]+)", page.url)
-                                if match:
-                                    state.conversation_id = match.group(1)
-                                    state.active_tab = await session.register_conversation(state.conversation_id, lease)
-
-                    payload = await asyncio.wait_for(queue.get(), timeout=self.config.chunk_timeout)
-                    if payload.get("type") == "done": break
-
-                    if state.active_tab:
-                        self._validate_tab_generation(state.active_tab, engine.browser_generation)
-
-                    text_to_send = ""
-                    if payload.get("type") == "chunk": text_to_send = payload["delta"]
-                    elif payload.get("type") == "rewrite" and not state.has_sent_text: text_to_send = payload["full_text"]
-
-                    if text_to_send:
-                        state.has_sent_text = True
-                        chunk = convert_to_openai_format(text_to_send, model, stream=True)
-                        if state.conversation_id:
-                            chunk["conversation_id"] = state.conversation_id
-                            chunk["reused_conversation"] = state.reused_conversation
-                        yield await format_sse_chunk(chunk)
-                except asyncio.TimeoutError: break
-
-            yield await get_done_chunk()
-
-        except (asyncio.CancelledError, GeneratorExit):
-            # Stream cancellation logging (only for cancellation, not completion)
-            duration = time.monotonic() - stream_start_time
-            logger.warning(
-                f"Stream cancelled: {request_id}",
-                extra={"request_id": request_id, "duration": f"{duration:.2f}s", "reason": "client_disconnect"}
+    async def _navigate(self, page: Page, state: PlaywrightRequestState, request, config: PlaywrightAdapterConfig) -> None:
+        if state.reused_conversation:
+            target_url = f"https://gemini.google.com/app/{state.conversation_id}"
+            if page.url != target_url:
+                if state.active_tab:
+                    state.active_tab.heartbeat("navigation_start")
+                await page.goto(target_url, wait_until="domcontentloaded", timeout=config.navigation_timeout)
+                if state.active_tab:
+                    state.active_tab.heartbeat("navigation_end")
+        elif request.conversation_id:
+            if state.active_tab:
+                state.active_tab.heartbeat("navigation_start")
+            await page.goto(
+                f"https://gemini.google.com/app/{request.conversation_id}",
+                wait_until="domcontentloaded",
+                timeout=config.navigation_timeout,
             )
-            stream_cancelled = True
-            try:
-                stop_button = page.locator(SELECTORS["STOP_BUTTON"]).first
-                if await stop_button.is_visible(): await stop_button.click()
-            except: pass
-            raise
+            if state.active_tab:
+                state.active_tab.heartbeat("navigation_end")
+        else:
+            if "gemini.google.com/app" not in page.url:
+                if state.active_tab:
+                    state.active_tab.heartbeat("navigation_start")
+                await page.goto("https://gemini.google.com/app", wait_until="domcontentloaded", timeout=config.navigation_timeout)
+                if state.active_tab:
+                    state.active_tab.heartbeat("navigation_end")
 
-        finally:
-            # Stream completion logging (only for successful completion)
-            if not stream_cancelled:
-                duration = time.monotonic() - stream_start_time
-                logger.info(
-                    f"Stream completed: {request_id}",
-                    extra={"request_id": request_id, "duration": f"{duration:.2f}s", "has_sent_text": state.has_sent_text}
-                )
-            await self._cleanup(observer_task, state, lease, session)
-
-    async def _get_buffered_response(self, queue: asyncio.Queue, model: str, page: Page, state: PlaywrightRequestState, observer_task: Optional[asyncio.Task], engine: Any, session: Any, lease: ManagedPage):
+    async def _wait_for_ready_ui(self, page: Page, state: PlaywrightRequestState, config: PlaywrightAdapterConfig) -> None:
+        input_locator = page.locator(SELECTORS["INPUT"]).first
+        if state.active_tab:
+            state.active_tab.heartbeat("input_wait")
         try:
-            full_text = ""
-            async with asyncio.timeout(self.config.total_request_timeout):
-                while True:
-                    if state.queue_overflow: raise QueueOverflowError("Event queue saturated")
-                    if not state.conversation_id and not state.active_tab:
-                        async with state.lock:
-                            if not state.conversation_id and not state.active_tab:
-                                match = re.search(r"/app/([a-z0-9]+)", page.url)
-                                if match:
-                                    state.conversation_id = match.group(1)
-                                    state.active_tab = await session.register_conversation(state.conversation_id, lease)
+            await input_locator.wait_for(state="visible", timeout=config.ui_wait_timeout)
+            await asyncio.sleep(0.5)
+        except (PlaywrightTimeoutError, PlaywrightError) as e:
+            state.page_poisoned = True
+            if state.active_tab:
+                state.active_tab.status = TabStatus.DEAD
+            raise TransientSessionError(f"Gemini input textbox acquisition failed: {e}") from e
 
-                    payload = await queue.get()
-                    if payload.get("type") == "done": break
-                    
-                    if state.active_tab:
-                        self._validate_tab_generation(state.active_tab, engine.browser_generation)
+    async def _start_observer(self, page: Page, callback_name: str, request_id: str) -> Any:
+        return await page.evaluate(f"({STREAM_EXTRACTOR_SCRIPT})('{callback_name}', '{request_id}')")
 
-                    if payload.get("type") == "rewrite": full_text = payload["full_text"]
-                    if payload.get("type") == "chunk": full_text += payload["delta"]
-            
-            res = convert_to_openai_format(full_text, model, stream=False)
-            if state.conversation_id:
-                res["conversation_id"] = state.conversation_id
-                res["reused_conversation"] = state.reused_conversation
-            return res
-        finally:
-            await self._cleanup(observer_task, state, lease, session)
+    async def _stop_observer(self, page: Page, request_id: str) -> None:
+        await page.evaluate(f"({STOP_OBSERVER_SCRIPT})('{request_id}')")
 
-    async def _cleanup(self, observer_task: Optional[asyncio.Task], state: Optional[PlaywrightRequestState], lease: Optional[ManagedPage], session: Any):
-        if not state and not lease and not observer_task: return
-        await asyncio.shield(self._do_cleanup(observer_task, state, lease, session))
+    async def _stop_generation(self, page: Page) -> None:
+        stop_button = page.locator(SELECTORS["STOP_BUTTON"]).first
+        if await stop_button.is_visible():
+            await stop_button.click()
 
-    async def _do_cleanup(self, observer_task, state, lease, session):
-        async with state.lock:
-            if state.cleanup_started and state.page_closed: return
-            state.cleanup_started = True
-            try:
-                if observer_task and not observer_task.done():
-                    observer_task.cancel()
-                    try: await observer_task
-                    except: pass
-                if lease:
-                    if hasattr(lease.page, "_gemini_callbacks"):
-                        lease.page._gemini_callbacks.pop(state.request_id, None)
-                    if not state.page_closed:
-                        try: await lease.page.evaluate(f"({STOP_OBSERVER_SCRIPT})('{state.request_id}')")
-                        except: pass
-                        try:
-                            if state.on_close_handler: lease.page.remove_listener("close", state.on_close_handler)
-                            if state.on_crash_handler: lease.page.remove_listener("crash", state.on_crash_handler)
-                        except: pass
-                    if not state.active_tab and not state.page_closed:
-                        try:
-                            match = re.search(r"/app/([a-z0-9]+)", lease.page.url)
-                            if match:
-                                state.conversation_id = match.group(1)
-                                state.active_tab = await session.register_conversation(state.conversation_id, lease)
-                        except: pass
-                    if state.page_poisoned and state.active_tab: state.active_tab.invalidate()
-                    await lease.close()
-                    state.page_closed = True
-            except: pass
+    def _extract_conversation_id(self, url: str):
+        return GeminiProviderAdapter().extract_conversation_id(url)
 
-    def _validate_tab_generation(self, tab: Any, current_generation: int, message: Optional[str] = None):
-        if tab:
-            BrowserGenerationMismatchError.validate(tab.browser_generation, current_generation)
+    async def _cleanup(self, observer_task, state, lease, session):
+        await self.executor._cleanup(observer_task, state, lease, session)
 
     async def _orchestrate_model_selection(self, browser_adapter: GeminiProviderAdapter, page: Page, model_id: str, state: PlaywrightRequestState):
-        """
-        Coordinates model selection logic before prompt submission.
-        Maps OpenAI model IDs to Gemini UI labels and handles selection errors.
-        """
         if not model_id:
             return
 
         if model_id.startswith("playwright/"):
             model_id = model_id[len("playwright/"):]
-        
+
         target_label = PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.get(model_id.lower())
         if target_label:
-            if state.active_tab: state.active_tab.heartbeat("model_selection")
+            if state.active_tab:
+                state.active_tab.heartbeat("model_selection")
             try:
                 await browser_adapter.select_model(page, target_label, state)
             except GatedModelError as e:
@@ -521,10 +145,13 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
             except ModelNotFoundError as e:
                 raise HTTPException(status_code=400, detail=str(e))
         elif model_id != "gemini":
-            # If an unknown model is requested (not 'gemini' default), fail fast
             raise HTTPException(
                 status_code=400,
-                detail=f"Requested model '{model_id}' has no known Playwright UI mapping. Supported: {list(PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys())}"
+                detail=(
+                    f"Requested model '{model_id}' has no known Playwright UI mapping. "
+                    f"Supported: {list(PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys())}"
+                ),
             )
 
-    async def close(self) -> None: pass
+    async def close(self) -> None:
+        pass

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -39,6 +39,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                 provider_name="gemini",
                 session_name="gemini",
                 callback_name="__gemini_bridge",
+                bridge_callbacks_attr="_gemini_callbacks",
                 default_model="playwright/gemini",
                 create_browser_adapter=self._create_browser_adapter,
                 get_browser_engine=self._get_browser_engine,

--- a/src/app/services/providers/gemini/shared.py
+++ b/src/app/services/providers/gemini/shared.py
@@ -123,6 +123,8 @@ PLAYWRIGHT_GEMINI_MODEL_UI_LABELS = {
     "gemini-3.1-flash-lite": "Flash-Lite",
 }
 
+PLAYWRIGHT_GEMINI_PROVIDER_NAMESPACE = "playwright/gemini"
+
 def get_gemini_models() -> List[dict]:
     """Return the canonical list of supported Gemini models in OpenAI format."""
     from gemini_webapi.constants import Model
@@ -144,6 +146,12 @@ def get_gemini_models() -> List[dict]:
     for model_id in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys():
         models.append({
             "id": f"playwright/{model_id}",
+            "object": "model",
+            "created": ts,
+            "owned_by": "google",
+        })
+        models.append({
+            "id": f"{PLAYWRIGHT_GEMINI_PROVIDER_NAMESPACE}/{model_id}",
             "object": "model",
             "created": ts,
             "owned_by": "google",

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -45,6 +45,14 @@ def test_get_provider_model_prefix_gemini():
     assert isinstance(provider, GeminiProvider)
     assert model == "gemini-3-flash"
 
+def test_get_provider_model_prefix_playwright_browser_namespace_gemini():
+    """Verify ProviderFactory routes provider-aware browser namespaces to Gemini."""
+    request = OpenAIChatRequest(messages=[], model="playwright/gemini/gemini-3-flash")
+    provider, model = ProviderFactory.get_provider(request)
+
+    assert isinstance(provider, GeminiProvider)
+    assert model == "playwright/gemini/gemini-3-flash"
+
 def test_get_provider_unknown_prefix_defaults_to_gemini():
     """Verify ProviderFactory defaults to Gemini for unknown model prefixes."""
     request = OpenAIChatRequest(messages=[], model="unknown/model")

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -279,6 +279,14 @@ async def test_get_gemini_models_discovery_consistency():
     ]
     for model_id in verified_playwright_models:
         assert model_id in model_ids, f"Expected {model_id} to be advertised"
+
+    canonical_playwright_models = [
+        "playwright/gemini/gemini-3.1-pro",
+        "playwright/gemini/gemini-3.5-flash",
+        "playwright/gemini/gemini-3.1-flash-lite",
+    ]
+    for model_id in canonical_playwright_models:
+        assert model_id in model_ids, f"Expected canonical browser namespace model {model_id} to be advertised"
         
     # 2. Verify specific unverified aliases are NOT advertised
     unverified = [
@@ -316,6 +324,27 @@ async def test_orchestrate_model_selection_versioned_aliases():
     mock_browser_adapter.select_model.assert_any_call(mock_page, "Flash", mock_state)
     mock_browser_adapter.select_model.assert_any_call(mock_page, "Pro", mock_state)
     mock_browser_adapter.select_model.assert_any_call(mock_page, "Flash-Lite", mock_state)
+
+@pytest.mark.asyncio
+async def test_orchestrate_model_selection_browser_namespace_aliases():
+    """Verify provider-aware browser namespaces normalize to the same Gemini UI labels."""
+    adapter = GeminiPlaywrightAdapter(MagicMock())
+    mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
+    mock_browser_adapter.select_model = AsyncMock()
+    mock_page = MagicMock()
+    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state.active_tab = MagicMock()
+
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, mock_page, "playwright/gemini/gemini-3.5-flash", mock_state
+    )
+    await adapter._orchestrate_model_selection(
+        mock_browser_adapter, mock_page, "playwright/gemini/gemini-3.1-pro", mock_state
+    )
+
+    assert mock_browser_adapter.select_model.call_count == 2
+    mock_browser_adapter.select_model.assert_any_call(mock_page, "Flash", mock_state)
+    mock_browser_adapter.select_model.assert_any_call(mock_page, "Pro", mock_state)
 
 @pytest.mark.asyncio
 async def test_orchestrate_model_selection_unsupported_aliases_fail():

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -1,0 +1,696 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from app.schemas.request import OpenAIChatRequest
+from app.services.browser.auth_types import AuthStatus
+from app.services.factory import ProviderFactory
+from app.services.providers.gemini.playwright_adapter import (
+    GeminiPlaywrightAdapter,
+    PlaywrightRequestState,
+)
+from app.services.providers.gemini.provider import GeminiProvider
+
+
+def make_request(
+    *,
+    stream: bool,
+    conversation_id: str | None = None,
+    model: str = "playwright/gemini",
+) -> OpenAIChatRequest:
+    return OpenAIChatRequest(
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        conversation_id=conversation_id,
+        stream=stream,
+    )
+
+
+def make_mock_page(url: str = "https://gemini.google.com/app") -> MagicMock:
+    page = MagicMock()
+    page.url = url
+    page._gemini_callbacks = {}
+    page.goto = AsyncMock()
+    page.evaluate = AsyncMock()
+    page.on = MagicMock()
+    page.remove_listener = MagicMock()
+    page.is_closed.return_value = False
+
+    input_locator = AsyncMock()
+    input_locator.wait_for = AsyncMock()
+
+    generic_locator = MagicMock()
+    generic_locator.first = input_locator
+    page.locator.return_value = generic_locator
+    return page
+
+
+def make_mock_lease(page: MagicMock, persistent_tab=None) -> MagicMock:
+    lease = MagicMock()
+    lease.page = page
+    lease.persistent_tab = persistent_tab
+    lease.close = AsyncMock()
+    return lease
+
+
+def make_mock_session(lease: MagicMock) -> AsyncMock:
+    session = AsyncMock()
+    session.submit_lock = asyncio.Lock()
+    session._setup_page_bridge = AsyncMock()
+    session.acquire_lease = AsyncMock(return_value=lease)
+    session.handle_session_failure = AsyncMock()
+    session.register_conversation = AsyncMock()
+    return session
+
+
+async def emit_bridge_event(page: MagicMock, payload: dict, request_id: str | None = None) -> None:
+    callbacks = getattr(page, "_gemini_callbacks", {})
+    if request_id is None:
+        assert callbacks, "expected a registered Gemini bridge callback"
+        request_id = next(iter(callbacks))
+    callback = callbacks[request_id]
+    payload = dict(payload)
+    payload.setdefault("requestId", request_id)
+    await callback("gemini", payload)
+
+
+async def collect_stream_chunks(response: StreamingResponse) -> list[str]:
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+    return chunks
+
+
+def parse_sse_chunk(chunk: str) -> dict:
+    assert chunk.startswith("data: ")
+    assert chunk.endswith("\n\n")
+    return json.loads(chunk[6:-2])
+
+
+async def configure_playwright_success(
+    monkeypatch,
+    *,
+    page: MagicMock,
+    session: AsyncMock,
+    submit_side_effect,
+    auth_mgr=None,
+):
+    mock_engine = MagicMock()
+    mock_engine.browser_generation = 1
+    mock_engine.get_session = AsyncMock(return_value=session)
+
+    async def mock_get_browser_engine():
+        return mock_engine
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.get_browser_engine",
+        mock_get_browser_engine,
+    )
+
+    if auth_mgr is None:
+        auth_mgr = MagicMock()
+        auth_mgr.coordination_lock.is_locked.return_value = False
+        auth_mgr.refresh_playwright_status_lightweight.return_value = AuthStatus.VALID_SESSION
+
+    monkeypatch.setattr(
+        "app.services.browser.auth_manager.get_auth_manager",
+        lambda: auth_mgr,
+    )
+
+    async def check_authentication(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.GeminiProviderAdapter.check_authentication",
+        check_authentication,
+    )
+    async def submit_prompt_bound(_self, *args, **kwargs):
+        return await submit_side_effect(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.GeminiProviderAdapter.submit_prompt",
+        submit_prompt_bound,
+    )
+
+    async def evaluate_side_effect(script, *_args, **_kwargs):
+        if "__gemini_bridge" in script:
+            await emit_bridge_event(page, {"type": "ready"})
+        return None
+
+    page.evaluate = AsyncMock(side_effect=evaluate_side_effect)
+    return mock_engine
+
+
+@pytest.mark.asyncio
+async def test_stream_started_confirms_submission_without_emitting_content(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    assert isinstance(response, StreamingResponse)
+    chunks = await collect_stream_chunks(response)
+    assert chunks == ["data: [DONE]\n\n"]
+
+
+@pytest.mark.asyncio
+async def test_stream_chunk_emits_incremental_sse_delta(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": " world"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    chunks = await collect_stream_chunks(response)
+    assert len(chunks) == 3
+    assert parse_sse_chunk(chunks[0])["choices"][0]["delta"]["content"] == "hello"
+    assert parse_sse_chunk(chunks[1])["choices"][0]["delta"]["content"] == " world"
+    assert chunks[2] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_rewrite_emits_only_initial_full_text_before_first_chunk(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "rewrite", "full_text": "Hello world"})
+            await emit_bridge_event(page, {"type": "rewrite", "full_text": "Hello world!!"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    chunks = await collect_stream_chunks(response)
+    assert len(chunks) == 2
+    assert parse_sse_chunk(chunks[0])["choices"][0]["delta"]["content"] == "Hello world"
+    assert chunks[1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_done_terminates_with_done_chunk(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    chunks = await collect_stream_chunks(response)
+    assert chunks[-1] == "data: [DONE]\n\n"
+    assert chunks == ["data: [DONE]\n\n"]
+
+
+@pytest.mark.asyncio
+async def test_stream_queue_overflow_fails_request_without_session_poisoning(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            for idx in range(150):
+                await emit_bridge_event(page, {"type": "chunk", "delta": f"chunk-{idx}"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    await asyncio.sleep(0.05)
+
+    with pytest.raises(Exception) as exc_info:
+        await collect_stream_chunks(response)
+
+    assert "Event queue saturated" in str(exc_info.value)
+    session.handle_session_failure.assert_not_called()
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_late_bridge_events_after_cleanup_are_ignored(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    callback_ref = {}
+
+    async def submit_prompt(_page, _prompt, _state):
+        callback_ref["callback"] = next(iter(page._gemini_callbacks.values()))
+
+        async def emit_events():
+            await asyncio.sleep(0)
+            page.url = "https://gemini.google.com/app/abc123"
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    session.register_conversation = AsyncMock(return_value=MagicMock(browser_generation=1))
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=False))
+
+    assert response["choices"][0]["message"]["content"] == "hello"
+    assert page._gemini_callbacks == {}
+    assert session.register_conversation.await_count == 1
+
+    await callback_ref["callback"]("gemini", {"type": "chunk", "delta": "late", "requestId": "late-id"})
+    assert session.register_conversation.await_count == 1
+    assert page._gemini_callbacks == {}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_request_callback(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    await provider.chat_completions(make_request(stream=False))
+
+    assert page._gemini_callbacks == {}
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_executes_observer_stop_script(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    evaluate_scripts = []
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    async def evaluate_side_effect(script, *_args, **_kwargs):
+        evaluate_scripts.append(script)
+        if "__gemini_bridge" in script:
+            await emit_bridge_event(page, {"type": "ready"})
+        return None
+
+    page.evaluate = AsyncMock(side_effect=evaluate_side_effect)
+
+    provider = GeminiProvider()
+    await provider.chat_completions(make_request(stream=False))
+
+    assert len(evaluate_scripts) >= 2
+    assert any("__gemini_bridge" in script for script in evaluate_scripts)
+    assert any("__gemini_stop_observer" in script for script in evaluate_scripts)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_close_and_crash_listeners(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    await provider.chat_completions(make_request(stream=False))
+
+    registered_handlers = {}
+    for call in page.on.call_args_list:
+        event_name, handler = call.args
+        registered_handlers[event_name] = handler
+
+    removed_handlers = {}
+    for call in page.remove_listener.call_args_list:
+        event_name, handler = call.args
+        removed_handlers[event_name] = handler
+
+    assert "close" in registered_handlers
+    assert "crash" in registered_handlers
+    assert "close" in removed_handlers
+    assert "crash" in removed_handlers
+    assert removed_handlers["close"] is registered_handlers["close"]
+    assert removed_handlers["crash"] is registered_handlers["crash"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_idempotent_for_repeated_invocation():
+    provider = GeminiProvider()
+    adapter = provider.playwright_adapter
+    page = make_mock_page()
+    request_state = PlaywrightRequestState(request_id="req_1", start_time=0.0)
+    page._gemini_callbacks = {request_state.request_id: AsyncMock()}
+    request_state.on_close_handler = MagicMock()
+    request_state.on_crash_handler = MagicMock()
+    lease = make_mock_lease(page)
+    session = AsyncMock()
+
+    never_finishes = asyncio.Event()
+
+    async def observer_coroutine():
+        await never_finishes.wait()
+
+    observer_task = asyncio.create_task(observer_coroutine())
+
+    await adapter._cleanup(observer_task, request_state, lease, session)
+    await adapter._cleanup(observer_task, request_state, lease, session)
+
+    assert lease.close.await_count == 1
+    assert page.remove_listener.call_count == 2
+    assert request_state.request_id not in page._gemini_callbacks
+
+
+@pytest.mark.asyncio
+async def test_buffered_request_discovers_conversation_id_from_url_and_returns_it(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    persistent_tab = MagicMock(browser_generation=1)
+    session = make_mock_session(lease)
+    session.register_conversation = AsyncMock(return_value=persistent_tab)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            page.url = "https://gemini.google.com/app/abc123"
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=False))
+
+    assert response["conversation_id"] == "abc123"
+    assert response["reused_conversation"] is False
+    session.register_conversation.assert_awaited_once_with("abc123", lease)
+
+
+@pytest.mark.asyncio
+async def test_new_conversation_registration_occurs_once_when_url_becomes_available(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    session.register_conversation = AsyncMock(return_value=MagicMock(browser_generation=1))
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            page.url = "https://gemini.google.com/app/abc123"
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "he"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "llo"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=False))
+
+    assert response["conversation_id"] == "abc123"
+    assert session.register_conversation.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reused_persistent_tab_sets_reused_conversation_metadata(monkeypatch):
+    page = make_mock_page(url="https://gemini.google.com/app/existing123")
+    persistent_tab = MagicMock(browser_generation=1)
+    persistent_tab.heartbeat = MagicMock()
+    lease = make_mock_lease(page, persistent_tab=persistent_tab)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(
+        make_request(stream=False, conversation_id="existing123")
+    )
+
+    assert response["conversation_id"] == "existing123"
+    assert response["reused_conversation"] is True
+    page.goto.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_continuation_request_navigates_to_conversation_url(monkeypatch):
+    page = make_mock_page(url="https://gemini.google.com/app")
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    session.register_conversation = AsyncMock(return_value=MagicMock(browser_generation=1))
+
+    async def goto_side_effect(url, *args, **kwargs):
+        page.url = url
+        return None
+
+    page.goto = AsyncMock(side_effect=goto_side_effect)
+
+    async def submit_prompt(_page, _prompt, _state):
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+            await emit_bridge_event(page, {"type": "done"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(
+        make_request(stream=False, conversation_id="resume123")
+    )
+
+    assert response["conversation_id"] == "resume123"
+    page.goto.assert_awaited_once_with(
+        "https://gemini.google.com/app/resume123",
+        wait_until="domcontentloaded",
+        timeout=adapter_config_timeout(),
+    )
+
+
+def adapter_config_timeout() -> int:
+    return GeminiProvider().playwright_adapter.config.navigation_timeout
+
+
+@pytest.mark.asyncio
+async def test_request_rejected_when_login_in_progress_with_503(monkeypatch):
+    auth_mgr = MagicMock()
+    auth_mgr.coordination_lock.is_locked.return_value = True
+    auth_mgr.refresh_playwright_status_lightweight.return_value = AuthStatus.VALID_SESSION
+
+    monkeypatch.setattr(
+        "app.services.browser.auth_manager.get_auth_manager",
+        lambda: auth_mgr,
+    )
+
+    get_browser_engine = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.get_browser_engine",
+        get_browser_engine,
+    )
+
+    provider = GeminiProvider()
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.chat_completions(make_request(stream=False))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Authentication in progress."
+    get_browser_engine.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_rejected_when_preflight_auth_expired_with_401(monkeypatch):
+    auth_mgr = MagicMock()
+    auth_mgr.coordination_lock.is_locked.return_value = False
+    auth_mgr.refresh_playwright_status_lightweight.return_value = AuthStatus.EXPIRED_SESSION
+
+    monkeypatch.setattr(
+        "app.services.browser.auth_manager.get_auth_manager",
+        lambda: auth_mgr,
+    )
+
+    get_browser_engine = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.get_browser_engine",
+        get_browser_engine,
+    )
+
+    provider = GeminiProvider()
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.chat_completions(make_request(stream=False))
+
+    assert exc_info.value.status_code == 401
+    assert "Authentication expired." in exc_info.value.detail
+    assert exc_info.value.headers.get("WWW-Authenticate") == "Bearer"
+    get_browser_engine.assert_not_called()
+
+
+def test_factory_model_prefix_playwright_routes_to_gemini_and_preserves_model_name():
+    request = OpenAIChatRequest(messages=[], model="playwright/gemini-3.5-flash")
+    provider, model = ProviderFactory.get_provider(request)
+
+    assert isinstance(provider, GeminiProvider)
+    assert model == "playwright/gemini-3.5-flash"


### PR DESCRIPTION
## Summary

This PR refactors the browser runtime architecture to separate provider-specific behavior from core browser lifecycle management.

It introduces a reusable `BrowserRequestExecutor` abstraction for browser-native request execution, decouples Gemini-specific ownership from shared runtime components, and establishes the foundation for supporting additional browser-native providers beyond Gemini.

## Key Changes

### Browser Runtime Refactor

* Introduced `BrowserRequestExecutor` to own the shared browser request lifecycle.
* Centralized request-scoped orchestration, cleanup, and execution flow behind a reusable runtime abstraction.
* Reduced provider-specific logic embedded in shared browser runtime components.

### Multi-Provider Architecture

* Refactored `AuthManager` to operate as a provider-agnostic authentication orchestrator.
* Refactored `ProviderSession` to support multi-provider browser sessions.
* Introduced a browser-native provider registry and provider-aware routing.
* Removed remaining Gemini-centric ownership assumptions from shared runtime layers.

### Provider Decoupling

* Decoupled Playwright bridge ownership from Gemini-specific runtime paths.
* Established clearer ownership boundaries between:

  * Browser runtime infrastructure
  * Provider sessions
  * Authentication strategies
  * Provider-specific browser adapters

### Validation & Testing

* Added parity tests to ensure Gemini Playwright behavior remains unchanged after the refactor.
* Added coverage for provider routing and model-selection behavior.

## Testing

Tests run:

```bash
pytest tests/test_gemini_playwright_parity.py \
       tests/test_factory.py \
       tests/test_gemini_model_selection.py
```

Result:

```text
46 passed
```

## Notes

This PR is intended as an architectural foundation for future browser-native providers while preserving existing Gemini Playwright behavior.
