### PR TITLE
Unify runtime logging configuration and Docker logging controls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 EXPOSE 6969
 
 # Run the application via the startup wrapper
-CMD ["python", "src/run.py", "--host", "0.0.0.0", "--port", "6969", "--log-level", "info"]
+CMD ["python", "src/run.py", "--host", "0.0.0.0", "--port", "6969"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ poetry run playwright install chromium
 ```bash
 cp config.conf.example config.conf
 ```
+*For detailed settings (including logging verbosity and access log configurations), see [Configuration Guide](docs/configuration.md).*
+
 
 ### 3. Authenticate
 ```bash

--- a/config.conf.example
+++ b/config.conf.example
@@ -124,3 +124,13 @@ chunk_timeout = 90
 total_request_timeout = 120
 idle_conversation_timeout = 900
 lease_timeout = 180
+
+# --- Logging Settings ---
+# Configure server log output and verbosity.
+# Precedence: CLI Arg > OS Env > config.conf > Default
+[Logging]
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+level = INFO
+# Set to true to disable Uvicorn HTTP access logging
+disable_access_logs = false
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     environment:
       - PYTHONPATH=/app/src
       - PLAYWRIGHT_HEADLESS=true
+      - LOG_LEVEL=${LOG_LEVEL:-}
+      - DISABLE_ACCESS_LOGS=${DISABLE_ACCESS_LOGS:-false}
     volumes:
       - ./config.conf:/app/config.conf:ro
       - ./runtime:/app/runtime

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,50 @@ See `Docker.md` for complete deployment instructions.
 
 ---
 
+## Logging Configuration
+
+WebAI-to-API logging behavior can be configured centrally to manage console output verbosity and HTTP access logging.
+
+### Priority Resolution
+Logging settings are resolved in the following priority order:
+1. **CLI Arguments** (highest priority)
+2. **OS Environment Variables**
+3. **Configuration File** (`[Logging]` section in `config.conf`, if present)
+4. **System Defaults** (`INFO` level, access logs enabled)
+
+### Local Configuration Options
+
+You can manage logging in `config.conf` using the `[Logging]` section:
+
+```ini
+[Logging]
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+level = INFO
+# Disable Uvicorn request logs (default: false)
+disable_access_logs = false
+```
+
+### Local Execution Examples
+
+* **Default Run** (runs at `INFO` level, access logs enabled):
+  ```bash
+  poetry run python src/run.py
+  ```
+* **Enable DEBUG via CLI**:
+  ```bash
+  poetry run python src/run.py --log-level debug
+  ```
+* **Enable DEBUG via Environment Variable**:
+  ```bash
+  LOG_LEVEL=DEBUG poetry run python src/run.py
+  ```
+* **Disable HTTP Access Logs**:
+  ```bash
+  poetry run python src/run.py --disable-access-logs
+  ```
+
+---
+
 ## Configuration Template
 
 The full configuration template is available in:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -40,6 +40,25 @@ cp config.conf.example config.conf
 
 Changes to `config.conf` or `.env` on the host are reflected in the container after a restart; an image rebuild is not required for configuration-only updates. Do NOT commit `config.conf` or `.env` as they may contain secrets.
 
+### Container Logging Controls
+
+Container logging is configured via environment variables passed into the service. By default, the container logs at `INFO` level and outputs web request access logs to stderr.
+
+You can override these behaviors by passing environment variables:
+
+* **Default Run** (INFO level logs, access logs enabled):
+  ```bash
+  docker compose up
+  ```
+* **Enable Container DEBUG Logs**:
+  ```bash
+  LOG_LEVEL=DEBUG docker compose up
+  ```
+* **Disable HTTP Request Access Logs**:
+  ```bash
+  DISABLE_ACCESS_LOGS=true docker compose up
+  ```
+
 ---
 
 ## Build

--- a/src/app/logger.py
+++ b/src/app/logger.py
@@ -1,6 +1,10 @@
 # src/app/logger.py
 import logging
 
+# Register custom levels in standard logging
+logging.addLevelName(25, "SUCCESS")
+logging.addLevelName(5, "TRACE")
+
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/app/logger.py
+++ b/src/app/logger.py
@@ -10,3 +10,31 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger("app")
+
+
+def setup_logging(log_level: str, disable_access_logs: bool) -> None:
+    """Configures the root logger, overrides verbose loggers, and bridges Loguru to standard logging."""
+    numeric_level = getattr(logging, log_level.upper(), logging.INFO)
+
+    # Explicitly set root logger level (overrides fallback DEBUG level set on import)
+    logging.getLogger().setLevel(numeric_level)
+
+    # Prevent verbose logs from third-party libraries/HTTP clients from flooding the console
+    logging.getLogger("httpx").setLevel(logging.DEBUG if log_level.upper() in ("DEBUG", "TRACE") else logging.WARNING)
+
+    # Bridge Loguru (gemini_webapi) logs into standard logging via a function sink
+    try:
+        from loguru import logger as loguru_logger
+
+        def loguru_sink(message):
+            record = message.record
+            name = record["extra"].get("name", record["name"])
+            level_no = record["level"].no
+            msg = record["message"]
+            logging.getLogger(name).log(level_no, msg)
+
+        loguru_logger.remove()  # Remove Loguru default handler
+        loguru_logger.add(loguru_sink, level=0)  # Route all Loguru logs to Python logging
+    except ImportError:
+        pass
+

--- a/src/run.py
+++ b/src/run.py
@@ -101,6 +101,10 @@ def setup_logging(log_level: str, disable_access_logs: bool) -> None:
     """Configures the root logger, overrides verbose loggers, and bridges Loguru to standard logging."""
     numeric_level = getattr(logging, log_level.upper(), logging.INFO)
 
+    # Register custom levels (e.g. from Loguru) in standard logging
+    logging.addLevelName(25, "SUCCESS")
+    logging.addLevelName(5, "TRACE")
+
     # Initialize the Python standard root logger
     logging.basicConfig(
         level=numeric_level,

--- a/src/run.py
+++ b/src/run.py
@@ -97,42 +97,6 @@ def print_server_info(host: str, port: int, mode: str):
     print("=" * 80)
 
 
-def setup_logging(log_level: str, disable_access_logs: bool) -> None:
-    """Configures the root logger, overrides verbose loggers, and bridges Loguru to standard logging."""
-    numeric_level = getattr(logging, log_level.upper(), logging.INFO)
-
-    # Register custom levels (e.g. from Loguru) in standard logging
-    logging.addLevelName(25, "SUCCESS")
-    logging.addLevelName(5, "TRACE")
-
-    # Initialize the Python standard root logger
-    logging.basicConfig(
-        level=numeric_level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stderr)]
-    )
-    logging.getLogger().setLevel(numeric_level)
-
-    # Prevent verbose logs from third-party libraries/HTTP clients from flooding the console
-    logging.getLogger("httpx").setLevel(logging.DEBUG if log_level.upper() in ("DEBUG", "TRACE") else logging.WARNING)
-
-    # Bridge Loguru (gemini_webapi) logs into standard logging via a function sink
-    try:
-        from loguru import logger as loguru_logger
-
-        def loguru_sink(message):
-            record = message.record
-            name = record["extra"].get("name", record["name"])
-            level_no = record["level"].no
-            msg = record["message"]
-            logging.getLogger(name).log(level_no, msg)
-
-        loguru_logger.remove()  # Remove Loguru default handler
-        loguru_logger.add(loguru_sink, level=0)  # Route all Loguru logs to Python logging
-    except ImportError:
-        pass
-
-
 def resolve_logging_config(cli_log_level: str | None, cli_disable_access_logs: bool) -> Tuple[str, bool]:
     """Resolves log level and access log settings based on CLI, env, and config precedence."""
     # 1. Resolve log level precedence: explicit CLI > LOG_LEVEL env > config.conf > INFO
@@ -167,6 +131,7 @@ if __name__ == "__main__":
     resolved_level, resolved_disable_access = resolve_logging_config(args.log_level, args.disable_access_logs)
 
     # Setup logging
+    from app.logger import setup_logging
     setup_logging(resolved_level, resolved_disable_access)
 
     # 4. Import app.main now that the standard root logger handlers are set up

--- a/src/run.py
+++ b/src/run.py
@@ -2,6 +2,7 @@
 import argparse
 import asyncio
 import logging
+import os
 import sys
 import uvicorn
 from typing import Tuple
@@ -19,7 +20,6 @@ except ImportError:
 
 # --- App and Service Imports ---
 from app.config import load_config, CONFIG
-from app.main import app as webai_app
 
 
 def _read_project_metadata() -> Tuple[str, str]:
@@ -97,6 +97,53 @@ def print_server_info(host: str, port: int, mode: str):
     print("=" * 80)
 
 
+def setup_logging(log_level: str, disable_access_logs: bool) -> None:
+    """Configures the root logger, overrides verbose loggers, and bridges Loguru to standard logging."""
+    numeric_level = getattr(logging, log_level.upper(), logging.INFO)
+
+    # Initialize the Python standard root logger
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stderr)]
+    )
+    logging.getLogger().setLevel(numeric_level)
+
+    # Prevent verbose logs from third-party libraries/HTTP clients from flooding the console
+    logging.getLogger("httpx").setLevel(logging.DEBUG if log_level.upper() in ("DEBUG", "TRACE") else logging.WARNING)
+
+    # Bridge Loguru (gemini_webapi) logs into standard logging via a function sink
+    try:
+        from loguru import logger as loguru_logger
+
+        def loguru_sink(message):
+            record = message.record
+            name = record["extra"].get("name", record["name"])
+            level_no = record["level"].no
+            msg = record["message"]
+            logging.getLogger(name).log(level_no, msg)
+
+        loguru_logger.remove()  # Remove Loguru default handler
+        loguru_logger.add(loguru_sink, level=0)  # Route all Loguru logs to Python logging
+    except ImportError:
+        pass
+
+
+def resolve_logging_config(cli_log_level: str | None, cli_disable_access_logs: bool) -> Tuple[str, bool]:
+    """Resolves log level and access log settings based on CLI, env, and config precedence."""
+    # 1. Resolve log level precedence: explicit CLI > LOG_LEVEL env > config.conf > INFO
+    env_log_level = os.environ.get("LOG_LEVEL")
+    conf_log_level = CONFIG.get("Logging", "level", fallback=None) if CONFIG.has_section("Logging") else None
+    resolved_level = cli_log_level or env_log_level or conf_log_level or "INFO"
+
+    # 2. Resolve access logs precedence: explicit CLI --disable-access-logs > DISABLE_ACCESS_LOGS env > config.conf > false
+    env_disable_access = os.environ.get("DISABLE_ACCESS_LOGS", "false").lower() in ("true", "1", "yes", "on")
+    conf_disable_access = CONFIG.getboolean("Logging", "disable_access_logs", fallback=False) if CONFIG.has_section("Logging") else False
+    resolved_disable_access = cli_disable_access_logs or env_disable_access or conf_disable_access
+
+    return resolved_level, resolved_disable_access
+
+
 # --- Main Execution Block ---
 if __name__ == "__main__":
     # Fix: Set the asyncio event loop policy for Windows.
@@ -108,11 +155,18 @@ if __name__ == "__main__":
     )
     parser.add_argument("--host", type=str, default="localhost", help="Host IP address")
     parser.add_argument("--port", type=int, default=6969, help="Port number")
-    parser.add_argument("--log-level", type=str, default="debug", help="Logging level")
+    parser.add_argument("--log-level", type=str, default=None, help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    parser.add_argument("--disable-access-logs", action="store_true", help="Disable HTTP access logs")
     args = parser.parse_args()
 
-    # Sync root logger level with CLI argument
-    logging.getLogger().setLevel(args.log_level.upper())
+    # Resolve configuration options
+    resolved_level, resolved_disable_access = resolve_logging_config(args.log_level, args.disable_access_logs)
+
+    # Setup logging
+    setup_logging(resolved_level, resolved_disable_access)
+
+    # 4. Import app.main now that the standard root logger handlers are set up
+    from app.main import app as webai_app
 
     print("INFO:     Checking Gemini service availability...")
     # Preflight gate: only start the server when Gemini is enabled in config.
@@ -140,6 +194,7 @@ if __name__ == "__main__":
         port=args.port,
         reload=False,
         log_config=None,
-        log_level=args.log_level,
+        log_level=resolved_level.lower(),
+        access_log=not resolved_disable_access,
         workers=1,
     )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -53,3 +53,9 @@ def test_fallback_logger_works_on_import():
     from app.logger import logger
     assert logger.name == "app"
     assert len(logging.getLogger().handlers) > 0
+
+def test_custom_logging_levels():
+    # Verify SUCCESS (25) and TRACE (5) levels are registered in standard logging
+    assert logging.getLevelName(25) == "SUCCESS"
+    assert logging.getLevelName(5) == "TRACE"
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,7 +4,8 @@ import logging
 from unittest import mock
 import pytest
 
-from run import resolve_logging_config, setup_logging
+from run import resolve_logging_config
+from app.logger import setup_logging
 
 def test_default_log_level_is_info():
     # Clear environment variables to test default fallback

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,55 @@
+# File: tests/test_logging.py
+import os
+import logging
+from unittest import mock
+import pytest
+
+from run import resolve_logging_config, setup_logging
+
+def test_default_log_level_is_info():
+    # Clear environment variables to test default fallback
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with mock.patch("app.config.CONFIG.has_section", return_value=False):
+            level, disable_access = resolve_logging_config(None, False)
+            assert level == "INFO"
+            assert disable_access is False
+
+def test_cli_overrides_env_and_config():
+    with mock.patch.dict(os.environ, {"LOG_LEVEL": "WARNING", "DISABLE_ACCESS_LOGS": "true"}):
+        with mock.patch("app.config.CONFIG.has_section", return_value=True):
+            with mock.patch("app.config.CONFIG.get", return_value="ERROR"):
+                with mock.patch("app.config.CONFIG.getboolean", return_value=True):
+                    # Explicit CLI value overrides
+                    level, disable_access = resolve_logging_config("DEBUG", False)
+                    assert level == "DEBUG"
+                    # Note: resolved_disable_access resolves to True because (CLI: False OR Env: True OR Config: True) is True
+                    assert disable_access is True
+
+def test_env_overrides_config():
+    with mock.patch.dict(os.environ, {"LOG_LEVEL": "WARNING", "DISABLE_ACCESS_LOGS": "true"}):
+        with mock.patch("app.config.CONFIG.has_section", return_value=True):
+            with mock.patch("app.config.CONFIG.get", return_value="ERROR"):
+                with mock.patch("app.config.CONFIG.getboolean", return_value=False):
+                    # With no CLI arg, Env takes precedence over Config
+                    level, disable_access = resolve_logging_config(None, False)
+                    assert level == "WARNING"
+                    assert disable_access is True
+
+def test_loguru_debug_suppressed_at_info():
+    # Set logging to INFO
+    setup_logging("INFO", False)
+    
+    # Assert that gemini_webapi logger is NOT enabled for DEBUG
+    assert not logging.getLogger("gemini_webapi").isEnabledFor(logging.DEBUG)
+    
+    # Set logging to DEBUG
+    setup_logging("DEBUG", False)
+    
+    # Assert that gemini_webapi logger IS enabled for DEBUG
+    assert logging.getLogger("gemini_webapi").isEnabledFor(logging.DEBUG)
+
+def test_fallback_logger_works_on_import():
+    # Ensure standard fallback logger works for tests and utility imports
+    from app.logger import logger
+    assert logger.name == "app"
+    assert len(logging.getLogger().handlers) > 0


### PR DESCRIPTION
## Summary

This PR consolidates runtime logging configuration into a single logging module, introduces configurable log verbosity and access log controls, and improves Docker runtime behavior by aligning container logging with the application's configuration precedence model.

## Key Changes

* **Unified Logging Setup**

  * Moved runtime logging initialization into `src/app/logger.py`.
  * Added Loguru integration so `gemini_webapi` logs follow the application's logging configuration.
  * Registered Loguru custom levels (`SUCCESS`, `TRACE`) in standard Python logging.

* **Configurable Logging**

  * Added a `[Logging]` section to `config.conf.example`.
  * Added support for log level and access log configuration using:

    * CLI arguments
    * Environment variables
    * Optional `[Logging]` configuration section
  * Logging resolution order:

    * CLI arguments
    * Environment variables
    * Configuration file
    * Defaults

* **Docker Runtime Improvements**

  * Removed the hardcoded `--log-level info` argument from the Docker image startup command.
  * Added `LOG_LEVEL` and `DISABLE_ACCESS_LOGS` environment variable support in `docker-compose.yml`.
  * Allows runtime log configuration without rebuilding the image.

* **Documentation**

  * Added logging configuration documentation to:

    * `docs/configuration.md`
    * `docs/docker.md`
  * Added a configuration guide reference in `README.md`.

* **Tests**

  * Added `tests/test_logging.py`.
  * Covers:

    * configuration precedence
    * default log level behavior
    * custom level registration
    * fallback logger initialization

## Testing

* Tests run:

  * `pytest tests/test_logging.py`

* Result:

  * Passed

## Notes

* Default log level is now `INFO`.
* Debug logging can be enabled using:

  * `--log-level debug`
  * `LOG_LEVEL=DEBUG`
* HTTP access logs remain enabled by default and can be disabled independently.
