### PR TITLE
Migrate package metadata to PEP 621

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2820,4 +2820,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "37c3a059e393c2eba6bdb2db8d24b9a384710df6db880db39c3d65ab7845ff23"
+content-hash = "865ecbcc899c0ba75194bb983b24abe9e806c3de3751c8a4a1c845dec125c2a4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,18 @@
 # File: pyproject.toml
 
-[tool.poetry]
+[project]
 name = "webai-to-api"
 version = "0.5.0"
 description = "WebAI-to-API is a modular web server built with FastAPI, designed to manage requests across AI services."
-authors = ["Mohammad <m.khani2810@gmail.com>"]
+authors = [
+    { name = "Mohammad", email = "m.khani2810@gmail.com" },
+]
 license = "Apache-2.0"
 readme = "README.md"
+requires-python = ">=3.10,<3.13"
+dynamic = ["dependencies"]
+
+[tool.poetry]
 
 packages = [
     { include = "app", from = "src" },
@@ -46,5 +52,5 @@ asyncio_default_test_loop_scope = "function"
 timeout = 30
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/run.py
+++ b/src/run.py
@@ -22,6 +22,25 @@ from app.config import load_config, CONFIG
 from app.main import app as webai_app
 
 
+def _read_project_metadata() -> Tuple[str, str]:
+    """Read the project name and version from pyproject metadata."""
+    if not tomli:
+        return "WebAI to API", "N/A (tomli not installed)"
+
+    try:
+        with open("pyproject.toml", "rb") as f:
+            toml_data = tomli.load(f)
+
+        project_data = toml_data.get("project", {})
+        poetry_data = toml_data.get("tool", {}).get("poetry", {})
+
+        name = project_data.get("name") or poetry_data.get("name", "WebAI-to-API")
+        version = project_data.get("version") or poetry_data.get("version", "N/A")
+        return name.replace("-", " ").title(), version
+    except (FileNotFoundError, KeyError, TypeError):
+        return "WebAI-to-API", "N/A"
+
+
 # Helper class for terminal colors
 class Colors:
     """A class to hold ANSI color codes for terminal output."""
@@ -37,17 +56,7 @@ class Colors:
 # --- Helper function to get app info ---
 def get_app_info() -> Tuple[str, str]:
     """Reads application name and version from pyproject.toml."""
-    if not tomli:
-        return "WebAI to API", "N/A (tomli not installed)"
-    try:
-        with open("pyproject.toml", "rb") as f:
-            toml_data = tomli.load(f)
-        poetry_data = toml_data.get("tool", {}).get("poetry", {})
-        name = poetry_data.get("name", "WebAI-to-API").replace("-", " ").title()
-        version = poetry_data.get("version", "N/A")
-        return name, version
-    except (FileNotFoundError, KeyError):
-        return "WebAI-to-API", "N/A"
+    return _read_project_metadata()
 
 
 # --- Helper Function for Printing Info ---


### PR DESCRIPTION
## Summary

This PR migrates the project's package metadata from the legacy `[tool.poetry]` section to the standard PEP 621 `[project]` section. It also updates the runtime metadata loading logic to support both metadata layouts and aligns the build backend with the Poetry 2.x toolchain.

## Key Changes

* Migrated package metadata to the `[project]` section:

  * `name`
  * `version`
  * `description`
  * `authors`
  * `license`
  * `readme`
  * `requires-python`
* Added `dynamic = ["dependencies"]` to preserve the existing hybrid Poetry configuration while keeping dependencies under `[tool.poetry.dependencies]`.
* Preserved Poetry-specific configuration, including:

  * dependency definitions
  * dependency groups
  * package discovery (`packages = [{ include = "app", from = "src" }]`)
* Updated the build backend requirement to `poetry-core>=2.0.0,<3.0.0`.
* Refactored metadata loading in `src/run.py` to read from `[project]` first with fallback to legacy Poetry metadata.
* Regenerated `poetry.lock` after the metadata migration.

## Testing

Validated with:

* `poetry check`
* `poetry lock`
* `make export-reqs`
* `poetry build`

Results:

* `poetry check` passes without Poetry 2.x metadata deprecation warnings.
* Package discovery and build output remain unchanged.
* Startup banner metadata resolution remains backward compatible.

## Notes

* This is a packaging and metadata modernization change only.
* No API behavior changes.
* No runtime behavior changes.
* Existing unrelated timeout failures in `tests/test_config_utils.py` remain unchanged.
