### PR TITLE
refactor(translate): enable concurrent stateless requests

### DIFF
--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -9,7 +9,6 @@ from app.openapi.chat_completions import (
 )
 from app.schemas.request import GeminiRequest, OpenAIChatRequest
 from app.services.gemini_client import get_gemini_client, GeminiClientNotInitializedError
-from app.services.providers.gemini.session_manager import get_translate_session_manager
 from app.services.factory import ProviderFactory
 from app.services.model_catalog import list_models as build_model_catalog
 from app.services.providers.gemini.temporary_chat import handle_temporary_chat_completions
@@ -51,7 +50,7 @@ async def list_gems():
     "/translate",
     tags=["Translation"],
     summary="Translate Extension Compatibility",
-    description="Extension-specific translation endpoint retained for compatibility with Translate It!-style browser extensions. This endpoint uses a shared global in-memory session, sends Gemini WebAPI translation requests as temporary requests so they are not saved in Gemini history, has no `conversation_id` support, does not support streaming, and does not survive server restarts. The client is responsible for sending a translation-specific prompt. For isolated or persistent translation workflows, use `/v1/chat/completions`."
+    description="Extension-specific translation endpoint retained for compatibility with Translate It!-style browser extensions. This endpoint executes stateless Gemini WebAPI requests concurrently, sends them as temporary requests so they are not saved in Gemini history, has no `conversation_id` support, does not support streaming, and does not maintain conversation state. The client is responsible for sending a translation-specific prompt. For persistent translation workflows, use `/v1/chat/completions`."
 )
 async def translate_chat(request: GeminiRequest):
     try:
@@ -59,15 +58,12 @@ async def translate_chat(request: GeminiRequest):
     except GeminiClientNotInitializedError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
-    session_manager = get_translate_session_manager()
-    if not session_manager:
-        raise HTTPException(status_code=503, detail="Session manager is not initialized.")
     try:
-        response = await session_manager.get_response(
-            request.model,
+        response = await gemini_client.generate_content(
             request.message,
-            request.files,
-            request.gem,
+            request.model,
+            files=request.files,
+            gem=request.gem,
             temporary=True,
         )
         return {"response": response.text}

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -418,25 +418,21 @@ class SessionRegistry:
                         break
 
 
-# Global instances
-_translate_session_manager = None
+# Global persistent-chat registry.
 _gemini_chat_registry = None
 
 async def init_session_managers():
     """
-    Initialize session managers. 
-    /translate keeps its singleton legacy manager.
-    /gemini-chat moves to the new SessionRegistry.
+    Initialize persistent chat session managers.
     If already initialized, safely updates client references in all active 
     session managers and registries to preserve runtime/concurrency state.
     """
-    global _translate_session_manager, _gemini_chat_registry
+    global _gemini_chat_registry
     try:
         client = get_gemini_client()
         
         # If already initialized, safely update their client references to preserve runtime state
-        if _translate_session_manager is not None and _gemini_chat_registry is not None:
-            _translate_session_manager.client = client
+        if _gemini_chat_registry is not None:
             await _gemini_chat_registry.update_client(client)
             logger.info("Session managers safely updated with new client reference.")
             return
@@ -447,13 +443,9 @@ async def init_session_managers():
             db_path=os.getenv("CONVERSATION_SNAPSHOT_DB", get_default_conversation_snapshot_db())
         )
         repository.initialize_sync()
-        _translate_session_manager = SessionManager(client)
         _gemini_chat_registry = SessionRegistry(client, repository=repository)
     except GeminiClientNotInitializedError:
         logger.warning("Session managers not initialized: Gemini client not available.")
-
-def get_translate_session_manager():
-    return _translate_session_manager
 
 def get_gemini_chat_registry():
     return _gemini_chat_registry

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -99,15 +100,12 @@ async def test_chat_completions_endpoint_atlas(mocker):
 @pytest.mark.asyncio
 async def test_translate_endpoint_uses_temporary_gemini_requests(mocker):
     """Verify /translate forwards Gemini requests with temporary=True."""
-    mock_response = mocker.Mock()
-    mock_response.text = "Translated response"
+    mock_response = SimpleNamespace(text="Translated response")
 
     mock_client = mocker.Mock()
-    mock_session_manager = mocker.Mock()
-    mock_session_manager.get_response = mocker.AsyncMock(return_value=mock_response)
+    mock_client.generate_content = mocker.AsyncMock(return_value=mock_response)
 
     mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
-    mocker.patch("app.endpoints.chat.get_translate_session_manager", return_value=mock_session_manager)
 
     payload = {
         "model": "gemini-3-flash",
@@ -121,13 +119,79 @@ async def test_translate_endpoint_uses_temporary_gemini_requests(mocker):
 
     assert response.status_code == 200
     assert response.json() == {"response": "Translated response"}
-    mock_session_manager.get_response.assert_called_once_with(
-        "gemini-3-flash",
+    mock_client.generate_content.assert_awaited_once_with(
         "Translate this text",
-        [],
-        None,
+        "gemini-3-flash",
+        files=[],
+        gem=None,
         temporary=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_translate_requests_execute_concurrently_and_independently(mocker):
+    """Verify /translate uses independent direct Gemini requests."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def generate_content(message, model, *, files, gem, temporary):
+        calls.append((message, model, files, gem, temporary))
+        if len(calls) == 2:
+            entered.set()
+        await release.wait()
+        return SimpleNamespace(text=f"translated:{message}")
+
+    mock_client = mocker.Mock()
+    mock_client.generate_content = generate_content
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+    mocker.patch(
+        "app.services.providers.gemini.session_manager.SessionManager.get_response",
+        side_effect=AssertionError("/translate must not use SessionManager"),
+    )
+
+    payloads = [
+        {"model": "gemini-3-flash", "message": "alpha", "files": ["a.txt"], "gem": "gem-a"},
+        {"model": "gemini-3-pro", "message": "beta", "files": ["b.txt"], "gem": "gem-b"},
+    ]
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        tasks = [asyncio.create_task(ac.post("/translate", json=payload)) for payload in payloads]
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        release.set()
+        responses = await asyncio.gather(*tasks)
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert [response.json() for response in responses] == [
+        {"response": "translated:alpha"},
+        {"response": "translated:beta"},
+    ]
+    assert sorted(calls) == sorted([
+        ("alpha", "gemini-3-flash", ["a.txt"], "gem-a", True),
+        ("beta", "gemini-3-pro", ["b.txt"], "gem-b", True),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_translate_failure_does_not_block_other_request(mocker):
+    """Verify one direct translation failure does not affect another request."""
+    async def generate_content(message, model, *, files, gem, temporary):
+        if message == "bad":
+            raise RuntimeError("translation failed")
+        return SimpleNamespace(text="good result")
+
+    mock_client = mocker.Mock()
+    mock_client.generate_content = generate_content
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        bad, good = await asyncio.gather(
+            ac.post("/translate", json={"message": "bad"}),
+            ac.post("/translate", json={"message": "good"}),
+        )
+
+    assert bad.status_code == 500
+    assert good.status_code == 200
+    assert good.json() == {"response": "good result"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -43,12 +43,12 @@ async def test_openapi_translate_endpoint_metadata():
     assert translate_path["post"].get("deprecated") is not True
     assert "Translation" in translate_path["post"]["tags"]
     assert "Translate Extension Compatibility" in translate_path["post"]["summary"]
-    assert "shared global in-memory session" in translate_path["post"]["description"]
+    assert "stateless Gemini WebAPI requests concurrently" in translate_path["post"]["description"]
     assert "temporary requests" in translate_path["post"]["description"]
     assert "not saved in Gemini history" in translate_path["post"]["description"]
     assert "no `conversation_id`" in translate_path["post"]["description"]
     assert "does not support streaming" in translate_path["post"]["description"]
-    assert "not survive server restarts" in translate_path["post"]["description"]
+    assert "does not maintain conversation state" in translate_path["post"]["description"]
     assert "/v1/chat/completions" in translate_path["post"]["description"]
 
 


### PR DESCRIPTION
## Summary

Make `/translate` stateless and allow concurrent Gemini requests.

## Changes

* Replace shared `SessionManager` / `ChatSession` with direct `generate_content()` calls.
* Preserve `temporary=True` and existing response contract.
* Remove legacy translation session singleton.
* Keep persistent chat session locking unchanged.
* Update `/translate` OpenAPI description.
* Add concurrency and failure-isolation tests.

## Before

```text
/translate
→ shared SessionManager
→ shared ChatSession
→ global lock
→ serialized generations
```

## After

```text
/translate
→ shared Gemini client
→ independent temporary requests
→ concurrent generations
```

## Validation

* 408 tests passed
* Focused tests passed
* `git diff --check` passed

## Remaining Risk

Concurrent requests share underlying Gemini HTTP client. No mutable `ChatSession` state is shared, but real-client concurrency/load testing remains recommended.
