### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Interactive API documentation is available through Swagger UI when the server is
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Amm1rr/WebAI-to-API\&type=Date)](https://www.star-history.com/#Amm1rr/WebAI-to-API&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Amm1rr/WebAI-to-API\&type=Date)](https://star-history.dera.page/#Amm1rr/WebAI-to-API&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken, as the underlying service no longer works reliably with GitHub's stargazer API restrictions. This change updates the chart image and its link to use a working service so the chart displays correctly for visitors.