### PR TITLE
refactor(gemini): use runtime model catalog

### DIFF
--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -18,6 +18,7 @@ from app.config import CONFIG
 from app.services.providers.gemini.shared import build_tools_prompt
 from app.services.providers.gemini.webapi_adapter import GeminiWebAPIAdapter
 from app.services.providers.gemini.playwright_adapter import GeminiPlaywrightAdapter
+from app.services.providers.gemini.client import GeminiClientNotInitializedError, get_gemini_client
 
 class GeminiProvider(BaseProvider):
     """
@@ -122,7 +123,13 @@ class GeminiProvider(BaseProvider):
 
     async def list_models(self, allow_stale: bool = False) -> List[dict]:
         from app.services.providers.gemini.shared import get_gemini_models
-        return get_gemini_models()
+
+        try:
+            runtime_models = get_gemini_client().list_models()
+        except GeminiClientNotInitializedError:
+            runtime_models = None
+
+        return get_gemini_models(runtime_models)
 
     async def close(self) -> None:
         await self.webapi_adapter.close()

--- a/src/app/services/providers/gemini/shared.py
+++ b/src/app/services/providers/gemini/shared.py
@@ -127,24 +127,25 @@ PLAYWRIGHT_GEMINI_MODEL_UI_LABELS = {
 
 PLAYWRIGHT_GEMINI_PROVIDER_NAMESPACE = "playwright/gemini"
 
-def get_gemini_models() -> List[dict]:
-    """Return the canonical list of supported Gemini models in OpenAI format."""
-    from gemini_webapi.constants import Model
+def get_gemini_models(runtime_models: Optional[List[Any]] = None) -> List[dict]:
+    """Return runtime WebAPI models followed by canonical Playwright models."""
     ts = int(time.time())
-    
-    # 1. Standard WebAPI Models
-    models = [
-        {
-            "id": model.model_name,
+
+    models = []
+    seen_ids = set()
+    for model in runtime_models or []:
+        model_id = getattr(model, "model_name", None)
+        if getattr(model, "is_available", False) is not True or not model_id or model_id in seen_ids:
+            continue
+        seen_ids.add(model_id)
+        models.append({
+            "id": model_id,
             "object": "model",
             "created": ts,
             "owned_by": "google",
-        }
-        for model in Model
-        if model != Model.UNSPECIFIED
-    ]
-    
-    # 2. Playwright-native Models
+        })
+
+    # Playwright-native models
     for model_id in PLAYWRIGHT_GEMINI_MODEL_UI_LABELS.keys():
         models.append({
             "id": f"playwright/{model_id}",

--- a/src/app/services/providers/gemini/webapi_client.py
+++ b/src/app/services/providers/gemini/webapi_client.py
@@ -35,6 +35,10 @@ class MyGeminiClient:
         """Resolve a model against upstream's account-discovered catalog."""
         return self.client.resolve_model(model_name)
 
+    def list_models(self):
+        """Return the account-discovered model catalog."""
+        return self.client.list_models()
+
     async def _persist_cookies(self) -> None:
         """
         No-op under unified-auth-state architecture.

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -8,6 +8,17 @@ from app.services.browser.auth_loader import GeminiAuthStateLoader
 from app.services.providers.gemini.auth_selector import GeminiAuthCandidate
 
 
+@pytest.fixture(autouse=True)
+def reset_gemini_client_state():
+    gemini_client_module._gemini_client = None
+    gemini_client_module._initialization_error = None
+    gemini_client_module._gemini_client_auth_source = None
+    yield
+    gemini_client_module._gemini_client = None
+    gemini_client_module._initialization_error = None
+    gemini_client_module._gemini_client_auth_source = None
+
+
 class Status:
     def __init__(self, name):
         self.name = name

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -8,7 +8,7 @@ from app.services.providers.gemini.playwright_adapter import (
     PlaywrightRequestState, 
     PlaywrightAdapterConfig
 )
-from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS
+from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS, get_gemini_models
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.errors import TransientSessionError, GatedModelError, ModelNotFoundError
 from app.services.browser.auth_types import AuthStatus
@@ -263,12 +263,9 @@ async def test_select_model_collision_prevention_flash_vs_lite(adapter, mock_pag
     assert opt_flash.click.call_count == 1
     assert opt_lite.click.call_count == 0
 
-@pytest.mark.asyncio
-async def test_get_gemini_models_discovery_consistency():
-    """Verify that get_gemini_models returns exactly the verified playwright models."""
-    from app.services.providers.gemini.shared import get_gemini_models
-    
-    models = get_gemini_models()
+def test_get_gemini_models_preserves_playwright_models_without_runtime_catalog():
+    """Runtime catalog absence must not remove Playwright models."""
+    models = get_gemini_models(None)
     model_ids = [m["id"] for m in models]
     
     # 1. Verify exactly these models exist

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -8,6 +8,7 @@ from gemini_webapi.exceptions import APIError, AuthError
 from app.services.providers.base_repository import ConversationSnapshot
 from app.services.providers.exceptions import ConversationInUseError
 from app.services.providers.gemini.provider import GeminiProvider
+from app.services.providers.gemini.client import GeminiClientNotInitializedError
 from app.services.providers.gemini.session_manager import SessionRegistry
 from app.services.providers.gemini.webapi_response_builder import (
     build_choice_artifacts,
@@ -33,6 +34,69 @@ def make_delete_snapshot(conversation_id="conv-delete", remote_cid="c_remote_del
         schema_version=1,
         updated_at=datetime.now(timezone.utc),
     )
+
+
+def test_my_gemini_client_exposes_runtime_models(mocker):
+    from app.services.providers.gemini.webapi_client import MyGeminiClient
+
+    client = MyGeminiClient(secure_1psid="test", secure_1psidts="test")
+    client.client.list_models = mocker.Mock(return_value=["runtime-model"])
+
+    assert client.list_models() == ["runtime-model"]
+    client.client.list_models.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_models", [None, []])
+async def test_list_models_without_runtime_catalog_returns_playwright_only(mocker, runtime_models):
+    mocker.patch(
+        "app.services.providers.gemini.provider.get_gemini_client",
+        return_value=SimpleNamespace(list_models=lambda: runtime_models),
+    )
+
+    models = await GeminiProvider().list_models()
+    model_ids = [model["id"] for model in models]
+
+    assert not any(model_id.startswith("gemini-") for model_id in model_ids)
+    assert "playwright/gemini-3.1-pro" in model_ids
+    assert "playwright/gemini/gemini-3.1-pro" in model_ids
+
+
+@pytest.mark.asyncio
+async def test_list_models_filters_unavailable_and_deduplicates_runtime_models(mocker):
+    runtime_models = [
+        SimpleNamespace(model_id="hex-1", model_name="gemini-first", is_available=True, aliases=["alias"]),
+        SimpleNamespace(model_id="hex-2", model_name="gemini-hidden", is_available=False, aliases=[]),
+        SimpleNamespace(model_id="hex-3", model_name="gemini-first", is_available=True, aliases=[]),
+        SimpleNamespace(model_id="hex-4", model_name="gemini-second", is_available=True, aliases=["other"]),
+    ]
+    mocker.patch(
+        "app.services.providers.gemini.provider.get_gemini_client",
+        return_value=SimpleNamespace(list_models=lambda: runtime_models),
+    )
+
+    models = await GeminiProvider().list_models()
+    model_ids = [model["id"] for model in models]
+    runtime_entries = [model for model in models if not model["id"].startswith("playwright/")]
+
+    assert model_ids[:2] == ["gemini-first", "gemini-second"]
+    assert len(runtime_entries) == 2
+    assert "gemini-hidden" not in model_ids
+    assert "hex-1" not in model_ids
+    assert "alias" not in model_ids
+
+
+@pytest.mark.asyncio
+async def test_list_models_handles_uninitialized_runtime_client(mocker):
+    mocker.patch(
+        "app.services.providers.gemini.provider.get_gemini_client",
+        side_effect=GeminiClientNotInitializedError("not initialized"),
+    )
+
+    models = await GeminiProvider().list_models()
+
+    assert any(model["id"] == "playwright/gemini-3.5-flash" for model in models)
+    assert not any(model["id"] == "gemini-pro" for model in models)
 
 
 def make_delete_client(mocker, status_name="AVAILABLE"):

--- a/tests/test_gemini_provider_architecture.py
+++ b/tests/test_gemini_provider_architecture.py
@@ -1,4 +1,5 @@
 import pytest
+from types import SimpleNamespace
 from fastapi import HTTPException
 from app.config import load_config
 from app.services.providers.gemini.provider import GeminiProvider
@@ -18,7 +19,15 @@ def test_invalid_gemini_backend_config_fails_fast(tmp_path):
 
 @pytest.mark.asyncio
 async def test_list_models_stability_across_backends(mocker):
-    """Verify that list_models returns the same list regardless of the configured backend."""
+    """Verify that list_models returns runtime WebAPI and Playwright models."""
+    runtime_models = [
+        SimpleNamespace(model_name="gemini-runtime", is_available=True),
+    ]
+    mocker.patch(
+        "app.services.providers.gemini.provider.get_gemini_client",
+        return_value=SimpleNamespace(list_models=lambda: runtime_models),
+    )
+
     # 1. Test with webapi backend
     mocker.patch("app.services.providers.gemini.provider.CONFIG", {"Gemini": {"backend": "webapi"}})
     provider_webapi = GeminiProvider()
@@ -32,9 +41,8 @@ async def test_list_models_stability_across_backends(mocker):
     # 3. Verify stability
     assert models_webapi == models_playwright
     assert len(models_webapi) > 0
-    assert any("gemini-3" in m["id"] for m in models_webapi)
-    # Ensure it's not just the single "gemini" model from Playwright
-    assert len(models_webapi) > 1
+    assert "gemini-runtime" in [m["id"] for m in models_webapi]
+    assert any(m["id"].startswith("playwright/") for m in models_webapi)
 
 def test_import_graph_safety():
     """Verify that components can be imported without relying on package-level side effects."""


### PR DESCRIPTION
## Summary

Migrate Gemini WebAPI model discovery from deprecated static `Model` enum to `gemini-webapi 2.1.0` runtime catalog.

## Changes

- Add runtime model listing through `MyGeminiClient`.
- Build Gemini WebAPI catalog from account-discovered models.
- Include only available runtime models.
- Deduplicate models by public `model_name`.
- Remove deprecated static `Model` catalog usage.
- Preserve existing Playwright model entries and routing.
- Return Playwright-only catalog when Gemini runtime catalog is unavailable.
- Keep Atlas behavior unchanged.
- Add test isolation for global Gemini client state.

## Behavior

Before:

`/v1/models` could advertise static Gemini models regardless of account availability.

After:

`/v1/models` exposes available models discovered for current Gemini account, while preserving Playwright and other provider entries.

## Validation

- Focused tests: `90 passed`
- Full suite: `419 passed`
- `git diff --check`: passed

## Remaining Scope

Alias catalog redesign and `/translate` invalid-model handling remain separate follow-up work.

Refs: #117