### PR TITLE
Refactor model catalog and advertise canonical Playwright Gemini IDs

### DIFF
--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -9,6 +9,7 @@ from app.schemas.request import GeminiRequest, OpenAIChatRequest
 from app.services.gemini_client import get_gemini_client, GeminiClientNotInitializedError
 from app.services.providers.gemini.session_manager import get_translate_session_manager
 from app.services.factory import ProviderFactory
+from app.services.model_catalog import list_models as build_model_catalog
 
 router = APIRouter()
 
@@ -72,19 +73,8 @@ async def translate_chat(request: GeminiRequest):
     summary="List Available Models",
     description="Returns available models from all registered providers. Includes provider-prefixed models used for discovery and routing."
 )
-async def list_models():
-    all_models = []
-    # Collect models from all registered providers in the registry
-    for provider_key in ProviderFactory._registry.keys():
-        # Using a dummy request to resolve the provider instance via factory
-        dummy_request = OpenAIChatRequest(messages=[], provider=provider_key)
-        provider, _ = ProviderFactory.get_provider(dummy_request)
-        all_models.extend(await provider.list_models())
-    
-    return {
-        "object": "list",
-        "data": all_models
-    }
+async def get_models():
+    return await build_model_catalog(include_legacy_playwright_aliases=False)
 
 
 @router.post(

--- a/src/app/endpoints/ui.py
+++ b/src/app/endpoints/ui.py
@@ -7,7 +7,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from app.endpoints.auth import get_auth_status
-from app.endpoints.chat import list_models
+from app.services.model_catalog import list_models
 from app.endpoints.chat import delete_conversation as delete_conversation_api
 from app.endpoints.chat import delete_conversations as delete_conversations_api
 from app.endpoints.chat import list_conversations

--- a/src/app/endpoints/ui.py
+++ b/src/app/endpoints/ui.py
@@ -263,7 +263,7 @@ async def dashboard_auth_panel(request: Request):
 
 @router.get("/models", response_class=HTMLResponse)
 async def dashboard_models(request: Request):
-    models = await list_models()
+    models = await list_models(include_legacy_playwright_aliases=False)
     model_rows = [
         {
             **model,
@@ -280,7 +280,7 @@ async def dashboard_models(request: Request):
 
 @router.get("/playground", response_class=HTMLResponse)
 async def dashboard_playground(request: Request):
-    models = await list_models()
+    models = await list_models(include_legacy_playwright_aliases=False)
     return templates.TemplateResponse(
         request,
         "ui/playground.html",

--- a/src/app/services/model_catalog.py
+++ b/src/app/services/model_catalog.py
@@ -1,0 +1,38 @@
+from app.schemas.request import OpenAIChatRequest
+from app.services.factory import ProviderFactory
+from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
+
+
+def is_legacy_playwright_gemini_alias(model_id: str) -> bool:
+    if not model_id.startswith("playwright/"):
+        return False
+    if model_id.startswith("playwright/gemini/"):
+        return False
+
+    alias_name = model_id[len("playwright/"):]
+    return alias_name in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
+
+
+def filter_advertised_model_catalog(models: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [model for model in models if not is_legacy_playwright_gemini_alias(str(model.get("id", "")))]
+
+
+async def list_models(*, include_legacy_playwright_aliases: bool = True) -> dict[str, object]:
+    """Build the shared model catalog.
+
+    UI callers keep legacy aliases for backward-compatible selection.
+    The public /v1/models route disables them to advertise only canonical IDs.
+    """
+    all_models = []
+    for provider_key in ProviderFactory._registry.keys():
+        dummy_request = OpenAIChatRequest(messages=[], provider=provider_key)
+        provider, _ = ProviderFactory.get_provider(dummy_request)
+        all_models.extend(await provider.list_models())
+
+    if not include_legacy_playwright_aliases:
+        all_models = filter_advertised_model_catalog(all_models)
+
+    return {
+        "object": "list",
+        "data": all_models,
+    }

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -7,10 +7,18 @@ from app.services.providers.atlas import AtlasProvider
 
 @pytest.mark.asyncio
 async def test_list_models_endpoint(mocker):
-    """Verify /v1/models returns models from all registered providers."""
+    """Verify /v1/models filters legacy Playwright Gemini aliases from discovery."""
     # Mock providers to return deterministic model lists
     mock_gemini = mocker.Mock(spec=GeminiProvider)
-    mock_gemini.list_models = mocker.AsyncMock(return_value=[{"id": "gemini-model", "object": "model"}])
+    mock_gemini.list_models = mocker.AsyncMock(return_value=[
+        {"id": "gemini-model", "object": "model"},
+        {"id": "playwright/gemini-3.5-flash", "object": "model"},
+        {"id": "playwright/gemini-3.1-pro", "object": "model"},
+        {"id": "playwright/gemini-3.1-flash-lite", "object": "model"},
+        {"id": "playwright/gemini/gemini-3.5-flash", "object": "model"},
+        {"id": "playwright/gemini/gemini-3.1-pro", "object": "model"},
+        {"id": "playwright/gemini/gemini-3.1-flash-lite", "object": "model"},
+    ])
     
     mock_atlas = mocker.Mock(spec=AtlasProvider)
     mock_atlas.list_models = mocker.AsyncMock(return_value=[{"id": "atlas-model", "object": "model"}])
@@ -32,6 +40,12 @@ async def test_list_models_endpoint(mocker):
     model_ids = [m["id"] for m in data["data"]]
     assert "gemini-model" in model_ids
     assert "atlas-model" in model_ids
+    assert "playwright/gemini/gemini-3.5-flash" in model_ids
+    assert "playwright/gemini/gemini-3.1-pro" in model_ids
+    assert "playwright/gemini/gemini-3.1-flash-lite" in model_ids
+    assert "playwright/gemini-3.5-flash" not in model_ids
+    assert "playwright/gemini-3.1-pro" not in model_ids
+    assert "playwright/gemini-3.1-flash-lite" not in model_ids
 
 @pytest.mark.asyncio
 async def test_chat_completions_endpoint_gemini(mocker):

--- a/tests/test_ui_dashboard.py
+++ b/tests/test_ui_dashboard.py
@@ -347,20 +347,15 @@ async def test_ui_auth_panel_renders_status_classes(mocker):
 
 @pytest.mark.asyncio
 async def test_ui_models_returns_html(mocker):
-    list_models = mocker.patch(
-        "app.endpoints.ui.list_models",
-        return_value={
+    async def list_models(include_legacy_playwright_aliases=True):
+        assert include_legacy_playwright_aliases is False
+        return {
             "object": "list",
             "data": [
                 {
                     "id": "gemini/gemini-3-flash",
                     "object": "model",
                     "owned_by": "gemini",
-                },
-                {
-                    "id": "playwright/gemini-3.1-pro",
-                    "object": "model",
-                    "owned_by": "google",
                 },
                 {
                     "id": "playwright/gemini/gemini-3.1-pro",
@@ -371,10 +366,11 @@ async def test_ui_models_returns_html(mocker):
                     "id": "atlas/MiniMaxAI/MiniMax-M2",
                     "object": "model",
                     "owned_by": "atlascloud",
-                }
+                },
             ],
-        },
-    )
+        }
+
+    list_models = mocker.patch("app.endpoints.ui.list_models", side_effect=list_models)
 
     response = await _get("/ui/models")
 
@@ -383,31 +379,27 @@ async def test_ui_models_returns_html(mocker):
     assert "Available Models" in response.text
     assert "<th>Backend</th>" in response.text
     assert "gemini/gemini-3-flash" in response.text
-    assert "playwright/gemini-3.1-pro" in response.text
     assert "playwright/gemini/gemini-3.1-pro" in response.text
     assert "atlas/MiniMaxAI/MiniMax-M2" in response.text
+    assert "playwright/gemini-3.1-pro" not in response.text
     assert "WebAPI" in response.text
     assert "Playwright" in response.text
     assert "Atlas" in response.text
     list_models.assert_called_once()
+    list_models.assert_called_once_with(include_legacy_playwright_aliases=False)
 
 
 @pytest.mark.asyncio
 async def test_ui_playground_returns_html_and_populates_models(mocker):
-    list_models = mocker.patch(
-        "app.endpoints.ui.list_models",
-        return_value={
+    async def list_models(include_legacy_playwright_aliases=True):
+        assert include_legacy_playwright_aliases is False
+        return {
             "object": "list",
             "data": [
                 {
                     "id": "gemini/gemini-3-flash",
                     "object": "model",
                     "owned_by": "gemini",
-                },
-                {
-                    "id": "playwright/gemini-3.5-flash",
-                    "object": "model",
-                    "owned_by": "google",
                 },
                 {
                     "id": "playwright/gemini/gemini-3.5-flash",
@@ -420,8 +412,9 @@ async def test_ui_playground_returns_html_and_populates_models(mocker):
                     "owned_by": "atlascloud",
                 },
             ],
-        },
-    )
+        }
+
+    list_models = mocker.patch("app.endpoints.ui.list_models", side_effect=list_models)
 
     response = await _get("/ui/playground")
 
@@ -430,12 +423,13 @@ async def test_ui_playground_returns_html_and_populates_models(mocker):
     assert "Chat Completion" in response.text
     assert 'name="model"' in response.text
     assert "gemini/gemini-3-flash" in response.text
-    assert "playwright/gemini-3.5-flash" in response.text
     assert "playwright/gemini/gemini-3.5-flash" in response.text
     assert "atlas/MiniMaxAI/MiniMax-M2" in response.text
+    assert "playwright/gemini-3.5-flash" not in response.text
     assert "/ui/static/js/playground.js" in response.text
     assert 'fetch("/v1/chat/completions"' not in response.text
     list_models.assert_called_once()
+    list_models.assert_called_once_with(include_legacy_playwright_aliases=False)
 
 
 def test_ui_static_mount_uses_staticfiles():

--- a/tests/test_ui_dashboard.py
+++ b/tests/test_ui_dashboard.py
@@ -363,6 +363,11 @@ async def test_ui_models_returns_html(mocker):
                     "owned_by": "google",
                 },
                 {
+                    "id": "playwright/gemini/gemini-3.1-pro",
+                    "object": "model",
+                    "owned_by": "google",
+                },
+                {
                     "id": "atlas/MiniMaxAI/MiniMax-M2",
                     "object": "model",
                     "owned_by": "atlascloud",
@@ -379,6 +384,7 @@ async def test_ui_models_returns_html(mocker):
     assert "<th>Backend</th>" in response.text
     assert "gemini/gemini-3-flash" in response.text
     assert "playwright/gemini-3.1-pro" in response.text
+    assert "playwright/gemini/gemini-3.1-pro" in response.text
     assert "atlas/MiniMaxAI/MiniMax-M2" in response.text
     assert "WebAPI" in response.text
     assert "Playwright" in response.text
@@ -399,6 +405,16 @@ async def test_ui_playground_returns_html_and_populates_models(mocker):
                     "owned_by": "gemini",
                 },
                 {
+                    "id": "playwright/gemini-3.5-flash",
+                    "object": "model",
+                    "owned_by": "google",
+                },
+                {
+                    "id": "playwright/gemini/gemini-3.5-flash",
+                    "object": "model",
+                    "owned_by": "google",
+                },
+                {
                     "id": "atlas/MiniMaxAI/MiniMax-M2",
                     "object": "model",
                     "owned_by": "atlascloud",
@@ -414,6 +430,8 @@ async def test_ui_playground_returns_html_and_populates_models(mocker):
     assert "Chat Completion" in response.text
     assert 'name="model"' in response.text
     assert "gemini/gemini-3-flash" in response.text
+    assert "playwright/gemini-3.5-flash" in response.text
+    assert "playwright/gemini/gemini-3.5-flash" in response.text
     assert "atlas/MiniMaxAI/MiniMax-M2" in response.text
     assert "/ui/static/js/playground.js" in response.text
     assert 'fetch("/v1/chat/completions"' not in response.text


### PR DESCRIPTION
## Summary

Centralizes model catalog generation into a dedicated service and removes legacy Playwright Gemini aliases from advertised model discovery surfaces.

Legacy Playwright model IDs remain fully supported for request routing and backward compatibility.

## Key Changes

- Added `app.services.model_catalog` to centralize model catalog generation and filtering.
- Moved model catalog aggregation logic out of endpoint modules.
- Updated `/v1/models` to advertise only canonical Playwright Gemini model IDs:
  - `playwright/gemini/gemini-*`
- Removed legacy Playwright Gemini aliases from dashboard model discovery:
  - `/ui/models`
  - `/ui/playground`
- Preserved backward-compatible routing for legacy model IDs such as:
  - `playwright/gemini-3.5-flash`
- Updated endpoint and dashboard tests to verify canonical-only discovery behavior.

## Testing

- `pytest tests/test_endpoints.py`
- `pytest tests/test_ui_dashboard.py`

Result: Passed

## Notes

This change affects only advertised model discovery.

Both legacy and canonical Playwright Gemini model IDs continue to be accepted by the routing layer, while discovery surfaces now consistently advertise only canonical provider-aware model IDs.