### PR TITLE
fix(translate): validate runtime model before generation

### DIFF
--- a/src/app/endpoints/chat.py
+++ b/src/app/endpoints/chat.py
@@ -12,6 +12,10 @@ from app.services.gemini_client import get_gemini_client, GeminiClientNotInitial
 from app.services.factory import ProviderFactory
 from app.services.model_catalog import list_models as build_model_catalog
 from app.services.providers.gemini.temporary_chat import handle_temporary_chat_completions
+from app.services.providers.gemini.shared import (
+    ensure_gemini_client_ready,
+    validate_direct_webapi_model_name,
+)
 
 router = APIRouter()
 
@@ -59,6 +63,8 @@ async def translate_chat(request: GeminiRequest):
         raise HTTPException(status_code=503, detail=str(e))
 
     try:
+        ensure_gemini_client_ready(gemini_client)
+        validate_direct_webapi_model_name(request.model, gemini_client)
         response = await gemini_client.generate_content(
             request.message,
             request.model,
@@ -67,6 +73,8 @@ async def translate_chat(request: GeminiRequest):
             temporary=True,
         )
         return {"response": response.text}
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in /translate endpoint: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Error during translation: {str(e)}")

--- a/src/app/services/providers/gemini/shared.py
+++ b/src/app/services/providers/gemini/shared.py
@@ -35,6 +35,50 @@ def validate_model_name(model: Optional[str], gemini_client: Any = None) -> None
             raise HTTPException(status_code=400, detail=str(e)) from e
         raise
 
+
+def validate_direct_webapi_model_name(model: Optional[str], gemini_client: Any) -> None:
+    """Validate a model for direct WebAPI endpoints without provider routing."""
+    if not model:
+        return
+
+    resolved_model = resolve_model_name(model)
+    if "/" in resolved_model:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{model}' is not supported by the Gemini WebAPI endpoint.",
+        )
+
+    try:
+        gemini_client.resolve_model(resolved_model)
+    except ValueError as e:
+        if is_unknown_model_error(e):
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        raise
+
+
+def ensure_gemini_client_ready(
+    gemini_client: Any,
+    *,
+    unauthenticated_detail: Optional[str] = None,
+) -> None:
+    """Raise the standard HTTP error for a non-ready Gemini client."""
+    account_status = getattr(gemini_client.client, "account_status", None)
+    status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
+    if status_name == "AVAILABLE":
+        return
+
+    logger.warning(f"Gemini client account status is '{status_name}'.")
+    if status_name == "UNAUTHENTICATED":
+        raise HTTPException(
+            status_code=401,
+            detail=unauthenticated_detail or "Gemini authentication is required. Please sign in and try again.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    raise HTTPException(
+        status_code=401 if status_name == "UNKNOWN" else 503,
+        detail=f"Gemini client is not ready (status: {status_name}).",
+    )
+
 def build_tools_prompt(tools: list) -> str:
     """Convert OpenAI tool definitions to a system prompt for Gemini."""
     declarations = []

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -19,6 +19,7 @@ from app.services.providers.exceptions import (
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
 from app.services.providers.gemini.shared import (
     convert_to_openai_format,
+    ensure_gemini_client_ready,
     parse_tool_call,
     validate_model_name,
     UNRECOVERABLE_CONVERSATION_ERROR_CODES
@@ -51,20 +52,13 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
         except GeminiClientNotInitializedError as e:
             raise HTTPException(status_code=503, detail=str(e))
 
-        account_status = getattr(gemini_client.client, "account_status", None)
-        status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
-        if status_name != "AVAILABLE":
-            logger.warning(f"Gemini client account status is '{status_name}'.")
-            if status_name == "UNAUTHENTICATED":
-                raise HTTPException(
-                    status_code=401,
-                    detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-            raise HTTPException(
-                status_code=401 if status_name == "UNKNOWN" else 503,
-                detail=f"Gemini client is not ready (status: {status_name}).",
-            )
+        ensure_gemini_client_ready(
+            gemini_client,
+            unauthenticated_detail=(
+                "The provided conversation_id requires an authenticated Gemini session. "
+                "Please sign in and try again."
+            ),
+        )
 
         return gemini_client
 
@@ -319,22 +313,13 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
             cleanup_started = True
             await cleanup_staged_files(normalized)
 
-        # Check client authentication status
-        account_status = getattr(gemini_client.client, "account_status", None)
-        status_name = getattr(account_status, "name", "UNKNOWN") if account_status else "UNKNOWN"
-        
-        if status_name != "AVAILABLE":
-            logger.warning(f"Gemini client account status is '{status_name}'.")
-            if status_name == "UNAUTHENTICATED":
-                raise HTTPException(
-                    status_code=401,
-                    detail="The provided conversation_id requires an authenticated Gemini session. Please sign in and try again.",
-                    headers={"WWW-Authenticate": "Bearer"},
-                )
-            raise HTTPException(
-                status_code=401 if status_name == "UNKNOWN" else 503,
-                detail=f"Gemini client is not ready (status: {status_name}).",
-            )
+        ensure_gemini_client_ready(
+            gemini_client,
+            unauthenticated_detail=(
+                "The provided conversation_id requires an authenticated Gemini session. "
+                "Please sign in and try again."
+            ),
+        )
 
         validate_model_name(request.model, gemini_client)
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient, ASGITransport
 from app.main import app
 from app.services.factory import ProviderFactory
 from app.services.providers.gemini.provider import GeminiProvider
+from app.services.providers.gemini.client import GeminiClientNotInitializedError
 from app.services.providers.atlas import AtlasProvider
 
 @pytest.mark.asyncio
@@ -103,6 +104,7 @@ async def test_translate_endpoint_uses_temporary_gemini_requests(mocker):
     mock_response = SimpleNamespace(text="Translated response")
 
     mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
     mock_client.generate_content = mocker.AsyncMock(return_value=mock_response)
 
     mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
@@ -129,6 +131,100 @@ async def test_translate_endpoint_uses_temporary_gemini_requests(mocker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["unknown-model", "playwright/gemini-3.1-pro", "atlas/model"])
+async def test_translate_rejects_invalid_direct_webapi_models_before_generation(mocker, model):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    if "/" not in model:
+        mock_client.resolve_model.side_effect = ValueError(f"Unknown model name: {model}")
+    mock_client.generate_content = mocker.AsyncMock()
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/translate", json={"model": model, "message": "Translate this text"})
+
+    assert response.status_code == 400
+    mock_client.generate_content.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "resolved_model"),
+    [("flash", "gemini-3-flash"), ("pro", "gemini-3-pro"), ("thinking", "gemini-3-flash-thinking")],
+)
+async def test_translate_validates_and_preserves_aliases(mocker, model, resolved_model):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_client.resolve_model.return_value = SimpleNamespace(model_name=resolved_model)
+    mock_client.generate_content = mocker.AsyncMock(return_value=SimpleNamespace(text="translated"))
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/translate", json={"model": model, "message": "Translate this text"})
+
+    assert response.status_code == 200
+    mock_client.resolve_model.assert_called_once_with(resolved_model)
+    mock_client.generate_content.assert_awaited_once_with(
+        "Translate this text",
+        model,
+        files=[],
+        gem=None,
+        temporary=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_translate_client_unavailable_precedes_model_validation(mocker):
+    mocker.patch(
+        "app.endpoints.chat.get_gemini_client",
+        side_effect=GeminiClientNotInitializedError("client unavailable"),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/translate", json={"model": "unknown-model", "message": "Translate this text"})
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_name", "expected_status"),
+    [("UNAUTHENTICATED", 401), ("BLOCKED", 503)],
+)
+async def test_translate_readiness_precedes_model_validation(mocker, status_name, expected_status):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = status_name
+    mock_client.resolve_model = mocker.Mock()
+    mock_client.generate_content = mocker.AsyncMock()
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/translate", json={"model": "unknown-model", "message": "Translate this text"})
+
+    assert response.status_code == expected_status
+    if status_name == "UNAUTHENTICATED":
+        assert response.json()["detail"] == "Gemini authentication is required. Please sign in and try again."
+        assert "conversation_id" not in response.json()["detail"]
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+    mock_client.resolve_model.assert_not_called()
+    mock_client.generate_content.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_translate_non_model_value_error_remains_500(mocker):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_client.resolve_model.return_value = SimpleNamespace(model_name="gemini-3-flash")
+    mock_client.generate_content = mocker.AsyncMock(side_effect=ValueError("generation failed"))
+    mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.post("/translate", json={"message": "Translate this text"})
+
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
 async def test_translate_requests_execute_concurrently_and_independently(mocker):
     """Verify /translate uses independent direct Gemini requests."""
     entered = asyncio.Event()
@@ -143,6 +239,7 @@ async def test_translate_requests_execute_concurrently_and_independently(mocker)
         return SimpleNamespace(text=f"translated:{message}")
 
     mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
     mock_client.generate_content = generate_content
     mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
     mocker.patch(
@@ -180,6 +277,7 @@ async def test_translate_failure_does_not_block_other_request(mocker):
         return SimpleNamespace(text="good result")
 
     mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
     mock_client.generate_content = generate_content
     mocker.patch("app.endpoints.chat.get_gemini_client", return_value=mock_client)
 


### PR DESCRIPTION
## Summary

Add runtime model validation and Gemini readiness checks to `/translate`.

## Changes

- Validate models against Gemini runtime catalog before generation.
- Return `400` for unknown or unsupported direct WebAPI models.
- Reject provider-prefixed models such as `playwright/...` and `atlas/...`.
- Preserve `flash`, `pro`, and `thinking` aliases.
- Check Gemini auth/readiness before model validation.
- Return `401/503` for non-ready clients before model errors.
- Avoid activity sync, file upload, gem lookup, and generation for invalid models.
- Share Gemini readiness logic with `/v1/chat/completions`.
- Preserve existing chat-specific authentication error contract.
- Keep `/translate` stateless and concurrent.

## Error Precedence

`client → readiness/auth → model validation → generation`

## Validation

- Focused tests: `113 passed`
- Full suite: `429 passed`
- `git diff --check`: passed