### PR TITLE
Refactor startup ownership and logging configuration resolution

### DIFF
--- a/src/app/config.py
+++ b/src/app/config.py
@@ -106,3 +106,25 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
 
 # Load configuration globally
 CONFIG = load_config()
+
+
+def resolve_logging_config(
+    cli_log_level: str | None,
+    cli_disable_access_logs: bool,
+    config: configparser.ConfigParser | None = None,
+) -> tuple[str, bool]:
+    """Resolves log level and access log settings based on CLI, env, and config precedence."""
+    config = config or CONFIG
+
+    # 1. Resolve log level precedence: explicit CLI > LOG_LEVEL env > config.conf > INFO
+    env_log_level = os.environ.get("LOG_LEVEL")
+    conf_log_level = config.get("Logging", "level", fallback=None) if config.has_section("Logging") else None
+    resolved_level = cli_log_level or env_log_level or conf_log_level or "INFO"
+
+    # 2. Resolve access logs precedence: explicit CLI --disable-access-logs > DISABLE_ACCESS_LOGS env > config.conf > false
+    env_disable_access = os.environ.get("DISABLE_ACCESS_LOGS", "false").lower() in ("true", "1", "yes", "on")
+    conf_disable_access = config.getboolean("Logging", "disable_access_logs", fallback=False) if config.has_section("Logging") else False
+    resolved_disable_access = cli_disable_access_logs or env_disable_access or conf_disable_access
+
+    return resolved_level, resolved_disable_access
+

--- a/src/app/utils/startup.py
+++ b/src/app/utils/startup.py
@@ -1,0 +1,102 @@
+# src/app/utils/startup.py
+import sys
+from typing import Tuple
+
+# Import tomli to read pyproject.toml
+try:
+    import tomli
+except ImportError:
+    # For Python 3.11+, tomllib is in the standard library
+    try:
+        import tomllib as tomli
+    except ImportError:
+        tomli = None
+
+
+# Helper class for terminal colors
+class Colors:
+    """A class to hold ANSI color codes for terminal output, dynamically checking TTY support."""
+
+    _use_color = sys.stdout.isatty() if hasattr(sys.stdout, "isatty") else False
+
+    YELLOW = "\033[93m" if _use_color else ""
+    GREEN = "\033[92m" if _use_color else ""
+    CYAN = "\033[96m" if _use_color else ""
+    MAGENTA = "\033[95m" if _use_color else ""
+    RED = "\033[91m" if _use_color else ""
+    RESET = "\033[0m" if _use_color else ""
+    BOLD = "\033[1m" if _use_color else ""
+
+
+def _read_project_metadata() -> Tuple[str, str]:
+    """Read the project name and version from pyproject metadata."""
+    if not tomli:
+        return "WebAI to API", "N/A (tomli not installed)"
+
+    try:
+        with open("pyproject.toml", "rb") as f:
+            toml_data = tomli.load(f)
+
+        project_data = toml_data.get("project", {})
+        poetry_data = toml_data.get("tool", {}).get("poetry", {})
+
+        name = project_data.get("name") or poetry_data.get("name", "WebAI-to-API")
+        version = project_data.get("version") or poetry_data.get("version", "N/A")
+        return name.replace("-", " ").title(), version
+    except (FileNotFoundError, KeyError, TypeError):
+        return "WebAI-to-API", "N/A"
+
+
+def get_app_info() -> Tuple[str, str]:
+    """Reads application name and version from pyproject.toml."""
+    return _read_project_metadata()
+
+
+def print_server_info(host: str, port: int, mode: str, default_model: str | None = None):
+    """Displays complete, formatted information about the running server."""
+    protocol = "http"
+    base_url = f"{protocol}://{host}:{port}"
+    app_name, app_version = get_app_info()
+    app_info_line = f"{app_name} v{app_version}".center(80)
+    print("\n" + "=" * 80)
+    print(f"{Colors.BOLD}{Colors.YELLOW}{app_info_line}{Colors.RESET}")
+    if mode == "webai":
+        print("WebAI-to-API Server is RUNNING".center(80))
+        print("=" * 80)
+        print("\n✨ Available Services:")
+        print(f"  - Dashboard:      {base_url}/ui")
+        print(f"  - Docs (Swagger): {base_url}/docs")
+        print("\n⚙️ Config.conf:")
+        if default_model:
+            print(f"  - Default Model: {default_model}")
+        else:
+            print("  - Could not load config details.")
+        print("\n🔗 Primary APIs:")
+        print(f"  - POST {base_url}/v1/chat/completions")
+        print(f"  - POST {base_url}/translate")
+        print(f"  - POST {base_url}/v1beta/models/{{model_path:path}}")
+        print("\n🔗 Useful Endpoints:")
+        print(f"  - GET  {base_url}/v1/models")
+        print(f"  - GET  {base_url}/v1/auth/status")
+        print(f"  - POST {base_url}/v1/auth/login")
+    print("\n" + "=" * 80)
+    instruction_text = "Press Ctrl+C to Quit"
+    colored_instructions = (
+        f"{Colors.BOLD}{Colors.YELLOW}{instruction_text.center(80)}{Colors.RESET}"
+    )
+    print(colored_instructions)
+    print("=" * 80)
+
+
+def print_gemini_preflight_status(enabled: bool) -> None:
+    """Prints the availability check message during startup preflight."""
+    print("INFO:     Checking Gemini service availability...")
+    if enabled:
+        print(
+            f"INFO:     {Colors.GREEN}✅ Gemini service is enabled; starting WebAI-to-API server.{Colors.RESET}"
+        )
+    else:
+        print(
+            f"WARN:     {Colors.YELLOW}⚠️ WebAI-to-API mode is not available (Gemini is disabled in config).{Colors.RESET}"
+        )
+        print(f"\n{Colors.RED}ERROR:    Gemini service is disabled. Exiting.{Colors.RESET}")

--- a/src/run.py
+++ b/src/run.py
@@ -1,31 +1,12 @@
 # src/run.py
 import argparse
 import asyncio
-import logging
-import os
 import sys
 import uvicorn
-from typing import Tuple
-from fastapi.routing import APIRoute
-
 # --- App and Service Imports ---
-from app.config import CONFIG
+from app.config import CONFIG, resolve_logging_config
 from app.utils.startup import print_server_info, print_gemini_preflight_status
 
-
-def resolve_logging_config(cli_log_level: str | None, cli_disable_access_logs: bool) -> Tuple[str, bool]:
-    """Resolves log level and access log settings based on CLI, env, and config precedence."""
-    # 1. Resolve log level precedence: explicit CLI > LOG_LEVEL env > config.conf > INFO
-    env_log_level = os.environ.get("LOG_LEVEL")
-    conf_log_level = CONFIG.get("Logging", "level", fallback=None) if CONFIG.has_section("Logging") else None
-    resolved_level = cli_log_level or env_log_level or conf_log_level or "INFO"
-
-    # 2. Resolve access logs precedence: explicit CLI --disable-access-logs > DISABLE_ACCESS_LOGS env > config.conf > false
-    env_disable_access = os.environ.get("DISABLE_ACCESS_LOGS", "false").lower() in ("true", "1", "yes", "on")
-    conf_disable_access = CONFIG.getboolean("Logging", "disable_access_logs", fallback=False) if CONFIG.has_section("Logging") else False
-    resolved_disable_access = cli_disable_access_logs or env_disable_access or conf_disable_access
-
-    return resolved_level, resolved_disable_access
 
 
 # --- Main Execution Block ---
@@ -50,7 +31,7 @@ if __name__ == "__main__":
     from app.logger import setup_logging
     setup_logging(resolved_level, resolved_disable_access)
 
-    # 4. Import app.main now that the standard root logger handlers are set up
+    # Import app.main now that the root logger is configured
     from app.main import app as webai_app
 
     # Preflight gate: only start the server when Gemini is enabled in config.

--- a/src/run.py
+++ b/src/run.py
@@ -8,96 +8,9 @@ import uvicorn
 from typing import Tuple
 from fastapi.routing import APIRoute
 
-# Import tomli to read pyproject.toml
-try:
-    import tomli
-except ImportError:
-    # For Python 3.11+, tomllib is in the standard library
-    try:
-        import tomllib as tomli
-    except ImportError:
-        tomli = None
-
 # --- App and Service Imports ---
-from app.config import load_config, CONFIG
-
-
-def _read_project_metadata() -> Tuple[str, str]:
-    """Read the project name and version from pyproject metadata."""
-    if not tomli:
-        return "WebAI to API", "N/A (tomli not installed)"
-
-    try:
-        with open("pyproject.toml", "rb") as f:
-            toml_data = tomli.load(f)
-
-        project_data = toml_data.get("project", {})
-        poetry_data = toml_data.get("tool", {}).get("poetry", {})
-
-        name = project_data.get("name") or poetry_data.get("name", "WebAI-to-API")
-        version = project_data.get("version") or poetry_data.get("version", "N/A")
-        return name.replace("-", " ").title(), version
-    except (FileNotFoundError, KeyError, TypeError):
-        return "WebAI-to-API", "N/A"
-
-
-# Helper class for terminal colors
-class Colors:
-    """A class to hold ANSI color codes for terminal output, dynamically checking TTY support."""
-
-    _use_color = sys.stdout.isatty() if hasattr(sys.stdout, "isatty") else False
-
-    YELLOW = "\033[93m" if _use_color else ""
-    GREEN = "\033[92m" if _use_color else ""
-    CYAN = "\033[96m" if _use_color else ""
-    MAGENTA = "\033[95m" if _use_color else ""
-    RED = "\033[91m" if _use_color else ""
-    RESET = "\033[0m" if _use_color else ""
-    BOLD = "\033[1m" if _use_color else ""
-
-
-# --- Helper function to get app info ---
-def get_app_info() -> Tuple[str, str]:
-    """Reads application name and version from pyproject.toml."""
-    return _read_project_metadata()
-
-
-# --- Helper Function for Printing Info ---
-def print_server_info(host: str, port: int, mode: str):
-    """Displays complete, formatted information about the running server."""
-    protocol = "http"
-    base_url = f"{protocol}://{host}:{port}"
-    app_name, app_version = get_app_info()
-    app_info_line = f"{app_name} v{app_version}".center(80)
-    print("\n" + "=" * 80)
-    print(f"{Colors.BOLD}{Colors.YELLOW}{app_info_line}{Colors.RESET}")
-    if mode == "webai":
-        print("WebAI-to-API Server is RUNNING".center(80))
-        print("=" * 80)
-        print("\n✨ Available Services:")
-        print(f"  - Dashboard:      {base_url}/ui")
-        print(f"  - Docs (Swagger): {base_url}/docs")
-        print("\n⚙️ Config.conf:")
-        try:
-            CONFIG = load_config()
-            print(f"  - Default Model: {CONFIG['Gemini']['default_model']}")
-        except Exception:
-            print("  - Could not load config details.")
-        print("\n🔗 Primary APIs:")
-        print(f"  - POST {base_url}/v1/chat/completions")
-        print(f"  - POST {base_url}/translate")
-        print(f"  - POST {base_url}/v1beta/models/{{model_path:path}}")
-        print("\n🔗 Useful Endpoints:")
-        print(f"  - GET  {base_url}/v1/models")
-        print(f"  - GET  {base_url}/v1/auth/status")
-        print(f"  - POST {base_url}/v1/auth/login")
-    print("\n" + "=" * 80)
-    instruction_text = "Press Ctrl+C to Quit"
-    colored_instructions = (
-        f"{Colors.BOLD}{Colors.YELLOW}{instruction_text.center(80)}{Colors.RESET}"
-    )
-    print(colored_instructions)
-    print("=" * 80)
+from app.config import CONFIG
+from app.utils.startup import print_server_info, print_gemini_preflight_status
 
 
 def resolve_logging_config(cli_log_level: str | None, cli_disable_access_logs: bool) -> Tuple[str, bool]:
@@ -140,24 +53,15 @@ if __name__ == "__main__":
     # 4. Import app.main now that the standard root logger handlers are set up
     from app.main import app as webai_app
 
-    print("INFO:     Checking Gemini service availability...")
     # Preflight gate: only start the server when Gemini is enabled in config.
     webai_is_available = CONFIG.getboolean("EnabledAI", "gemini", fallback=True)
-    if webai_is_available:
-        print(
-            f"INFO:     {Colors.GREEN}✅ Gemini service is enabled; starting WebAI-to-API server.{Colors.RESET}"
-        )
-    else:
-        print(
-            f"WARN:     {Colors.YELLOW}⚠️ WebAI-to-API mode is not available (Gemini is disabled in config).{Colors.RESET}"
-        )
-
+    print_gemini_preflight_status(webai_is_available)
     if not webai_is_available:
-        print(f"\n{Colors.RED}ERROR:    Gemini service is disabled. Exiting.{Colors.RESET}")
         sys.exit(1)
 
     # Print server information summary banner
-    print_server_info(args.host, args.port, "webai")
+    default_model = CONFIG.get("Gemini", "default_model", fallback=None)
+    print_server_info(args.host, args.port, "webai", default_model=default_model)
 
     # Run the Uvicorn server directly in the main thread
     uvicorn.run(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,40 +1,45 @@
 # File: tests/test_logging.py
 import os
 import logging
+import configparser
 from unittest import mock
 import pytest
 
-from run import resolve_logging_config
+from app.config import resolve_logging_config
 from app.logger import setup_logging
 
 def test_default_log_level_is_info():
     # Clear environment variables to test default fallback
     with mock.patch.dict(os.environ, {}, clear=True):
-        with mock.patch("app.config.CONFIG.has_section", return_value=False):
-            level, disable_access = resolve_logging_config(None, False)
-            assert level == "INFO"
-            assert disable_access is False
+        test_config = configparser.ConfigParser()
+        level, disable_access = resolve_logging_config(None, False, config=test_config)
+        assert level == "INFO"
+        assert disable_access is False
 
 def test_cli_overrides_env_and_config():
     with mock.patch.dict(os.environ, {"LOG_LEVEL": "WARNING", "DISABLE_ACCESS_LOGS": "true"}):
-        with mock.patch("app.config.CONFIG.has_section", return_value=True):
-            with mock.patch("app.config.CONFIG.get", return_value="ERROR"):
-                with mock.patch("app.config.CONFIG.getboolean", return_value=True):
-                    # Explicit CLI value overrides
-                    level, disable_access = resolve_logging_config("DEBUG", False)
-                    assert level == "DEBUG"
-                    # Note: resolved_disable_access resolves to True because (CLI: False OR Env: True OR Config: True) is True
-                    assert disable_access is True
+        test_config = configparser.ConfigParser()
+        test_config.add_section("Logging")
+        test_config.set("Logging", "level", "ERROR")
+        test_config.set("Logging", "disable_access_logs", "true")
+        
+        # Explicit CLI value overrides
+        level, disable_access = resolve_logging_config("DEBUG", False, config=test_config)
+        assert level == "DEBUG"
+        assert disable_access is True
 
 def test_env_overrides_config():
     with mock.patch.dict(os.environ, {"LOG_LEVEL": "WARNING", "DISABLE_ACCESS_LOGS": "true"}):
-        with mock.patch("app.config.CONFIG.has_section", return_value=True):
-            with mock.patch("app.config.CONFIG.get", return_value="ERROR"):
-                with mock.patch("app.config.CONFIG.getboolean", return_value=False):
-                    # With no CLI arg, Env takes precedence over Config
-                    level, disable_access = resolve_logging_config(None, False)
-                    assert level == "WARNING"
-                    assert disable_access is True
+        test_config = configparser.ConfigParser()
+        test_config.add_section("Logging")
+        test_config.set("Logging", "level", "ERROR")
+        test_config.set("Logging", "disable_access_logs", "false")
+        
+        # With no CLI arg, Env takes precedence over Config
+        level, disable_access = resolve_logging_config(None, False, config=test_config)
+        assert level == "WARNING"
+        assert disable_access is True
+
 
 def test_loguru_debug_suppressed_at_info():
     # Set logging to INFO


### PR DESCRIPTION
## Summary

Refactors startup-related responsibilities to improve ownership boundaries, modularity, and testability.

The runtime entrypoint (`src/run.py`) is now a thinner orchestration layer, while logging configuration resolution and startup presentation concerns have been moved into their respective modules.

## Key Changes

* Moved `resolve_logging_config()` from `src/run.py` to `src/app/config.py`.
* Updated `resolve_logging_config()` to accept an optional configuration object, reducing reliance on global state and simplifying testing.
* Extracted startup presentation utilities from `src/run.py` into `src/app/utils/startup.py`:

  * application metadata helpers
  * TTY-aware terminal colors
  * startup banner rendering
  * Gemini preflight status output
* Simplified `src/run.py` so it primarily handles:

  * CLI parsing
  * runtime bootstrapping
  * logging initialization
  * delayed application import
  * preflight orchestration
  * Uvicorn startup
* Removed unused imports and startup helper implementations from the entrypoint.
* Updated `tests/test_logging.py` to import `resolve_logging_config()` from `app.config` and use dedicated `ConfigParser` instances where appropriate.

## Testing

* Tests run: `pytest`
* Result: `406 passed`

## Notes

This is a behavior-preserving refactor focused on ownership and maintainability.

Logging configuration resolution now belongs to the configuration domain, startup presentation belongs to dedicated startup utilities, and the runtime entrypoint is reduced to orchestration responsibilities.
