### PR TITLE
Support generated artifacts in Gemini WebAPI and Playground UI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -89,6 +89,16 @@ Current limits remain unchanged:
 
 See the same note in [docs/specs/api-contract.md](specs/api-contract.md) for the contract-level rules.
 
+#### Generated Artifacts
+
+Gemini WebAPI responses may include `choices[0].artifacts` in buffered responses. `message.content` remains text-only, and thoughts are not exposed.
+
+Streaming responses may emit one final artifact SSE chunk before `[DONE]` with `choices[0].delta = {}` and `choices[0].artifacts = [...]`.
+
+Artifacts are metadata only. Artifact blobs are not persisted.
+
+Artifact URLs are opaque provider metadata and should not be assumed to be permanent, public, or to have stable download semantics.
+
 ---
 
 ### GET `/v1/models`

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -46,4 +46,6 @@ Dashboard CSS and JavaScript assets are served by standard Starlette `StaticFile
 The playground uses the existing `/v1/chat/completions` JSON contract. When files are attached, they are converted client-side into OpenAI-style `type: "file"` content parts and sent to Gemini WebAPI only. Gemini Playwright and Atlas do not support file parts, and Gemini WebAPI does not preserve exact text/file interleaving order.
 The current supported file formats are documented in [API documentation](api.md).
 
+The playground also includes a dedicated `Artifacts` panel. Buffered and streaming artifacts appear there. Rendering is link-first, with no autoplay and no iframe embedding. Response text remains separate from artifacts.
+
 The UI enforces conservative file limits to account for browser-side base64 expansion. Backend validation remains authoritative.

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -55,6 +55,17 @@ Current MVP rules:
 - The currently verified file format list is maintained in [docs/api.md](../api.md).
 - For Gemini WebAPI, text content parts are concatenated into one prompt and file parts are passed as attachments, so exact text/file interleaving order is not preserved.
 
+### 3.2 Generated Output Artifacts
+
+Gemini WebAPI may return generated artifacts alongside text output.
+
+- **Buffered Responses**: Gemini WebAPI responses may include `choices[0].artifacts` while `message.content` remains text-only.
+- **Streaming Responses**: Gemini WebAPI may emit one final SSE chunk before `[DONE]` that carries `choices[0].delta = {}` and `choices[0].artifacts = [...]`.
+- **Provider Scope**: Generated output artifacts are Gemini WebAPI-specific. Playwright and Atlas do not expose this response shape.
+- **Thoughts**: Model thoughts remain hidden by default and are not exposed through the public API response shape.
+- **Persistence**: Artifact blobs are not persisted in local snapshots or conversation state.
+- **Metadata Semantics**: Artifact URLs are provider metadata only. Clients must not assume they are permanent, public, or stable download handles.
+
 ## 4. Conversation Contract
 
 ### `conversation_id`

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -126,6 +126,7 @@ class SessionManager:
         """
         self.active_streams += 1
         interrupted_sent = False
+        final_response = None
         
         async with self.lock:
             try:
@@ -143,11 +144,18 @@ class SessionManager:
                 try:
                     async with asyncio.timeout(MAX_GENERATION_DURATION):
                         async for chunk in self.session.send_message_stream(prompt=prompt, files=files):
+                            final_response = chunk
                             yield {
                                 "type": "chunk",
                                 "text_delta": getattr(chunk, 'text_delta', ""),
                                 "is_reused": is_reused
                             }
+                    if final_response is not None:
+                        yield {
+                            "type": "final",
+                            "response": final_response,
+                            "is_reused": is_reused,
+                        }
                 except asyncio.TimeoutError:
                     logger.warning("Stream exceeded MAX_GENERATION_DURATION, interrupting.")
                     interrupted_sent = True

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -24,6 +24,7 @@ from app.services.providers.gemini.shared import (
 )
 from app.services.providers.gemini.webapi_response_builder import (
     build_webapi_chat_completion_response,
+    build_webapi_streaming_artifact_chunk,
 )
 from app.services.providers.gemini.persistence import (
     serialize_session_state,
@@ -382,6 +383,15 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
                                 openai_chunk["conversation_id"] = cid
                                 openai_chunk["reused_conversation"] = chunk.get("is_reused", False)
                                 yield await format_sse_chunk(openai_chunk)
+                            elif chunk.get("type") == "final":
+                                artifact_chunk = build_webapi_streaming_artifact_chunk(
+                                    chunk.get("response"),
+                                    request.model or "unknown",
+                                    conversation_id=cid,
+                                    reused_conversation=chunk.get("is_reused", False),
+                                )
+                                if artifact_chunk is not None:
+                                    yield await format_sse_chunk(artifact_chunk)
                     except (asyncio.CancelledError, GeneratorExit):
                         raise
                     except Exception as e:

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -18,9 +18,12 @@ from app.services.providers.exceptions import (
 )
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
 from app.services.providers.gemini.shared import (
-    convert_to_openai_format, 
+    convert_to_openai_format,
     parse_tool_call,
     UNRECOVERABLE_CONVERSATION_ERROR_CODES
+)
+from app.services.providers.gemini.webapi_response_builder import (
+    build_webapi_chat_completion_response,
 )
 from app.services.providers.gemini.persistence import (
     serialize_session_state,
@@ -412,18 +415,25 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
             
             # 4. Parse tool calls if necessary
             tool_call = parse_tool_call(response.text) if request.tools else None
-            
-            # 5. Normalize response to OpenAI format
-            openai_response = convert_to_openai_format(
-                response.text, 
-                request.model or "unknown", 
-                is_stream, 
-                tool_call
-            )
-            
-            # Inject stateful conversation identifiers
-            openai_response["conversation_id"] = cid
-            openai_response["reused_conversation"] = is_reused
+
+            # 5. Normalize Gemini WebAPI response to OpenAI format and attach artifacts
+            if is_stream:
+                openai_response = convert_to_openai_format(
+                    response.text,
+                    request.model or "unknown",
+                    is_stream,
+                    tool_call,
+                )
+                openai_response["conversation_id"] = cid
+                openai_response["reused_conversation"] = is_reused
+            else:
+                openai_response = build_webapi_chat_completion_response(
+                    response,
+                    request.model or "unknown",
+                    conversation_id=cid,
+                    reused_conversation=is_reused,
+                    tool_call=tool_call,
+                )
             
             if is_stream:
                 from app.utils.streaming import simulate_streaming_generator

--- a/src/app/services/providers/gemini/webapi_response_builder.py
+++ b/src/app/services/providers/gemini/webapi_response_builder.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from app.services.providers.gemini.shared import convert_to_openai_format
+
+ARTIFACT_PROVIDER = "gemini_webapi"
+
+
+def _string_value(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _list_value(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _build_image_artifact(image: Any) -> Optional[dict]:
+    artifact: dict[str, str] = {
+        "type": "image",
+        "provider": ARTIFACT_PROVIDER,
+    }
+
+    title = _string_value(getattr(image, "title", None))
+    url = _string_value(getattr(image, "url", None))
+    alt = _string_value(getattr(image, "alt", None))
+
+    if title:
+        artifact["title"] = title
+    if url:
+        artifact["url"] = url
+    if alt:
+        artifact["alt"] = alt
+
+    return artifact if len(artifact) > 2 else None
+
+
+def _build_video_artifact(video: Any) -> Optional[dict]:
+    artifact: dict[str, str] = {
+        "type": "video",
+        "provider": ARTIFACT_PROVIDER,
+    }
+
+    title = _string_value(getattr(video, "title", None))
+    url = _string_value(getattr(video, "url", None))
+    thumbnail_url = _string_value(getattr(video, "thumbnail", None))
+
+    if title:
+        artifact["title"] = title
+    if url:
+        artifact["url"] = url
+    if thumbnail_url:
+        artifact["thumbnail_url"] = thumbnail_url
+
+    return artifact if len(artifact) > 2 else None
+
+
+def _build_audio_artifact(media: Any) -> Optional[dict]:
+    artifact: dict[str, str] = {
+        "type": "audio",
+        "provider": ARTIFACT_PROVIDER,
+    }
+
+    title = _string_value(getattr(media, "title", None))
+    url = _string_value(getattr(media, "mp3_url", None)) or _string_value(
+        getattr(media, "url", None)
+    )
+    thumbnail_url = _string_value(getattr(media, "mp3_thumbnail", None)) or _string_value(
+        getattr(media, "thumbnail", None)
+    )
+
+    if title:
+        artifact["title"] = title
+    if url:
+        artifact["url"] = url
+    if thumbnail_url:
+        artifact["thumbnail_url"] = thumbnail_url
+
+    return artifact if len(artifact) > 2 else None
+
+
+def build_choice_artifacts(response: Any) -> list[dict]:
+    artifacts: list[dict] = []
+
+    for image in _list_value(getattr(response, "images", [])):
+        artifact = _build_image_artifact(image)
+        if artifact:
+            artifacts.append(artifact)
+
+    for video in _list_value(getattr(response, "videos", [])):
+        artifact = _build_video_artifact(video)
+        if artifact:
+            artifacts.append(artifact)
+
+    for media in _list_value(getattr(response, "media", [])):
+        artifact = _build_audio_artifact(media)
+        if artifact:
+            artifacts.append(artifact)
+
+    return artifacts
+
+
+def build_webapi_chat_completion_response(
+    response: Any,
+    model: str,
+    *,
+    tool_call: Optional[dict] = None,
+    conversation_id: Optional[str] = None,
+    reused_conversation: bool = False,
+) -> dict:
+    openai_response = convert_to_openai_format(
+        getattr(response, "text", "") or "",
+        model,
+        False,
+        tool_call,
+    )
+
+    artifacts = build_choice_artifacts(response)
+    if artifacts:
+        openai_response["choices"][0]["artifacts"] = artifacts
+
+    if conversation_id is not None:
+        openai_response["conversation_id"] = conversation_id
+        openai_response["reused_conversation"] = reused_conversation
+
+    return openai_response

--- a/src/app/services/providers/gemini/webapi_response_builder.py
+++ b/src/app/services/providers/gemini/webapi_response_builder.py
@@ -130,3 +130,22 @@ def build_webapi_chat_completion_response(
         openai_response["reused_conversation"] = reused_conversation
 
     return openai_response
+
+
+def build_webapi_streaming_artifact_chunk(
+    response: Any,
+    model: str,
+    *,
+    conversation_id: Optional[str] = None,
+    reused_conversation: bool = False,
+) -> Optional[dict]:
+    artifacts = build_choice_artifacts(response)
+    if not artifacts:
+        return None
+
+    openai_chunk = convert_to_openai_format("", model, True)
+    openai_chunk["choices"][0]["delta"] = {}
+    openai_chunk["choices"][0]["artifacts"] = artifacts
+    openai_chunk["conversation_id"] = conversation_id
+    openai_chunk["reused_conversation"] = reused_conversation
+    return openai_chunk

--- a/src/app/static/ui/css/dashboard.css
+++ b/src/app/static/ui/css/dashboard.css
@@ -631,6 +631,65 @@ button:disabled {
   overflow-wrap: anywhere;
 }
 
+.playground-artifacts .panel-head {
+  margin-bottom: 12px;
+}
+
+.artifact-empty {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.artifact-list {
+  display: grid;
+  gap: 10px;
+}
+
+.artifact-item {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fbfcfd;
+}
+
+.artifact-header {
+  display: grid;
+  gap: 2px;
+}
+
+.artifact-title {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.artifact-meta {
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.artifact-link-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.artifact-link-row a {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.artifact-link-row a:hover {
+  text-decoration: underline;
+}
+
 @media (max-width: 700px) {
   .topbar {
     align-items: flex-start;

--- a/src/app/static/ui/js/playground.js
+++ b/src/app/static/ui/js/playground.js
@@ -15,6 +15,8 @@
   var metaReused = root.querySelector("[data-meta-reused]");
   var metaModel = root.querySelector("[data-meta-model]");
   var metaStatus = root.querySelector("[data-meta-status]");
+  var artifactOutput = root.querySelector("[data-artifact-output]");
+  var artifactEmpty = root.querySelector("[data-artifact-empty]");
   var fileInput = root.querySelector("[data-file-input]");
   var fileList = root.querySelector("[data-file-list]");
   var fileAttachmentSummary = root.querySelector("[data-file-attachment-summary]");
@@ -372,6 +374,7 @@
 
   function resetOutput() {
     output.textContent = "";
+    clearArtifacts();
     lastConversationId = "";
     lastReusedConversation = "";
     lastReusedConversationSeen = false;
@@ -550,6 +553,78 @@
     return "";
   }
 
+  function extractArtifacts(data) {
+    var choice = data && data.choices && data.choices[0];
+    var artifacts = choice && choice.artifacts;
+    return Array.isArray(artifacts) ? artifacts : [];
+  }
+
+  function clearArtifacts() {
+    artifactOutput.textContent = "";
+    artifactEmpty.style.display = "block";
+  }
+
+  function renderArtifacts(artifacts) {
+    var list = Array.isArray(artifacts) ? artifacts : [];
+    artifactOutput.textContent = "";
+    artifactEmpty.style.display = list.length ? "none" : "block";
+
+    if (!list.length) {
+      return;
+    }
+
+    var fragment = document.createDocumentFragment();
+
+    list.forEach(function (artifact) {
+      if (!artifact || typeof artifact !== "object") {
+        return;
+      }
+
+      var item = document.createElement("article");
+      item.className = "artifact-item";
+
+      var header = document.createElement("div");
+      header.className = "artifact-header";
+
+      var title = document.createElement("div");
+      title.className = "artifact-title";
+      title.textContent = artifact.title || artifact.type || "artifact";
+      header.appendChild(title);
+
+      var meta = document.createElement("div");
+      meta.className = "artifact-meta";
+      var metaBits = [];
+      if (artifact.type) {
+        metaBits.push(String(artifact.type));
+      }
+      if (artifact.mime_type) {
+        metaBits.push(String(artifact.mime_type));
+      }
+      if (artifact.provider) {
+        metaBits.push(String(artifact.provider));
+      }
+      meta.textContent = metaBits.join(" · ");
+      header.appendChild(meta);
+      item.appendChild(header);
+
+      if (artifact.url) {
+        var linkRow = document.createElement("div");
+        linkRow.className = "artifact-link-row";
+        var link = document.createElement("a");
+        link.href = String(artifact.url);
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.textContent = "Open artifact";
+        linkRow.appendChild(link);
+        item.appendChild(linkRow);
+      }
+
+      fragment.appendChild(item);
+    });
+
+    artifactOutput.appendChild(fragment);
+  }
+
   function renderError(error) {
     output.textContent = error.message || String(error);
     setState("Error");
@@ -574,6 +649,7 @@
     }
 
     output.textContent = extractAssistantText(body);
+    renderArtifacts(extractArtifacts(body));
     applyMetadata(body, payload.model);
     setState("Complete");
   }
@@ -591,6 +667,10 @@
 
     var parsed = JSON.parse(data);
     output.textContent += extractAssistantText(parsed);
+    var artifacts = extractArtifacts(parsed);
+    if (artifacts.length) {
+      renderArtifacts(artifacts);
+    }
     applyMetadata(parsed, payload.model);
     return false;
   }

--- a/src/app/templates/ui/playground.html
+++ b/src/app/templates/ui/playground.html
@@ -53,6 +53,14 @@
       <pre class="response-box" data-response-output></pre>
     </section>
 
+    <section class="panel playground-artifacts">
+      <div class="panel-head">
+        <h2>Artifacts</h2>
+      </div>
+      <div class="artifact-empty" data-artifact-empty>Generated artifacts will appear here.</div>
+      <div class="artifact-list" data-artifact-output aria-live="polite"></div>
+    </section>
+
     <details class="panel playground-files">
       <summary class="playground-files-summary">
         <span>

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -9,6 +9,10 @@ from app.services.providers.base_repository import ConversationSnapshot
 from app.services.providers.exceptions import ConversationInUseError
 from app.services.providers.gemini.provider import GeminiProvider
 from app.services.providers.gemini.session_manager import SessionRegistry
+from app.services.providers.gemini.webapi_response_builder import (
+    build_choice_artifacts,
+    build_webapi_chat_completion_response,
+)
 
 @pytest.fixture
 def provider():
@@ -89,6 +93,172 @@ def test_convert_to_openai_format_with_tool_call(provider):
     assert result["choices"][0]["finish_reason"] == "tool_calls"
     assert result["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "test_tool"
     assert json.loads(result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"]) == {"arg": 1}
+
+
+def test_build_choice_artifacts_maps_safe_webapi_metadata():
+    response = SimpleNamespace(
+        images=[
+            SimpleNamespace(
+                url="https://example.com/image.png",
+                title="Generated image",
+                alt="A generated image",
+            )
+        ],
+        videos=[
+            SimpleNamespace(
+                url="https://example.com/video.mp4",
+                title="Generated video",
+                thumbnail="https://example.com/video-thumb.jpg",
+            )
+        ],
+        media=[
+            SimpleNamespace(
+                mp3_url="https://example.com/audio.mp3",
+                mp3_thumbnail="https://example.com/audio-thumb.jpg",
+                title="Generated audio",
+            )
+        ],
+    )
+
+    artifacts = build_choice_artifacts(response)
+
+    assert artifacts == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "title": "Generated image",
+            "url": "https://example.com/image.png",
+            "alt": "A generated image",
+        },
+        {
+            "type": "video",
+            "provider": "gemini_webapi",
+            "title": "Generated video",
+            "url": "https://example.com/video.mp4",
+            "thumbnail_url": "https://example.com/video-thumb.jpg",
+        },
+        {
+            "type": "audio",
+            "provider": "gemini_webapi",
+            "title": "Generated audio",
+            "url": "https://example.com/audio.mp3",
+            "thumbnail_url": "https://example.com/audio-thumb.jpg",
+        },
+    ]
+
+
+def test_build_choice_artifacts_ignores_missing_and_non_string_fields():
+    response = SimpleNamespace(
+        images=[
+            SimpleNamespace(url=123, title=None, alt=""),
+            SimpleNamespace(url="https://example.com/image.png", unknown_field="ignored"),
+        ],
+        videos=[
+            SimpleNamespace(url=None, title=456, thumbnail={}),
+        ],
+        media=[
+            SimpleNamespace(mp3_url="", mp3_thumbnail=None, title=None),
+        ],
+    )
+
+    artifacts = build_choice_artifacts(response)
+
+    assert artifacts == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "url": "https://example.com/image.png",
+        }
+    ]
+
+
+def test_build_webapi_chat_completion_response_keeps_text_only_shape():
+    response = SimpleNamespace(text="Hello world", images=[], videos=[], media=[])
+
+    result = build_webapi_chat_completion_response(
+        response,
+        "gemini-3-flash",
+        conversation_id="conv-1",
+        reused_conversation=False,
+    )
+
+    assert result["model"] == "gemini-3-flash"
+    assert result["choices"][0]["message"]["content"] == "Hello world"
+    assert "artifacts" not in result["choices"][0]
+    assert result["conversation_id"] == "conv-1"
+    assert result["reused_conversation"] is False
+
+
+def test_build_webapi_chat_completion_response_attaches_artifacts_without_thoughts():
+    response = SimpleNamespace(
+        text="Done.",
+        thoughts="internal reasoning",
+        images=[
+            SimpleNamespace(
+                url="https://example.com/image.png",
+                title="Generated image",
+            )
+        ],
+        videos=[],
+        media=[],
+    )
+
+    result = build_webapi_chat_completion_response(
+        response,
+        "gemini-3-flash",
+        conversation_id="conv-2",
+        reused_conversation=True,
+    )
+
+    assert result["choices"][0]["message"]["content"] == "Done."
+    assert result["choices"][0]["artifacts"] == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "title": "Generated image",
+            "url": "https://example.com/image.png",
+        }
+    ]
+    assert "thoughts" not in result["choices"][0]
+    assert result["conversation_id"] == "conv-2"
+    assert result["reused_conversation"] is True
+
+
+def test_build_webapi_chat_completion_response_preserves_tool_calls_and_artifacts():
+    response = SimpleNamespace(
+        text='{"tool_call": {"name": "generate_report", "arguments": {"topic": "status"}}}',
+        thoughts="internal reasoning",
+        images=[
+            SimpleNamespace(
+                url="https://example.com/report.png",
+                title="Report image",
+            )
+        ],
+        videos=[],
+        media=[],
+    )
+
+    result = build_webapi_chat_completion_response(
+        response,
+        "gemini-3-flash",
+        tool_call={"name": "generate_report", "arguments": {"topic": "status"}},
+        conversation_id="conv-3",
+        reused_conversation=False,
+    )
+
+    message = result["choices"][0]["message"]
+    assert message["content"] is None
+    assert message["tool_calls"]
+    assert result["choices"][0]["artifacts"] == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "title": "Report image",
+            "url": "https://example.com/report.png",
+        }
+    ]
+    assert "thoughts" not in result["choices"][0]
+    assert result["conversation_id"] == "conv-3"
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -12,6 +12,7 @@ from app.services.providers.gemini.session_manager import SessionRegistry
 from app.services.providers.gemini.webapi_response_builder import (
     build_choice_artifacts,
     build_webapi_chat_completion_response,
+    build_webapi_streaming_artifact_chunk,
 )
 
 @pytest.fixture
@@ -259,6 +260,51 @@ def test_build_webapi_chat_completion_response_preserves_tool_calls_and_artifact
     ]
     assert "thoughts" not in result["choices"][0]
     assert result["conversation_id"] == "conv-3"
+
+
+def test_build_webapi_streaming_artifact_chunk_behaviour():
+    empty_response = SimpleNamespace(text="Done.", images=[], videos=[], media=[], thoughts="hidden")
+    assert build_webapi_streaming_artifact_chunk(
+        empty_response,
+        "gemini-3-flash",
+        conversation_id="conv-4",
+        reused_conversation=False,
+    ) is None
+
+    response = SimpleNamespace(
+        text="Done.",
+        images=[
+            SimpleNamespace(
+                url="https://example.com/image.png",
+                title="Generated image",
+                alt="A generated image",
+            )
+        ],
+        videos=[],
+        media=[],
+        thoughts="hidden",
+    )
+
+    result = build_webapi_streaming_artifact_chunk(
+        response,
+        "gemini-3-flash",
+        conversation_id="conv-4",
+        reused_conversation=True,
+    )
+
+    assert result["choices"][0]["delta"] == {}
+    assert result["choices"][0]["artifacts"] == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "title": "Generated image",
+            "url": "https://example.com/image.png",
+            "alt": "A generated image",
+        }
+    ]
+    assert "thoughts" not in result["choices"][0]
+    assert result["conversation_id"] == "conv-4"
+    assert result["reused_conversation"] is True
 
 
 @pytest.mark.asyncio
@@ -996,6 +1042,17 @@ async def test_chat_completions_stateful_streaming(mocker, provider):
             "text_delta": "Stateful delta content",
             "is_reused": True
         }
+        yield {
+            "type": "final",
+            "response": SimpleNamespace(
+                text="Stateful response content",
+                images=[],
+                videos=[],
+                media=[],
+                thoughts="hidden",
+            ),
+            "is_reused": True,
+        }
 
     mock_manager.get_streaming_response_stateful = mock_generator
     mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
@@ -1032,6 +1089,145 @@ async def test_chat_completions_stateful_streaming(mocker, provider):
     assert chunk_data["conversation_id"] == "test_token_XYZ"
     assert chunk_data["reused_conversation"] is True
     mock_registry.save_session_snapshot.assert_called_once_with("test_token_XYZ", provider, mock_manager)
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stateful_streaming_emits_final_artifact_chunk_before_done(mocker, provider):
+    """Verify WebAPI streaming emits a final artifact chunk before [DONE] when artifacts exist."""
+    from app.schemas.request import OpenAIChatRequest
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
+
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_registry = mocker.Mock(spec=SessionRegistry)
+    mock_manager = mocker.Mock(spec=SessionManager)
+
+    async def mock_generator(*args, **kwargs):
+        yield {
+            "type": "chunk",
+            "text_delta": "Stateful delta content",
+            "is_reused": False,
+        }
+        yield {
+            "type": "final",
+            "response": SimpleNamespace(
+                text="Stateful response content",
+                images=[
+                    SimpleNamespace(
+                        url="https://example.com/generated.png",
+                        title="Generated image",
+                        alt="A generated image",
+                    )
+                ],
+                videos=[],
+                media=[],
+                thoughts="hidden",
+            ),
+            "is_reused": False,
+        }
+
+    mock_manager.get_streaming_response_stateful = mock_generator
+    mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
+    mock_registry.save_session_snapshot = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    request = OpenAIChatRequest(
+        messages=[{"role": "user", "content": "I am Ali. What is my name?"}],
+        model="gemini-3-flash",
+        stream=True,
+        conversation_id="test_token_XYZ",
+    )
+
+    response = await provider.chat_completions(request)
+    assert response is not None
+
+    from fastapi.responses import StreamingResponse
+    assert isinstance(response, StreamingResponse)
+
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+
+    assert len(chunks) == 3
+
+    text_chunk = json.loads(chunks[0][6:-2])
+    artifact_chunk = json.loads(chunks[1][6:-2])
+
+    assert text_chunk["choices"][0]["delta"]["content"] == "Stateful delta content"
+    assert text_chunk["conversation_id"] == "test_token_XYZ"
+    assert text_chunk["reused_conversation"] is False
+
+    assert artifact_chunk["choices"][0]["delta"] == {}
+    assert artifact_chunk["choices"][0]["finish_reason"] == "stop"
+    assert artifact_chunk["choices"][0]["artifacts"] == [
+        {
+            "type": "image",
+            "provider": "gemini_webapi",
+            "title": "Generated image",
+            "url": "https://example.com/generated.png",
+            "alt": "A generated image",
+        }
+    ]
+    assert "thoughts" not in artifact_chunk["choices"][0]
+    assert artifact_chunk["conversation_id"] == "test_token_XYZ"
+    assert artifact_chunk["reused_conversation"] is False
+    assert chunks[2] == "data: [DONE]\n\n"
+    mock_registry.save_session_snapshot.assert_called_once_with("test_token_XYZ", provider, mock_manager)
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stateful_streaming_interrupt_does_not_emit_artifact_chunk(mocker, provider):
+    """Verify interrupting WebAPI streaming does not emit an artifact chunk."""
+    from app.schemas.request import OpenAIChatRequest
+    from app.services.providers.gemini.session_manager import SessionManager, SessionRegistry
+
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_registry = mocker.Mock(spec=SessionRegistry)
+    mock_manager = mocker.Mock(spec=SessionManager)
+
+    async def mock_generator(*args, **kwargs):
+        yield {
+            "type": "chunk",
+            "text_delta": "Stateful delta content",
+            "is_reused": True,
+        }
+        yield {
+            "type": "interrupt",
+            "interrupted": True,
+            "reason": "timeout",
+            "is_reused": True,
+        }
+
+    mock_manager.get_streaming_response_stateful = mock_generator
+    mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
+    mock_registry.save_session_snapshot = mocker.AsyncMock()
+
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_client", return_value=mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    request = OpenAIChatRequest(
+        messages=[{"role": "user", "content": "I am Ali. What is my name?"}],
+        model="gemini-3-flash",
+        stream=True,
+        conversation_id="test_token_XYZ",
+    )
+
+    response = await provider.chat_completions(request)
+    assert response is not None
+
+    from fastapi.responses import StreamingResponse
+    assert isinstance(response, StreamingResponse)
+
+    chunks = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk)
+
+    assert len(chunks) == 2
+    assert json.loads(chunks[0][6:-2])["choices"][0]["delta"]["content"] == "Stateful delta content"
+    assert chunks[1] == "data: [DONE]\n\n"
 
 
 def test_transform_messages_formatting():

--- a/tests/test_ui_dashboard.py
+++ b/tests/test_ui_dashboard.py
@@ -433,11 +433,16 @@ async def test_ui_playground_returns_html_and_populates_models(mocker):
     assert "<summary class=\"playground-files-summary\">" in response.text
     assert response.text.index('data-response-output') < response.text.index('data-file-input')
     assert response.text.index('data-file-input') < response.text.index('data-meta-conversation-id')
+    assert response.text.index('data-response-output') < response.text.index('data-artifact-output')
+    assert response.text.index('data-artifact-output') < response.text.index('data-file-input')
     assert "data-file-input" in response.text
     assert "data-file-list" in response.text
     assert "data-clear-files" in response.text
     assert "data-file-guidance" in response.text
     assert "data-file-attachment-summary" in response.text
+    assert "data-artifact-output" in response.text
+    assert "data-artifact-empty" in response.text
+    assert "Generated artifacts will appear here." in response.text
     assert "No files attached." in response.text
     assert "Gemini WebAPI" in response.text
     assert "Exact text/file interleaving is not preserved by Gemini WebAPI." in response.text
@@ -488,6 +493,11 @@ async def test_ui_html_references_static_assets():
     assert "data:text/plain;base64," in playground_js
     assert "must be plain text to use without an extension" in playground_js
     assert "must contain UTF-8 plain text" in playground_js
+    assert "extractArtifacts" in playground_js
+    assert "renderArtifacts" in playground_js
+    assert "clearArtifacts" in playground_js
+    assert "artifactOutput" in playground_js
+    assert "artifactEmpty" in playground_js
     assert '"application/json": [".json"]' in playground_js
     assert '"application/xml": [".xml"]' in playground_js
     assert '"text/xml": [".xml"]' in playground_js
@@ -499,6 +509,7 @@ async def test_ui_html_references_static_assets():
     assert "Selected files will be attached on submit" in playground_js
     assert "Gemini Playwright and Atlas do not support file parts" in playground_js
     assert "MAX_TOTAL_FILE_SIZE_BYTES = 40 * 1024 * 1024" in playground_js
+    assert "Open artifact" in playground_js
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_dashboard.py
+++ b/tests/test_ui_dashboard.py
@@ -522,6 +522,26 @@ async def test_dashboard_docs_mention_playground_file_support():
     assert "Gemini Playwright and Atlas do not support file parts" in docs_text
     assert "conservative file limits" in docs_text
     assert "API documentation" in docs_text
+    assert "Artifacts" in docs_text
+    assert "link-first" in docs_text
+
+
+def test_api_docs_mention_generated_artifacts():
+    docs_path = Path("docs/api.md")
+    assert docs_path.is_file()
+    docs_text = docs_path.read_text(encoding="utf-8")
+    assert "#### Generated Artifacts" in docs_text
+    assert "choices[0].artifacts" in docs_text
+    assert "Artifact URLs are opaque provider metadata" in docs_text
+
+
+def test_api_contract_docs_mention_generated_artifacts():
+    docs_path = Path("docs/specs/api-contract.md")
+    assert docs_path.is_file()
+    docs_text = docs_path.read_text(encoding="utf-8")
+    assert "### 3.2 Generated Output Artifacts" in docs_text
+    assert "choices[0].artifacts" in docs_text
+    assert "Artifact URLs are provider metadata only" in docs_text
 
 
 def test_api_docs_mention_extensionless_text_support():


### PR DESCRIPTION
## Summary

This PR adds support for Gemini WebAPI generated artifacts across the API, streaming pipeline, Playground UI, and documentation.

Generated artifacts are exposed separately from assistant text through `choices[].artifacts`, while preserving the existing OpenAI-compatible text response shape.

## Key Changes

* **Generated Artifact Support**: Added support for generated artifact metadata in Gemini WebAPI responses, including images, videos, audio/media, and future artifact types.
* **Buffered Responses**: Expose artifact metadata through `choices[].artifacts` while keeping `message.content` text-only.
* **Streaming Responses**: Emit a final artifact SSE chunk before `[DONE]`, allowing artifact metadata to be delivered without altering existing text streaming behavior.
* **Playground UI**: Added a dedicated Artifacts panel with link-first rendering for buffered and streaming responses.
* **Documentation**: Updated API, contract, and dashboard documentation to describe generated artifact behavior and limitations.
* **Testing**: Added regression coverage for buffered artifacts, streaming artifacts, artifact rendering, and documentation updates.

## Testing

* Tests run:

  * `pytest tests/test_gemini_provider.py`
  * `pytest tests/test_ui_dashboard.py`
  * `pytest tests/test_streaming.py`
  * `pytest tests/test_gemini_playwright_parity.py`
* Result: All tests passed
