### PR TITLE
fix(browser): harden shutdown, recovery, and request lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ This document specifies the architectural governance, runtime contracts, and ope
 The system operates according to a strict ownership hierarchy and state machine.
 
 ### 2.1 Component Hierarchy
-1. **BrowserEngine**: Global singleton. Authoritative orchestrator for the core Chromium process and coordinator for terminal shutdown.
-2. **ProviderSession**: Created per provider (Gemini, etc.). Authoritative owner of the `BrowserContext`, the `keepalive_page`, and session-scoped recovery logic (context recreation, tab invalidation).
+1. **BrowserEngine**: Global singleton. Authoritative owner of Playwright, Browser, browser generation, shutdown intent/source, provider-session registry, and terminal orchestration.
+2. **ProviderSession**: Created per provider (Gemini, etc.). Authoritative owner of the `BrowserContext`, `keepalive_page`, PersistentTabs/pages, lifecycle tasks, active-request abort/signal handles, and session-scoped recovery logic.
 3. **AuthManager**: Provider-agnostic orchestrator for authentication lifecycle, concurrency locks, and background login tasks.
 4. **ManagedPage**: Request-scoped resource container. Authoritatively owns exactly one semaphore permit and one `PersistentTab` lease.
 5. **PersistentTab**: Long-lived browser page in the session registry. Owns its individual `_lock` and internal state.
@@ -46,10 +46,11 @@ The system operates according to a strict ownership hierarchy and state machine.
 To prevent deadlocks, locks must be acquired strictly in this order. Acquiring out-of-order is strictly forbidden:
 1. `BrowserEngine.management_lock` (Global orchestration)
 2. `ProviderSession.init_lock` (Session setup/recovery)
-3. `ProviderSession.registry_lock` (Synchronous registry mutations only)
-4. `PersistentTab._lock` (Individual tab operations)
+3. `ProviderSession._cleanup_lock` (Serialized session cleanup)
+4. `ProviderSession.registry_lock` (Synchronous registry mutations only)
+5. `PersistentTab._lock` (Individual tab operations)
 
-**Discipline**: `registry_lock` must NEVER be held across `await` points or long-running Playwright operations. Violating this scope discipline risks global request starvation.
+**Discipline**: `registry_lock` must NEVER be held across `await` points or long-running Playwright operations. `close_resources()` must not acquire `init_lock`; no production `init_lock` → `management_lock` path exists. Violating this scope discipline risks global request starvation.
 
 ### 3.2 Semaphore & Lease Semantics
 - **Exclusivity**: Active browser operations require a valid lease on a `PersistentTab`.
@@ -72,13 +73,14 @@ Providers must implement:
 - **Ordered Processing**: Bridge events for a single `request_id` must be processed in strict FIFO order.
 - **Failure Isolation**: Bounded queue overflow or request-level errors result in terminal request failure but must not poison the broader `ProviderSession`.
 - **Bridge Cleanup**: Request-scoped bridge state MUST be deterministically removed after stream termination.
+- **Post-Header Terminal Streams**: Expected `BrowserDisconnectedError` and `BrowserShuttingDownError` must be handled inside the stream iterator after SSE headers are sent; do not let them escape to ASGI or emit `[DONE]` for terminal truncation.
 
 ---
 
 ## 5. Failure & Recovery Boundaries
 
 - **Self-Healing (Recoverable)**: Transient transport or UI errors (timeouts, selector fails) trigger session-scoped recovery. Providers identify and escalate these conditions; `ProviderSession` executes the authoritative recovery.
-- **Terminal Shutdown (Non-Recoverable)**: Manual window closure or global disconnect triggers irreversible engine shutdown via `BrowserEngine`.
+- **Terminal Shutdown (Non-Recoverable)**: Manual window closure or global disconnect triggers irreversible engine shutdown via `BrowserEngine`; application shutdown intent suppresses duplicate crash orchestration while still terminating active browser operations.
 - **Window Liveness**: `browser.is_connected()` is NOT an authoritative signal for visible window liveness. Runtime components MUST verify `keepalive_page.is_closed()`.
 - **Poisoned Pages**: Crashed or corrupted tabs are permanently invalidated and never reused.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ Gemini WebAPI-only OpenAI-compatible chat completion endpoint for temporary requ
 * `playwright/*` models are rejected with HTTP 400
 * `atlas/*` models and `provider=atlas` are rejected with HTTP 400
 * File parts are staged per request and cleaned up after completion
-* Streaming responses still emit OpenAI-compatible SSE chunks and `[DONE]`
+* Successful streaming responses emit OpenAI-compatible SSE chunks and `[DONE]`; terminally truncated streams may end without `[DONE]`
 ---
 
 ### GET `/v1/conversations`

--- a/docs/specs/browser-runtime-architecture.md
+++ b/docs/specs/browser-runtime-architecture.md
@@ -13,9 +13,11 @@ The `BrowserEngine` operates according to a strict state machine. Transitions in
 - **CLOSED**: All resources (browser, contexts, loops) have been released.
 
 ### State Rules:
-- **Terminal Shutdown / Decoupled Intent**: To prevent diagnostic race conditions and clean up cleanly, the engine decouples shutdown intention from execution:
-  - `is_shutting_down` (Public Boolean): Lifecycle intention flag. Declares the *intent* to terminate. Set immediately when any signal is captured or teardown begins to block concurrent work, prevent loop execution, and suppress connection warning logs during event loop closures. External signal handlers or parent process wrappers may choose to set `is_shutting_down = True` on the engine singleton. Such integrations must be validated against the application's shutdown lifecycle.
-  - `_shutdown_started` (Private Boolean): `close()` execution guard. Protects the physical teardown actions of closing browser processes and stopping Playwright. It must only be modified inside `close()` under the `management_lock`. Upstream or external systems must never mutate `_shutdown_started`.
+- **Terminal Shutdown / Decoupled Intent**: The engine decouples shutdown intention from execution:
+  - `shutdown_requested` records lifecycle admission closure and first-writer-owned shutdown source (`application`, `browser-disconnect`, or `manual/internal`).
+  - `is_shutting_down` indicates that BrowserEngine terminal teardown is active and blocks recovery while active.
+  - `_shutdown_started` is the internal idempotency guard for `close()` execution. It is managed by `close()` under `management_lock`.
+- **Application Shutdown**: `ApplicationServer.handle_exit()` marks application shutdown intent before delegating to Uvicorn. Uvicorn drains connections; FastAPI lifespan later calls `BrowserEngine.close(source="application")`.
 - **No Resurrection**: A `CLOSED` engine can never transition back to `HEALTHY`. A new process instance must be created.
 - **Enforcement**: Any call to `ensure_healthy()` during `SHUTTING_DOWN` or `CLOSED` must raise `RuntimeError("Browser engine is shutting down")`.
 
@@ -23,16 +25,18 @@ The `BrowserEngine` operates according to a strict state machine. Transitions in
 
 The runtime follows a strict ownership hierarchy. Resource cleanup must cascade down this chain.
 
-1. **BrowserEngine**: Global singleton. Owns the Playwright process and the `management_lock`.
-2. **ProviderSession**: Created per provider. Owns the `BrowserContext`, the `keepalive_page`, and background loops (`reaper`, `autosave`, `eviction`).
+1. **BrowserEngine**: Global singleton. Owns the Playwright instance, Browser process, browser generation, shutdown intent/source, provider-session registry, and terminal lifecycle orchestration.
+2. **ProviderSession**: Created per provider. Owns the `BrowserContext`, `keepalive_page`, `PersistentTab` pages, lifecycle tasks, and active-request abort/signal handles.
    - **Page Ownership**: `ProviderSession` is solely responsible for the creation, monitoring, and cleanup of its `keepalive_page`.
    - **Separation of Concerns**: `BrowserEngine` must not manipulate the `keepalive_page` directly outside of session teardown orchestration.
 3. **ManagedPage**: Request-scoped lease. Owns exactly one semaphore permit and potentially one `PersistentTab` lease.
 4. **PersistentTab**: Long-lived browser page. Owns its individual `_lock` and state.
+5. **BrowserRequestExecutor**: Owns one request lifecycle state, terminal event/error, request task, observer/queue tasks, and lease release through request cleanup.
 
 ### Authority Rules:
 - **Teardown Authority**: `BrowserEngine.close()` is the ONLY authoritative entry point for terminal shutdown. 
-- **Direct Closure Forbidden**: Contributors must never call `browser.close()` or `context.close()` directly without triggering the engine's shutdown sequence to ensure background loops are cancelled.
+- **Parent-Child Teardown**: ProviderSession resources close before the parent Browser, and the Browser closes before Playwright stops, during both replacement and terminal shutdown.
+- **Context Closure Authority**: Arbitrary callers and provider adapters must not close the context directly. ProviderSession lifecycle cleanup is the authorized BrowserContext owner.
 - **Cleanup Ownership**: `ManagedPage` is responsible for releasing its own permits and leases, even during request cancellation (must be wrapped in `asyncio.shield`).
 
 ## 3. Zombie Chromium & Window Liveness
@@ -55,9 +59,11 @@ The system distinguishes between recoverable transient failures and non-recovera
 
 ### Non-Recoverable (Triggers Terminal Shutdown):
 - Manual browser window closure.
-- Explicit `BrowserContext` closure.
+- Unexpected closure of the current `BrowserContext`.
 - Global `disconnected` lifecycle event from Playwright.
 - System-wide resource exhaustion or engine shutdown initiation.
+
+Intentional BrowserContext closure performed by ProviderSession lifecycle cleanup is not a terminal failure.
 
 **Philosophy**: The system prefers terminal shutdown over aggressive recreation when the user-visible interface is terminated.
 
@@ -67,16 +73,48 @@ The system distinguishes between recoverable transient failures and non-recovera
 To prevent deadlocks, locks must always be acquired in this order. Acquiring locks out-of-order is strictly **forbidden**, as violating this contract introduces deterministic deadlocks:
 1. `BrowserEngine.management_lock` (Global orchestration)
 2. `ProviderSession.init_lock` (Session setup/recovery)
-3. `ProviderSession.registry_lock` (Registry lookups/mutations)
-4. `PersistentTab._lock` (Individual tab operations)
+3. `ProviderSession._cleanup_lock` (Serialized session cleanup)
+4. `ProviderSession.registry_lock` (Registry lookups/mutations)
+5. `PersistentTab._lock` (Individual tab operations)
+
+`conversation_lock` is independent. Production code has no `init_lock` to `management_lock` acquisition path. `close_resources()` must not acquire `init_lock`; `_setup_locked()` assumes management and init locks are held, `_setup()` acquires them in order, and `_ensure_healthy_browser()` assumes management-lock ownership.
+
+### 5.2 Browser Replacement
+Unhealthy-browser replacement follows this order:
+
+1. Detect unhealthy Browser under `management_lock`.
+2. Clean ProviderSessions bound to old lifecycle/resources and wait for in-progress cleanup.
+3. Close or skip old Browser, then stop old Playwright.
+4. Launch new Playwright and Browser.
+5. Increment `browser_generation` only after successful Browser launch.
+6. Set up ProviderSession contexts against the new generation.
+
+Failed launch leaves the generation unchanged. ProviderSessions observe and store `last_browser_generation`; they do not choose generation values. Context callbacks from generation N cannot terminate generation N+1.
 
 
 ## 6. Async Safety Constraints
 
 - **Event Loop Teardown**: Callback scheduling in event listeners must use `asyncio.get_running_loop().create_task()` wrapped in `try/except RuntimeError` to avoid crashes during late-stage interpreter shutdown.
 - **Fire-and-Forget**: Shutdown handlers must be non-blocking. Schedule the teardown task and return immediately to allow Playwright's event loop to progress.
+- **Cleanup Serialization**: `ProviderSession._cleanup_lock` detaches the context before awaiting its close, makes repeated/concurrent cleanup safe, and treats already-disconnected contexts as benign. Unexpected close failures remain visible. Active cleanup counts as lifecycle-active for replacement decisions.
+- **Task Ownership**: ProviderSession tracks context-close callback, recovery, recovery-wrapper, and orphan-cleanup tasks. BrowserEngine tracks disconnect-triggered close tasks. Project-owned task exceptions are retrieved/logged; request observer and queue tasks remain request-owned and are awaited or cancelled.
+- **Terminal Request Drain**: Application shutdown rejects new admissions, allows existing requests up to the 15-second drain deadline, then triggers request-owned abort callbacks. Request cleanup releases leases and semaphores; BrowserEngine never mutates lease counters.
 
-## 7. AI Agent Rules
+## 7. Context Close Semantics
+
+- **Intentional close**: ProviderSession lifecycle cleanup must not trigger terminal browser shutdown.
+- **Stale callback**: A callback for an old context or generation is ignored when identity or generation is no longer current.
+- **Unexpected current close**: A current-generation/current-context close without shutdown intent or an intentional marker triggers browser-disconnect terminal behavior.
+- **Application shutdown**: Current-context closure is expected shutdown activity and must not start crash recovery or duplicate shutdown orchestration. Active requests still receive an immediate terminal browser-disconnect signal if their browser resource disappears.
+
+## 8. Terminal Browser Cleanup
+
+- If public Browser state confirms disconnection, explicit `browser.close()` is skipped.
+- A public Playwright close error is benign only when state confirms disconnection afterward.
+- If Browser remains connected, close failure remains a warning; generic non-Playwright close exceptions remain visible regardless of connection state.
+- Browser cleanup always precedes Playwright stop and uses no private Playwright exception or API.
+
+## 9. AI Agent Rules
 
 AI Agents working on this runtime must adhere to these strict constraints to prevent architectural drift:
 

--- a/docs/specs/concurrency-model.md
+++ b/docs/specs/concurrency-model.md
@@ -39,8 +39,11 @@ Locks MUST be acquired in the following order. Acquiring out-of-order is strictl
 
 1. `BrowserEngine.management_lock`: Orchestrates global initialization and terminal shutdown.
 2. `ProviderSession.init_lock`: Serializes session-specific browser context setup.
-3. `ProviderSession.registry_lock`: Protects the in-memory `conversation_registry` and `active_orphans` set.
-4. `PersistentTab._lock`: Protects individual tab state transitions and lease ownership.
+3. `ProviderSession._cleanup_lock`: Serializes ProviderSession resource cleanup.
+4. `ProviderSession.registry_lock`: Protects the in-memory `conversation_registry` and `active_orphans` set.
+5. `PersistentTab._lock`: Protects individual tab state transitions and lease ownership.
+
+`conversation_lock` remains independent. No production path acquires `management_lock` from `init_lock`. `close_resources()` must not acquire `init_lock`; `_setup_locked()` assumes management and init locks are already held, `_setup()` acquires them in order, and `_ensure_healthy_browser()` assumes management-lock ownership.
 
 ### 2.1 Lock Scope Discipline
 - **Invariant**: `registry_lock` MUST NEVER be held across Playwright operations, network waits, or long-running awaits.
@@ -49,6 +52,15 @@ Locks MUST be acquired in the following order. Acquiring out-of-order is strictl
 ### 2.2 Recovery Concurrency Guarantees
 - **Serialization**: `ProviderSession.init_lock` serializes all recovery and setup paths.
 - **Convergence**: Concurrent recovery attempts must converge into a single authoritative execution path. Subsequent callers must wait and then verify the new state.
+
+### 2.3 Shutdown Admission and Request Drain
+- `shutdown_requested` closes new page/session admission before Uvicorn connection drain; `_shutdown_started` means terminal BrowserEngine cleanup has begun. First shutdown source wins.
+- Existing requests may finish during the existing 15-second grace period. After the deadline, BrowserEngine invokes request-owned abort callbacks and waits for bounded cleanup.
+- BrowserEngine never mutates lease counters. Request cleanup owns lease and semaphore release.
+- Browser/page/context loss signals the request terminal event immediately, bypassing queue/chunk/total timeout waits.
+
+### 2.4 Lifecycle Task Ownership
+ProviderSession owns context-close callback, recovery, recovery-wrapper, and orphan-cleanup tasks. BrowserEngine owns disconnect-triggered close tasks. Project-owned task completion must retrieve/log exceptions; request observer and queue tasks remain request-owned and are explicitly awaited or cancelled.
 
 ## 3. Cancellation Safety
 

--- a/docs/specs/error-policy.md
+++ b/docs/specs/error-policy.md
@@ -52,6 +52,14 @@ Failures are formally classified into four levels of impact:
 - **Examples**: Manual window closure, browser process disconnect, fatal `BrowserEngine` state corruption, generation rollover invalidation.
 - **Protocol**: The runtime enters an irreversible **Terminal Shutdown** state. All future recovery attempts and new requests MUST fail fast with terminal shutdown semantics.
 
+### 3.5 Browser Resource Loss During a Request
+- `BrowserDisconnectedError` represents terminal browser/page/context loss for the active request. The terminal signal wakes request waits immediately and preserves the existing HTTP 502 mapping.
+- Before streaming response headers are sent, this error is mapped through the normal HTTP 502 policy. After SSE status 200 is sent, the status cannot be rewritten; the stream iterator terminates cleanly instead.
+- Post-header `BrowserDisconnectedError` and `BrowserShuttingDownError` must not escape into Starlette/AnyIO as an ASGI application error and must not emit `[DONE]`.
+- If a request already recorded that terminal state, it takes precedence over a later raw Playwright close error caused by the same resource loss.
+- Raw Playwright errors without recorded terminal browser-disconnect state retain existing classification, including the existing 503 mapping for a closed page/context.
+- A true timeout remains a timeout and maps through existing timeout policy; browser death is not a timeout fallback.
+
 ---
 
 ## 4. Recovery Authority Boundaries
@@ -109,6 +117,7 @@ Cancellation safety is a core runtime invariant. The system prioritizes determin
 - **Non-Swallowing**: `asyncio.CancelledError` must be propagated after executing the shielded cleanup; it must never be silently suppressed.
 - **Best-Effort vs Mandatory Cleanup**: The system strongly guarantees the return of active leases and semaphores under normal cancellation (mandatory release). Auxiliary Playwright cleanup operations (such as script detachment, page closure, or tab recreation) are executed on a best-effort basis and must not prevent successful lease/semaphore release.
 - **Task Integrity**: Request-scoped async tasks (observers, stream buffers) must be terminated before the tab's communication channels are removed.
+- **Lease Ownership**: During graceful drain or forced abort, BrowserEngine invokes request-owned abort callbacks and never mutates lease counters directly.
 
 ---
 
@@ -124,6 +133,7 @@ Runtime integrity failures must be visible and traceable.
     - **WARNING**: Recoverable failures and successful session-scoped recovery events.
     - **ERROR**: Request-scoped terminal failures.
     - **CRITICAL**: Session corruption, invariant violations, or engine-scoped fatal errors.
+    - Expected page closure during application shutdown is `INFO`; unexpected runtime page closure is `WARNING`. Expected already-disconnected cleanup is debug/info; unexpected close errors remain warning/error.
 
 ---
 

--- a/docs/specs/lifecycle-and-recovery.md
+++ b/docs/specs/lifecycle-and-recovery.md
@@ -6,8 +6,9 @@ This document specifies the browser lifecycle, state transitions, and self-heali
 
 ### 1.1 Generation Rollover & Invalidation
 - **Generation ID**: The engine maintains a `browser_generation` counter.
-- **Trigger**: Every new browser process launch increments this counter.
-- **Initialization State**: A newly created session starts with `last_browser_generation = None` and is not associated with any browser generation until its first context initialization.- **Propagation**: Sessions track `last_browser_generation`. A generation rollover is detected only after the session has been initialized (`last_browser_generation is not None`) and the tracked generation differs from the engine generation. On rollover detection, the session MUST purge all registry tabs immediately.
+- **Trigger**: Every successful new Browser process launch increments this counter. A failed launch leaves it unchanged.
+- **Initialization State**: A newly created session starts with `last_browser_generation = None` and is not associated with any browser generation until its first context initialization.
+- **Propagation**: Sessions track `last_browser_generation`. A generation rollover is detected only after the session has been initialized (`last_browser_generation is not None`) and the tracked generation differs from the engine generation. On rollover detection, the session MUST purge all registry tabs immediately.
 - **Invalidation Invariant**: A generation rollover permanently invalidates all existing `PersistentTab` leases. Old tabs/pages from previous generations are stale and MUST NEVER be reused.
 
 
@@ -20,6 +21,18 @@ This document specifies the browser lifecycle, state transitions, and self-heali
 - **Convergence**: Concurrent `ensure_healthy()` calls must converge into a single recovery path.
 - **Serialization**: Redundant context recreation races are suppressed via `ProviderSession.init_lock`. Only the first caller performs the setup; subsequent concurrent callers wait and verify the new state.
 
+### 1.4 Browser Replacement Order
+Unhealthy-browser replacement runs under `BrowserEngine.management_lock`:
+
+1. Clean ProviderSessions bound to old lifecycle/resources and wait for active cleanup.
+2. Close or skip old Browser.
+3. Stop old Playwright.
+4. Launch new Playwright and Browser.
+5. Publish the successful launch by incrementing `browser_generation`.
+6. Set up ProviderSession contexts.
+
+ProviderSessions observe/store `last_browser_generation`; they do not choose generations. A close callback from generation N cannot terminate generation N+1.
+
 ## 2. Window Liveness & Terminal Shutdown
 
 ### 2.1 The "Zombie" Chromium Problem
@@ -28,15 +41,31 @@ This document specifies the browser lifecycle, state transitions, and self-heali
 - **Hardening**: `ProviderSession.is_alive` MUST check `keepalive_page.is_closed()`.
 
 ### 2.2 Deterministic Shutdown Ordering
-To ensure resource integrity, terminal shutdown MUST follow this exact sequence:
-1. **Halt**: Stop accepting new request work.
-2. **Flag**: Set `is_shutting_down = True`.
-3. **Drain**: Allow active requests a 15s grace period to complete.
-4. **Cancel**: Terminate all background loops (reaper, autosave, eviction).
-5. **Persist**: Atomically save context state to disk.
-6. **Release**: Physically close contexts and the Playwright browser process.
+Application shutdown follows:
 
-**Shutdown Invariant**: Once the shutdown sequence begins, all future recovery attempts MUST fail immediately.
+1. `ApplicationServer.handle_exit()` marks `shutdown_requested(source="application")`.
+2. Uvicorn drains active connections while new page/session admission is rejected.
+3. FastAPI lifespan calls `BrowserEngine.close(source="application")`.
+4. Existing requests receive up to 15 seconds to finish; remaining requests receive request-owned abort callbacks.
+5. ProviderSession lifecycle tasks are cancelled/drained and ProviderSession resources close.
+6. Browser closes or is skipped, then Playwright stops.
+
+ProviderSession resources always close before Browser, and Browser before Playwright. Runtime terminal cleanup uses `save_state=False`; bootstrap/manual auth cleanup may use `save_state=True`.
+
+**Shutdown Invariant**: Once shutdown intent exists, no new recovery or admission may begin. Workers recheck shutdown state after acquiring `init_lock` and before cleanup. Existing recovery may be cancelled and awaited during terminal cleanup.
+
+### 2.3 Context Close Classification
+- **Intentional close**: ProviderSession cleanup owns the context close and marks it so the callback cannot trigger terminal shutdown.
+- **Stale callback**: A callback for an old context or generation is ignored.
+- **Unexpected current-context close**: Without shutdown intent or an intentional marker, this triggers browser-disconnect terminal behavior.
+- **Application shutdown**: Current-context closure is expected activity and does not restart crash recovery or shutdown orchestration. Active requests still receive immediate terminal browser-disconnect signals when their browser resource disappears.
+
+### 2.4 Active Request Termination
+Browser/page/context loss signals the request terminal event immediately. Before SSE headers are sent, `BrowserRequestExecutor` maps terminal `BrowserDisconnectedError` through the existing HTTP 502 contract. After headers are sent, the stream boundary consumes the terminal state without waiting for queue, chunk, total, or request timeout. If a raw Playwright close error arrives later for the same closure, the recorded terminal browser-disconnect state takes precedence; raw Playwright errors without that state retain existing behavior.
+
+Request cleanup owns lease and semaphore release. BrowserEngine never decrements lease counters directly.
+
+During application shutdown, an active stream may already have sent headers when browser or shutdown termination occurs. The stream boundary consumes that terminal state, ends without `[DONE]`, and still completes request cleanup and lease release.
 
 ## 3. Recovery Boundaries
 
@@ -60,6 +89,8 @@ The system classifies failures into two categories with distinct response protoc
     - Manual window closure.
     - Explicit browser disconnect.
     - System-level shutdown signal (`SIGINT`).
+
+An application shutdown signal establishes shutdown intent before connection drain; it does not start a second crash-classification path.
 
 ### 3.3 Recovery Failure Escalation
 If recovery itself fails, the failure MUST be escalated:

--- a/docs/specs/provider-contract.md
+++ b/docs/specs/provider-contract.md
@@ -31,7 +31,7 @@ Authentication ownership is split by responsibility:
 Each auth strategy owns its own `provider_name` and may contribute provider-specific status reporting. The registry, not Gemini-specific code, determines which strategy is active for a given provider.
 
 ### Forbidden Behaviors:
-- Providers/Adapters must NEVER call `browser.close()` or `context.close()` directly.
+- Providers/Adapters must never close the Browser directly and must not close BrowserContext directly. ProviderSession lifecycle cleanup is the authorized BrowserContext owner; BrowserEngine owns Browser and Playwright teardown.
 - Providers/Adapters must NEVER recreate `BrowserContext` or sessions directly; they must escalate to the authoritative session layer.
 - Browser-native Adapters must NEVER bypass `ProviderSession.acquire_lease()` to obtain pages.
 - Providers/Adapters must NEVER manipulate `is_shutting_down` or other engine state flags.

--- a/docs/specs/streaming-pipeline.md
+++ b/docs/specs/streaming-pipeline.md
@@ -68,7 +68,40 @@ The pipeline is designed to handle providers that "rewrite" the full response te
 - **Format**: All events are normalized to OpenAI-compatible Server-Sent Events (SSE).
 - **Finalization**: Every successful stream MUST terminate with a literal `data: [DONE]` chunk.
 
-### 7.2 Failure Isolation & Propagation
+### 7.2 Terminal Browser Conditions
+- **Before response start**: The request executor owns terminal browser loss and applies normal HTTP error policy. `BrowserDisconnectedError` retains its existing HTTP 502 mapping.
+- **After response start**: Once SSE status 200 and headers are sent, HTTP status cannot be rewritten. The SSE body iterator owns expected terminal browser conditions.
+- **Expected terminal conditions**: `BrowserDisconnectedError` and `BrowserShuttingDownError` terminate the iterator internally and MUST NOT escape into Starlette/AnyIO. No new SSE error event or schema is emitted.
+- **Terminal truncation**: A browser/page/context loss or forced shutdown ends the stream without `data: [DONE]` and logs `Stream terminated`, not `Stream completed`. Absence of `[DONE]` means the stream did not complete successfully; clients MUST NOT interpret it as successful completion.
+
+Successful completion remains:
+
+```text
+normal generation completion
+-> final SSE data/chunks
+-> data: [DONE]
+-> Stream completed
+```
+
+Terminal truncation is:
+
+```text
+browser/page/context loss or forced browser shutdown
+-> terminal request state
+-> stream iterator exits cleanly
+-> no [DONE]
+-> Stream terminated
+```
+
+### 7.3 Cleanup and Forced Shutdown
+- Terminal stream exit always enters request cleanup/finally handling.
+- Observer tasks are cancelled and awaited; bridge callbacks and listeners are removed.
+- Request abort handles are unregistered, and `ManagedPage`/`PersistentTab` lease release remains request-owned.
+- `BrowserEngine` never mutates lease counters.
+- Forced shutdown follows: drain deadline -> request abort callback -> `BrowserShuttingDownError` signal -> request/ASGI task cancellation -> stream cancellation path -> cleanup.
+- Cancellation and terminal browser loss are distinct internal mechanisms, but neither may produce a false `[DONE]`.
+
+### 7.4 Failure Isolation & Propagation
 - **Isolation**: Failures in one request stream (e.g., generator error or client disconnect) must not terminate or poison the `ProviderSession` unless the underlying page/context becomes invalid.
 - **Timeout**: If no chunks are received within `chunk_timeout`, the stream is terminated with a `TimeoutError`.
 - **Cancellation**: If the client disconnects, the provider MUST attempt to click the "Stop" button in the browser UI before cleaning up.

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -99,7 +99,7 @@ async def lifespan(app: FastAPI):
     try:
         from app.services.browser.engine import get_browser_engine
         engine = await get_browser_engine()
-        await engine.close()
+        await engine.close(source="application")
         logger.info("BrowserEngine closed gracefully.")
     except Exception as e:
         logger.error(f"Error closing BrowserEngine: {e}", exc_info=True)

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -391,7 +391,7 @@ class BrowserEngine:
                 for session in list(self.sessions.values()):
                     try:
                         logger.info(f"BrowserEngine: Closing session resources for {session.name}", extra={"generation": self.browser_generation})
-                        await session.close_resources(save_state=True)
+                        await session.close_resources(save_state=self.is_bootstrap)
                         logger.info(f"BrowserEngine: Session resources for {session.name} closed successfully.", extra={"generation": self.browser_generation})
                     except Exception as e:
                         logger.error(f"BrowserEngine: Exception closing session resources for {session.name}: {e}", exc_info=True)

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -46,6 +46,7 @@ class BrowserEngine:
         self.shutdown_source: Optional[str] = None
         self._shutdown_started = False
         self._disconnect_handled = False
+        self._disconnect_close_task: Optional[asyncio.Task] = None
 
     def request_shutdown(self, source: str) -> bool:
         """Record first shutdown intent without starting resource teardown."""
@@ -101,6 +102,91 @@ class BrowserEngine:
             )
             await session.close_resources(save_state=False)
 
+    async def _close_browser_best_effort(self, phase: str) -> None:
+        if not self.browser:
+            return
+
+        browser = self.browser
+        try:
+            connected = browser.is_connected()
+        except Exception as inspection_error:
+            logger.warning(
+                "BrowserEngine: Failed to inspect browser connection before close: %s",
+                inspection_error,
+                exc_info=True,
+                extra={"phase": phase, "generation": self.browser_generation},
+            )
+            connected = True
+
+        if not connected:
+            logger.debug(
+                "BrowserEngine: Skipping browser close; transport already disconnected.",
+                extra={"phase": phase, "generation": self.browser_generation},
+            )
+            return
+
+        try:
+            await browser.close()
+        except PlaywrightError as close_error:
+            try:
+                connected_after_error = browser.is_connected()
+            except Exception as inspection_error:
+                logger.warning(
+                    "BrowserEngine: Browser close failed (%s); post-close connection inspection failed: %s",
+                    close_error,
+                    inspection_error,
+                    exc_info=(type(close_error), close_error, close_error.__traceback__),
+                    extra={"phase": phase, "generation": self.browser_generation},
+                )
+                return
+
+            if connected_after_error:
+                logger.warning(
+                    "BrowserEngine: Error closing browser: %s",
+                    close_error,
+                    exc_info=True,
+                    extra={"phase": phase, "generation": self.browser_generation},
+                )
+            else:
+                logger.debug(
+                    "BrowserEngine: Browser transport disconnected during close.",
+                    extra={"phase": phase, "generation": self.browser_generation},
+                )
+        except Exception as close_error:
+            logger.warning(
+                "BrowserEngine: Error closing browser: %s",
+                close_error,
+                exc_info=(type(close_error), close_error, close_error.__traceback__),
+                extra={"phase": phase, "generation": self.browser_generation},
+            )
+
+    def _track_disconnect_close_task(self, task: asyncio.Task) -> None:
+        self._disconnect_close_task = task
+
+        def consume_result(done_task: asyncio.Task) -> None:
+            if self._disconnect_close_task is done_task:
+                self._disconnect_close_task = None
+            if done_task.cancelled():
+                return
+            try:
+                error = done_task.exception()
+            except Exception as inspection_error:
+                logger.error(
+                    "BrowserEngine: Failed to inspect disconnect shutdown task: %s",
+                    inspection_error,
+                    exc_info=True,
+                )
+                return
+            if error is not None:
+                logger.error(
+                    "BrowserEngine: Disconnect shutdown task failed: %s",
+                    error,
+                    exc_info=(type(error), error, error.__traceback__),
+                    extra={"generation": self.browser_generation},
+                )
+
+        task.add_done_callback(consume_result)
+
     async def _ensure_healthy_browser(self):
         if self.is_shutting_down:
             logger.debug("BrowserEngine: Initialization skipped - engine is shutting down.", extra={"generation": self.browser_generation})
@@ -112,10 +198,7 @@ class BrowserEngine:
             await self._close_sessions_before_browser_replacement()
             
             if self.browser:
-                try: 
-                    await self.browser.close()
-                except Exception as e:
-                    logger.debug(f"BrowserEngine: Best-effort browser close failed: {e}", extra={"generation": self.browser_generation})
+                await self._close_browser_best_effort("replacement")
             if self.playwright:
                 try: 
                     await self.playwright.stop()
@@ -165,7 +248,9 @@ class BrowserEngine:
         logger.warning("BrowserEngine: Unexpected browser disconnection detected (Manual closure or crash).", extra={"generation": self.browser_generation})
         # Fire-and-forget terminal shutdown to kill all background loops and prevent recreation
         try:
-            asyncio.get_running_loop().create_task(self.close())
+            task = asyncio.get_running_loop().create_task(self.close())
+            if task is not None:
+                self._track_disconnect_close_task(task)
         except RuntimeError as e:
             logger.debug("BrowserEngine: Shutdown task scheduling skipped - event loop already closed.", exc_info=True, extra={"generation": self.browser_generation})
 
@@ -313,12 +398,8 @@ class BrowserEngine:
                         raise
                 
                 if self.browser:
-                    try: 
-                        logger.info("BrowserEngine: Closing browser process.", extra={"generation": self.browser_generation})
-                        await self.browser.close()
-                        logger.info("BrowserEngine: Browser process closed successfully.", extra={"generation": self.browser_generation})
-                    except Exception as e:
-                        logger.warning(f"BrowserEngine: Error closing browser: {e}", exc_info=True, extra={"generation": self.browser_generation})
+                    logger.info("BrowserEngine: Closing browser process.", extra={"generation": self.browser_generation})
+                    await self._close_browser_best_effort("terminal")
                 else:
                     logger.info("BrowserEngine: No browser process to close.", extra={"generation": self.browser_generation})
                 

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -12,6 +12,7 @@ from playwright.async_api import async_playwright, Playwright, BrowserContext, P
 from app.logger import logger
 from app.config import CONFIG, get_default_playwright_cache_dir
 
+from app.services.browser.errors import BrowserDisconnectedError
 from app.services.browser.tab import TabStatus, PersistentTab, ManagedPage
 
 from app.services.browser.session import ProviderSession
@@ -141,6 +142,10 @@ class BrowserEngine:
 
     def _on_browser_disconnected(self):
         """Internal handler for Playwright's disconnected event."""
+        self._signal_active_requests(
+            lambda: BrowserDisconnectedError("Browser transport disconnected during active request")
+        )
+
         if self.is_shutting_down or self._disconnect_handled:
             return
 
@@ -170,6 +175,18 @@ class BrowserEngine:
     def active_pages(self) -> int:
         """Counts current active leases (semaphore slots)."""
         return sum(s.active_lease_count for s in self.sessions.values())
+
+    def _signal_active_requests(self, error_factory) -> None:
+        for session in tuple(self.sessions.values()):
+            session.signal_active_requests(error_factory)
+
+    def _abort_active_requests(self) -> None:
+        for session in tuple(self.sessions.values()):
+            session.abort_active_requests()
+
+    async def _wait_for_active_requests_to_release(self) -> None:
+        while self.active_pages > 0:
+            await asyncio.sleep(0)
 
     @property
     def total_page_count(self) -> int:
@@ -267,6 +284,23 @@ class BrowserEngine:
                 except Exception as e:
                     logger.error(f"BrowserEngine: Exception during active pages drain: {e}", exc_info=True)
                     raise
+
+                if self.active_pages > 0:
+                    logger.warning(
+                        "BrowserEngine: Aborting active requests after drain deadline.",
+                        extra={"generation": self.browser_generation},
+                    )
+                    self._abort_active_requests()
+                    try:
+                        await asyncio.wait_for(
+                            self._wait_for_active_requests_to_release(),
+                            timeout=1.0,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "BrowserEngine: Active requests did not release before teardown continued.",
+                            extra={"active_pages": self.active_pages, "generation": self.browser_generation},
+                        )
                 
                 logger.info(f"BrowserEngine: Closing {len(self.sessions)} provider session(s)...", extra={"generation": self.browser_generation})
                 for session in list(self.sessions.values()):

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -22,6 +22,7 @@ class BrowserEngine:
     """
     _instance: Optional['BrowserEngine'] = None
     _lock = asyncio.Lock()
+    _SHUTDOWN_SOURCES = {"application", "browser-disconnect", "manual/internal"}
 
     def __init__(self, headless: Optional[bool] = None, is_bootstrap: bool = False):
         self.playwright: Optional[Playwright] = None
@@ -40,8 +41,26 @@ class BrowserEngine:
         self.max_pages = CONFIG["Playwright"].getint("max_concurrent_pages", 5)
         self.max_total_tabs = CONFIG["Playwright"].getint("max_total_tabs", 50)
         self.is_shutting_down = False
+        self.shutdown_requested = False
+        self.shutdown_source: Optional[str] = None
         self._shutdown_started = False
         self._disconnect_handled = False
+
+    def request_shutdown(self, source: str) -> bool:
+        """Record first shutdown intent without starting resource teardown."""
+        if source not in self._SHUTDOWN_SOURCES:
+            raise ValueError(f"Unsupported browser shutdown source: {source}")
+        if self.shutdown_requested:
+            return False
+
+        self.shutdown_requested = True
+        self.shutdown_source = source
+        if source == "application":
+            logger.info(
+                "BrowserEngine: Application shutdown requested",
+                extra={"shutdown_source": source, "generation": self.browser_generation},
+            )
+        return True
 
     @classmethod
     async def get_instance(cls, headless: Optional[bool] = None) -> 'BrowserEngine':
@@ -124,8 +143,20 @@ class BrowserEngine:
         """Internal handler for Playwright's disconnected event."""
         if self.is_shutting_down or self._disconnect_handled:
             return
+
+        if self.shutdown_requested:
+            self._disconnect_handled = True
+            logger.info(
+                "BrowserEngine: Browser disconnected during application shutdown",
+                extra={
+                    "shutdown_source": self.shutdown_source,
+                    "generation": self.browser_generation,
+                },
+            )
+            return
             
         self._disconnect_handled = True
+        self.request_shutdown("browser-disconnect")
         logger.warning("BrowserEngine: Unexpected browser disconnection detected (Manual closure or crash).", extra={"generation": self.browser_generation})
         # Fire-and-forget terminal shutdown to kill all background loops and prevent recreation
         try:
@@ -210,17 +241,19 @@ class BrowserEngine:
             else:
                 logger.warning(f"BrowserEngine: Eviction failed for {tab.conversation_id} (Status: {tab.status})")
 
-    async def close(self) -> None:
+    async def close(self, source: Optional[str] = None) -> None:
         try:
             async with self.management_lock:
                 if self._shutdown_started: 
                     logger.info("BrowserEngine: Shutdown already in progress or complete.", extra={"generation": self.browser_generation})
                     return
+
+                self.request_shutdown(source or self.shutdown_source or "manual/internal")
                 
                 if getattr(self, "is_bootstrap", False):
-                    logger.info("BrowserEngine: Shutting down isolated bootstrap engine...", extra={"generation": self.browser_generation})
+                    logger.info("BrowserEngine: Shutting down isolated bootstrap engine...", extra={"shutdown_source": self.shutdown_source, "generation": self.browser_generation})
                 else:
-                    logger.info("BrowserEngine: Shutting down singleton runtime engine...", extra={"generation": self.browser_generation})
+                    logger.info("BrowserEngine: Shutting down singleton runtime engine...", extra={"shutdown_source": self.shutdown_source, "generation": self.browser_generation})
                 
                 self.is_shutting_down = True
                 self._shutdown_started = True
@@ -277,3 +310,10 @@ async def get_browser_engine(headless: Optional[bool] = None, is_bootstrap: bool
     if is_bootstrap:
         return BrowserEngine(headless=headless, is_bootstrap=True)
     return await BrowserEngine.get_instance(headless=headless)
+
+
+def request_application_shutdown() -> bool:
+    """Mark existing runtime engine shutdown intent from Uvicorn's signal hook."""
+    if BrowserEngine._instance is None:
+        return False
+    return BrowserEngine._instance.request_shutdown("application")

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -69,6 +69,18 @@ class BrowserEngine:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
 
+    async def _close_sessions_before_browser_replacement(self):
+        """Detach provider resources before replacing their parent browser."""
+        for session in list(self.sessions.values()):
+            if not session._has_resources_to_close():
+                continue
+            logger.info(
+                "BrowserEngine: Closing resources for %s before browser replacement",
+                session.name,
+                extra={"generation": self.browser_generation},
+            )
+            await session.close_resources(save_state=False)
+
     async def _ensure_healthy_browser(self):
         if self.is_shutting_down:
             logger.debug("BrowserEngine: Initialization skipped - engine is shutting down.", extra={"generation": self.browser_generation})
@@ -76,6 +88,8 @@ class BrowserEngine:
 
         if not self.playwright or not self.browser or not self.browser.is_connected():
             logger.info("BrowserEngine: Initializing Browser...", extra={"generation": self.browser_generation})
+
+            await self._close_sessions_before_browser_replacement()
             
             if self.browser:
                 try: 

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -153,7 +153,12 @@ class BrowserRequestExecutor:
                 def on_close(_page):
                     if state.cleanup_started:
                         return
-                    logger.warning("Page close detected", extra={"request_id": state.request_id})
+                    shutting_down = (
+                        getattr(getattr(session, "engine", None), "shutdown_requested", False) is True
+                        or getattr(getattr(session, "engine", None), "is_shutting_down", False) is True
+                    )
+                    log_method = logger.info if shutting_down else logger.warning
+                    log_method("Page close detected", extra={"request_id": state.request_id})
                     state.page_poisoned = True
                     if state.active_tab:
                         state.active_tab.invalidate()

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -341,6 +341,13 @@ class BrowserRequestExecutor:
             raise
 
         except Exception as e:
+            if (
+                isinstance(e, PlaywrightError)
+                and state
+                and isinstance(state.terminal_error, BrowserDisconnectedError)
+            ):
+                e = state.terminal_error
+
             poison_session_errors = (
                 SessionNotAliveError,
                 BrowserDisconnectedError,

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -64,6 +65,20 @@ class PlaywrightRequestState:
     on_close_handler: Any = None
     on_crash_handler: Any = None
     queue_overflow: bool = False
+    terminal_event: asyncio.Event = field(default_factory=asyncio.Event)
+    terminal_error: Optional[BaseException] = None
+    request_task: Optional[asyncio.Task] = None
+    request_registered: bool = False
+
+    def signal_terminal(self, error: BaseException) -> None:
+        if self.terminal_error is None:
+            self.terminal_error = error
+        self.terminal_event.set()
+
+    def abort(self) -> None:
+        self.signal_terminal(BrowserShuttingDownError("Browser request aborted during engine shutdown"))
+        if self.request_task and not self.request_task.done():
+            self.request_task.cancel()
 
 
 @dataclass(frozen=True)
@@ -133,6 +148,7 @@ class BrowserRequestExecutor:
                 page_lease = None
                 observer_task = None
                 state = PlaywrightRequestState(request_id=request_id, start_time=start_time)
+                state.request_task = asyncio.current_task()
 
                 def on_close(_page):
                     if state.cleanup_started:
@@ -141,6 +157,9 @@ class BrowserRequestExecutor:
                     state.page_poisoned = True
                     if state.active_tab:
                         state.active_tab.invalidate()
+                    state.signal_terminal(
+                        BrowserDisconnectedError("Browser page closed during active request")
+                    )
 
                 def on_crash(_page):
                     if state.cleanup_started:
@@ -149,6 +168,9 @@ class BrowserRequestExecutor:
                     state.page_poisoned = True
                     if state.active_tab:
                         state.active_tab.invalidate()
+                    state.signal_terminal(
+                        BrowserDisconnectedError("Browser page crashed during active request")
+                    )
 
                 state.on_close_handler = on_close
                 state.on_crash_handler = on_crash
@@ -159,6 +181,14 @@ class BrowserRequestExecutor:
                         request_id=state.request_id,
                     )
                     state.permit_acquired = True
+                    register_request_abort = getattr(session, "register_request_abort", None)
+                    if register_request_abort and not inspect.iscoroutinefunction(register_request_abort):
+                        register_request_abort(
+                            state.request_id,
+                            state.signal_terminal,
+                            state.abort,
+                        )
+                        state.request_registered = True
                     page = page_lease.page
 
                     page.on("close", on_close)
@@ -407,7 +437,7 @@ class BrowserRequestExecutor:
                 try:
                     await self._register_conversation_if_available(page, state, session, lease)
 
-                    payload = await asyncio.wait_for(queue.get(), timeout=self.config.chunk_timeout)
+                    payload = await self._wait_for_payload(queue, state, self.config.chunk_timeout)
                     if payload.get("type") == "done":
                         break
 
@@ -473,7 +503,7 @@ class BrowserRequestExecutor:
                         raise QueueOverflowError("Event queue saturated")
                     await self._register_conversation_if_available(page, state, session, lease)
 
-                    payload = await queue.get()
+                    payload = await self._wait_for_payload(queue, state)
                     if payload.get("type") == "done":
                         break
 
@@ -567,6 +597,39 @@ class BrowserRequestExecutor:
                     state.request_id if state else "unknown",
                     e,
                 )
+            finally:
+                unregister_request_abort = getattr(session, "unregister_request_abort", None)
+                if state.request_registered and unregister_request_abort:
+                    unregister_request_abort(state.request_id)
+                    state.request_registered = False
+
+    async def _wait_for_payload(
+        self,
+        queue: asyncio.Queue,
+        state: PlaywrightRequestState,
+        timeout: Optional[float] = None,
+    ):
+        if state.terminal_event.is_set():
+            raise state.terminal_error or BrowserDisconnectedError("Browser request terminated")
+
+        queue_task = asyncio.create_task(queue.get())
+        terminal_task = asyncio.create_task(state.terminal_event.wait())
+        try:
+            done, _ = await asyncio.wait(
+                (queue_task, terminal_task),
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                raise asyncio.TimeoutError
+            if state.terminal_event.is_set():
+                raise state.terminal_error or BrowserDisconnectedError("Browser request terminated")
+            return queue_task.result()
+        finally:
+            for task in (queue_task, terminal_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(queue_task, terminal_task, return_exceptions=True)
 
     def _validate_tab_generation(self, tab: Any, current_generation: int, message: Optional[str] = None):
         if tab:

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -432,6 +432,7 @@ class BrowserRequestExecutor:
         request_id = state.request_id
         stream_start_time = time.monotonic()
         stream_cancelled = False
+        stream_terminated = False
 
         try:
             if state.queue_overflow:
@@ -474,6 +475,13 @@ class BrowserRequestExecutor:
 
             yield await get_done_chunk()
 
+        except (BrowserDisconnectedError, BrowserShuttingDownError) as error:
+            stream_terminated = True
+            logger.info(
+                f"Stream terminated: {request_id}",
+                extra={"request_id": request_id, "reason": type(error).__name__},
+            )
+
         except (asyncio.CancelledError, GeneratorExit):
             duration = time.monotonic() - stream_start_time
             logger.warning(
@@ -488,7 +496,7 @@ class BrowserRequestExecutor:
             raise
 
         finally:
-            if not stream_cancelled:
+            if not stream_cancelled and not stream_terminated:
                 duration = time.monotonic() - stream_start_time
                 logger.info(
                     f"Stream completed: {request_id}",

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -79,6 +79,10 @@ class ProviderSession:
         )
 
     @property
+    def application_shutdown_requested(self) -> bool:
+        return getattr(self.engine, "shutdown_requested", False) is True
+
+    @property
     def metrics(self) -> dict:
         return {
             "provider": self.name,
@@ -148,7 +152,7 @@ class ProviderSession:
         PHASE 1: Semaphore & Registry Lookup (In-memory)
         PHASE 2: Tab Lock Acquisition (Blocking, outside registry_lock)
         """
-        if self.engine.is_shutting_down:
+        if self.engine.is_shutting_down or self.application_shutdown_requested:
             raise BrowserShuttingDownError("BrowserEngine is shutting down")
 
         # 1. Atomic Check-and-Reserve under conversation_lock (Strictly Zero-Await for lookups/mutations)
@@ -343,14 +347,14 @@ class ProviderSession:
 
     async def ensure_healthy(self):
         """Self-healing: Ensures browser process and provider context are functional."""
-        if self.engine.is_shutting_down:
+        if self.engine.is_shutting_down or self.application_shutdown_requested:
             raise BrowserShuttingDownError("Browser engine is shutting down")
             
         async with self.engine.management_lock:
             async with self.init_lock:
                 await self.engine._ensure_healthy_browser()
 
-                if self.engine.is_shutting_down:
+                if self.engine.is_shutting_down or self.application_shutdown_requested:
                     raise BrowserShuttingDownError("Browser engine is shutting down")
 
                 # Atomic Purge on generation rollover
@@ -535,7 +539,7 @@ class ProviderSession:
             self.last_browser_generation = self.engine.browser_generation
             
             # Start background tasks
-            if not self.engine.is_shutting_down:
+            if not self.engine.is_shutting_down and not self.application_shutdown_requested:
                 # Background persistence tasks are strictly disabled in the runtime API service.
                 enable_autosave = (
                     self.enable_persistence and 
@@ -566,7 +570,7 @@ class ProviderSession:
 
     async def _autosave_loop(self):
         try:
-            while not self.engine.is_shutting_down:
+            while not self.engine.is_shutting_down and not self.application_shutdown_requested:
                 await asyncio.sleep(60)
                 if self.is_alive:
                     await self.save_state()
@@ -592,9 +596,9 @@ class ProviderSession:
     async def _eviction_loop(self):
         """Deterministic eviction and stale lease recovery."""
         try:
-            while not self.engine.is_shutting_down:
+            while not self.engine.is_shutting_down and not self.application_shutdown_requested:
                 await asyncio.sleep(30)
-                if self.engine.is_shutting_down: break
+                if self.engine.is_shutting_down or self.application_shutdown_requested: break
                 
                 # Ignore stale generation state and delegate recovery/teardown to rollover purge flow
                 if self.last_browser_generation != self.engine.browser_generation:
@@ -669,9 +673,9 @@ class ProviderSession:
     async def _reaper_loop(self):
         """Active liveness sweeper for IDLE persistent tabs."""
         try:
-            while not self.engine.is_shutting_down:
+            while not self.engine.is_shutting_down and not self.application_shutdown_requested:
                 await asyncio.sleep(30)
-                if self.engine.is_shutting_down: break
+                if self.engine.is_shutting_down or self.application_shutdown_requested: break
                 
                 # Ignore stale generation state and delegate liveness monitoring/recovery to authoritative flow
                 if self.last_browser_generation != self.engine.browser_generation:
@@ -682,7 +686,7 @@ class ProviderSession:
                     continue
 
                 if not self.is_alive:
-                    if not self.engine.is_shutting_down:
+                    if not self.engine.is_shutting_down and not self.application_shutdown_requested:
                         logger.warning(
                             "ProviderSession(%s): Unexpected liveness loss (Window closure). Triggering shutdown.",
                             self.name,
@@ -788,6 +792,17 @@ class ProviderSession:
                 "ProviderSession(%s): Ignoring intentional browser context close.",
                 self.name,
                 extra={"generation": self.last_browser_generation}
+            )
+            return
+
+        if self.application_shutdown_requested:
+            logger.info(
+                "ProviderSession(%s): Ignoring context close during application shutdown.",
+                self.name,
+                extra={
+                    "shutdown_source": self.engine.shutdown_source,
+                    "generation": self.last_browser_generation,
+                },
             )
             return
 

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -5,13 +5,13 @@ import os
 import time
 import weakref
 from collections import OrderedDict
-from typing import Optional, Dict, Any, List, TYPE_CHECKING
+from typing import Optional, Dict, Any, List, TYPE_CHECKING, Callable
 from playwright.async_api import Error as PlaywrightError, Page, BrowserContext
 
 from app.logger import logger
 from app.config import CONFIG, get_default_auth_state_dir
 from app.services.browser.tab import TabStatus, PersistentTab, ManagedPage
-from app.services.browser.errors import BrowserShuttingDownError, LeaseInvalidatedError, SessionNotAliveError, ConversationBusyError
+from app.services.browser.errors import BrowserDisconnectedError, BrowserShuttingDownError, LeaseInvalidatedError, SessionNotAliveError, ConversationBusyError
 
 if TYPE_CHECKING:
     from app.services.browser.engine import BrowserEngine
@@ -56,6 +56,7 @@ class ProviderSession:
         self._orphan_cleanup_tasks = set()
         self.active_orphans = weakref.WeakSet()
         self._intentional_context_closes = weakref.WeakValueDictionary()
+        self._active_request_handles: Dict[str, tuple[Callable[[BaseException], None], Callable[[], None]]] = {}
         
         # Persistent state
         auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
@@ -81,6 +82,25 @@ class ProviderSession:
     @property
     def application_shutdown_requested(self) -> bool:
         return getattr(self.engine, "shutdown_requested", False) is True
+
+    def register_request_abort(
+        self,
+        request_id: str,
+        signal_terminal: Callable[[BaseException], None],
+        abort: Callable[[], None],
+    ) -> None:
+        self._active_request_handles[request_id] = (signal_terminal, abort)
+
+    def unregister_request_abort(self, request_id: str) -> None:
+        self._active_request_handles.pop(request_id, None)
+
+    def signal_active_requests(self, error_factory: Callable[[], BaseException]) -> None:
+        for signal_terminal, _ in tuple(self._active_request_handles.values()):
+            signal_terminal(error_factory())
+
+    def abort_active_requests(self) -> None:
+        for _, abort in tuple(self._active_request_handles.values()):
+            abort()
 
     @property
     def metrics(self) -> dict:
@@ -785,6 +805,16 @@ class ProviderSession:
     async def _on_context_closed(self, context: BrowserContext, generation: int):
         """Handler for BrowserContext.on('close')."""
         if self.engine.is_shutting_down:
+            if (
+                not self._consume_intentional_context_close(context)
+                and generation == self.engine.browser_generation
+                and self.context is context
+            ):
+                self.signal_active_requests(
+                    lambda: BrowserDisconnectedError(
+                        "Browser context closed during active request"
+                    )
+                )
             return
 
         if self._consume_intentional_context_close(context):
@@ -796,6 +826,11 @@ class ProviderSession:
             return
 
         if self.application_shutdown_requested:
+            self.signal_active_requests(
+                lambda: BrowserDisconnectedError(
+                    "Browser context closed during application shutdown"
+                )
+            )
             logger.info(
                 "ProviderSession(%s): Ignoring context close during application shutdown.",
                 self.name,
@@ -819,6 +854,9 @@ class ProviderSession:
             return
         
         logger.warning(f"ProviderSession({self.name}): Context closed (Window manually closed or crash).")
+        self.signal_active_requests(
+            lambda: BrowserDisconnectedError("Browser context closed during active request")
+        )
         # Delegate terminal shutdown to engine
         self.engine._on_browser_disconnected()
 

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -346,47 +346,47 @@ class ProviderSession:
         if self.engine.is_shutting_down:
             raise BrowserShuttingDownError("Browser engine is shutting down")
             
-        async with self.init_lock:
-            async with self.engine.management_lock:
+        async with self.engine.management_lock:
+            async with self.init_lock:
                 await self.engine._ensure_healthy_browser()
 
-            if self.engine.is_shutting_down:
-                raise BrowserShuttingDownError("Browser engine is shutting down")
+                if self.engine.is_shutting_down:
+                    raise BrowserShuttingDownError("Browser engine is shutting down")
 
-            # Atomic Purge on generation rollover
-            if self.last_browser_generation is not None and self.last_browser_generation != self.engine.browser_generation:
-                old_generation = self.last_browser_generation
-                new_generation = self.engine.browser_generation
-                logger.warning(
-                    "ProviderSession(%s): Browser generation rollover (%s -> %s)",
-                    self.name,
-                    old_generation,
-                    new_generation,
-                    extra={
-                        "provider": self.name,
-                        "old_generation": old_generation,
-                        "new_generation": new_generation,
-                        "registry_size": len(self.conversation_registry)
-                    }
-                )
-                await self._purge_all_tabs()
-
-            # 2. Check active liveness of the session-wide keepalive page
-            if not self.is_alive:
-                await self._setup()
-            else:
-                try:
-                    if not self.keepalive_page or self.keepalive_page.is_closed():
-                        await self._setup()
-                    else:
-                        # ACTIVE PROBE: The authority for session liveness
-                        await asyncio.wait_for(self.keepalive_page.evaluate("1"), timeout=2.0)
-                except Exception as e:
+                # Atomic Purge on generation rollover
+                if self.last_browser_generation is not None and self.last_browser_generation != self.engine.browser_generation:
+                    old_generation = self.last_browser_generation
+                    new_generation = self.engine.browser_generation
                     logger.warning(
-                        f"ProviderSession({self.name}) liveness probe failed: {e}. Re-initializing.",
-                        extra={"generation": self.last_browser_generation}
+                        "ProviderSession(%s): Browser generation rollover (%s -> %s)",
+                        self.name,
+                        old_generation,
+                        new_generation,
+                        extra={
+                            "provider": self.name,
+                            "old_generation": old_generation,
+                            "new_generation": new_generation,
+                            "registry_size": len(self.conversation_registry)
+                        }
                     )
-                    await self._setup()
+                    await self._purge_all_tabs()
+
+                # 2. Check active liveness of the session-wide keepalive page
+                if not self.is_alive:
+                    await self._setup_locked()
+                else:
+                    try:
+                        if not self.keepalive_page or self.keepalive_page.is_closed():
+                            await self._setup_locked()
+                        else:
+                            # ACTIVE PROBE: The authority for session liveness
+                            await asyncio.wait_for(self.keepalive_page.evaluate("1"), timeout=2.0)
+                    except Exception as e:
+                        logger.warning(
+                            f"ProviderSession({self.name}) liveness probe failed: {e}. Re-initializing.",
+                            extra={"generation": self.last_browser_generation}
+                        )
+                        await self._setup_locked()
 
     async def _purge_all_tabs(self):
         """Atomically clears and invalidates all tabs in registry."""
@@ -471,9 +471,29 @@ class ProviderSession:
                 )
                 raise
 
+    def _has_resources_to_close(self) -> bool:
+        return any(
+            (
+                self.context is not None,
+                self.keepalive_page is not None,
+                bool(self.conversation_registry),
+                bool(self.active_orphans),
+                self.autosave_task is not None,
+                self.eviction_task is not None,
+                self.reaper_task is not None,
+                bool(self._orphan_cleanup_tasks),
+            )
+        )
+
     async def _setup(self):
+        async with self.engine.management_lock:
+            async with self.init_lock:
+                await self._setup_locked()
+
+    async def _setup_locked(self):
         """Full re-initialization of the provider context."""
-        await self.close_resources(save_state=False)
+        if self._has_resources_to_close():
+            await self.close_resources(save_state=False)
 
         context_args = {
             "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -482,6 +482,7 @@ class ProviderSession:
                 self.eviction_task is not None,
                 self.reaper_task is not None,
                 bool(self._orphan_cleanup_tasks),
+                self._cleanup_lock.locked(),
             )
         )
 

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -6,7 +6,7 @@ import time
 import weakref
 from collections import OrderedDict
 from typing import Optional, Dict, Any, List, TYPE_CHECKING
-from playwright.async_api import Page, BrowserContext
+from playwright.async_api import Error as PlaywrightError, Page, BrowserContext
 
 from app.logger import logger
 from app.config import CONFIG, get_default_auth_state_dir
@@ -35,6 +35,7 @@ class ProviderSession:
         self.active_lease_count = 0
         
         self.init_lock = asyncio.Lock()   # For setup/re-init
+        self._cleanup_lock = asyncio.Lock()  # Serializes session resource cleanup.
         self.registry_lock = asyncio.Lock() # ONLY for trivial registry mutations
         self.conversation_lock = asyncio.Lock() # Protects ONLY active_conversations; MUST NOT be held simultaneously with registry_lock
         self.state_lock = asyncio.Lock()  # For disk I/O
@@ -797,6 +798,10 @@ class ProviderSession:
                     except OSError: pass
 
     async def close_resources(self, save_state: bool = True):
+        async with self._cleanup_lock:
+            await self._close_resources(save_state=save_state)
+
+    async def _close_resources(self, save_state: bool = True):
         """Teardown all session resources and track tasks."""
         try:
             logger.info(
@@ -877,18 +882,55 @@ class ProviderSession:
     
             if self.context:
                 context_to_close = self.context
+                self.context = None
                 self._mark_intentional_context_close(context_to_close)
                 try: 
-                    logger.info(f"ProviderSession({self.name}): Closing browser context...")
-                    await context_to_close.close()
+                    if context_to_close.is_closed():
+                        logger.debug(
+                            f"ProviderSession({self.name}): Browser context already closed.",
+                            extra={"generation": self.last_browser_generation},
+                        )
+                    else:
+                        logger.info(f"ProviderSession({self.name}): Closing browser context...")
+                        await context_to_close.close()
+                except PlaywrightError as close_error:
+                    try:
+                        context_closed = context_to_close.is_closed()
+                    except Exception as inspection_error:
+                        logger.warning(
+                            f"ProviderSession({self.name}): Failed to inspect browser context after close error "
+                            f"{close_error}: {inspection_error}",
+                            exc_info=(
+                                type(close_error),
+                                close_error,
+                                close_error.__traceback__,
+                            ),
+                            extra={"generation": self.last_browser_generation},
+                        )
+                    else:
+                        if context_closed:
+                            logger.debug(
+                                f"ProviderSession({self.name}): Browser context already closed during cleanup.",
+                                extra={"generation": self.last_browser_generation},
+                            )
+                        else:
+                            logger.warning(
+                                f"ProviderSession({self.name}): Failed to close browser context: {close_error}",
+                                exc_info=(
+                                    type(close_error),
+                                    close_error,
+                                    close_error.__traceback__,
+                                ),
+                                extra={"generation": self.last_browser_generation},
+                            )
                 except Exception as e:
-                    self._consume_intentional_context_close(context_to_close)
                     logger.warning(
                         f"ProviderSession({self.name}): Failed to close browser context: {e}",
                         exc_info=True,
                         extra={"generation": self.last_browser_generation}
                     )
-                self.context = None
+                finally:
+                    self._consume_intentional_context_close(context_to_close)
                 
             logger.info(
                 f"ProviderSession({self.name}): Session resources closed successfully.",

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -515,10 +515,13 @@ class ProviderSession:
 
         try:
             self.context = await self.engine.browser.new_context(**context_args)
+            context_generation = self.engine.browser_generation
             
             def safe_on_context_close(c):
                 try:
-                    asyncio.get_running_loop().create_task(self._on_context_closed(c))
+                    asyncio.get_running_loop().create_task(
+                        self._on_context_closed(c, context_generation)
+                    )
                 except RuntimeError as e:
                     logger.debug(
                         "ProviderSession(%s): Context close callback scheduling skipped - event loop already closed: %s",
@@ -775,7 +778,7 @@ class ProviderSession:
     def _consume_intentional_context_close(self, context: BrowserContext) -> bool:
         return self._intentional_context_closes.pop(id(context), None) is context
 
-    async def _on_context_closed(self, context: BrowserContext):
+    async def _on_context_closed(self, context: BrowserContext, generation: int):
         """Handler for BrowserContext.on('close')."""
         if self.engine.is_shutting_down:
             return
@@ -785,6 +788,18 @@ class ProviderSession:
                 "ProviderSession(%s): Ignoring intentional browser context close.",
                 self.name,
                 extra={"generation": self.last_browser_generation}
+            )
+            return
+
+        if generation != self.engine.browser_generation or self.context is not context:
+            logger.debug(
+                "ProviderSession(%s): Ignoring stale browser context close.",
+                self.name,
+                extra={
+                    "context_generation": generation,
+                    "current_generation": self.engine.browser_generation,
+                    "provider": self.name,
+                },
             )
             return
         
@@ -918,6 +933,7 @@ class ProviderSession:
                     try:
                         context_closed = context_to_close.is_closed()
                     except Exception as inspection_error:
+                        self._consume_intentional_context_close(context_to_close)
                         logger.warning(
                             f"ProviderSession({self.name}): Failed to inspect browser context after close error "
                             f"{close_error}: {inspection_error}",
@@ -935,6 +951,7 @@ class ProviderSession:
                                 extra={"generation": self.last_browser_generation},
                             )
                         else:
+                            self._consume_intentional_context_close(context_to_close)
                             logger.warning(
                                 f"ProviderSession({self.name}): Failed to close browser context: {close_error}",
                                 exc_info=(
@@ -945,14 +962,13 @@ class ProviderSession:
                                 extra={"generation": self.last_browser_generation},
                             )
                 except Exception as e:
+                    self._consume_intentional_context_close(context_to_close)
                     logger.warning(
                         f"ProviderSession({self.name}): Failed to close browser context: {e}",
                         exc_info=True,
                         extra={"generation": self.last_browser_generation}
                     )
-                finally:
-                    self._consume_intentional_context_close(context_to_close)
-                
+
             logger.info(
                 f"ProviderSession({self.name}): Session resources closed successfully.",
                 extra={"generation": self.last_browser_generation}

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -84,6 +84,13 @@ class ProviderSession:
     def application_shutdown_requested(self) -> bool:
         return getattr(self.engine, "shutdown_requested", False) is True
 
+    @property
+    def shutdown_in_progress(self) -> bool:
+        return (
+            self.application_shutdown_requested
+            or getattr(self.engine, "is_shutting_down", False) is True
+        )
+
     def register_request_abort(
         self,
         request_id: str,
@@ -510,6 +517,13 @@ class ProviderSession:
 
     async def handle_session_failure(self):
         """Authoritative recovery execution for session failures."""
+        if self.shutdown_in_progress:
+            logger.debug(
+                "ProviderSession(%s): Recovery skipped during shutdown.",
+                self.name,
+                extra={"generation": self.last_browser_generation},
+            )
+            return
         if self._recovery_task and not self._recovery_task.done():
             logger.debug(f"ProviderSession({self.name}): Recovery task already in progress, skipping duplicate request.")
             return
@@ -521,6 +535,13 @@ class ProviderSession:
     async def _do_session_recovery(self):
         recovery_start = time.monotonic()
         async with self.init_lock:
+            if self.shutdown_in_progress:
+                logger.debug(
+                    "ProviderSession(%s): Recovery worker exited during shutdown.",
+                    self.name,
+                    extra={"generation": self.last_browser_generation},
+                )
+                return
             logger.warning(
                 "ProviderSession(%s): Session recovery started",
                 self.name,
@@ -539,6 +560,13 @@ class ProviderSession:
 
             # 2. Invalidate context to force re-setup on next ensure_healthy()
             try:
+                if self.shutdown_in_progress:
+                    logger.debug(
+                        "ProviderSession(%s): Recovery cleanup skipped during shutdown.",
+                        self.name,
+                        extra={"generation": self.last_browser_generation},
+                    )
+                    return
                 await self.close_resources(save_state=False)
                 recovery_duration = time.monotonic() - recovery_start
                 logger.info(

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -57,6 +57,7 @@ class ProviderSession:
         self.active_orphans = weakref.WeakSet()
         self._intentional_context_closes = weakref.WeakValueDictionary()
         self._active_request_handles: Dict[str, tuple[Callable[[BaseException], None], Callable[[], None]]] = {}
+        self._lifecycle_tasks: set[asyncio.Task] = set()
         
         # Persistent state
         auth_state_dir = CONFIG["Playwright"].get("auth_state_dir", get_default_auth_state_dir())
@@ -101,6 +102,66 @@ class ProviderSession:
     def abort_active_requests(self) -> None:
         for _, abort in tuple(self._active_request_handles.values()):
             abort()
+
+    def _track_lifecycle_task(self, task: asyncio.Task, source: str) -> None:
+        if not isinstance(task, asyncio.Future):
+            return
+        self._lifecycle_tasks.add(task)
+
+        def consume_result(done_task: asyncio.Task) -> None:
+            self._lifecycle_tasks.discard(done_task)
+            if done_task.cancelled():
+                return
+            try:
+                error = done_task.exception()
+            except Exception as inspection_error:
+                logger.error(
+                    "ProviderSession(%s): Failed to inspect %s task: %s",
+                    self.name,
+                    source,
+                    inspection_error,
+                    exc_info=True,
+                )
+                return
+            if error is not None:
+                logger.error(
+                    "ProviderSession(%s): %s task failed: %s",
+                    self.name,
+                    source,
+                    error,
+                    exc_info=(type(error), error, error.__traceback__),
+                    extra={"generation": self.last_browser_generation},
+                )
+
+        task.add_done_callback(consume_result)
+
+    async def _drain_lifecycle_tasks(self) -> None:
+        current = asyncio.current_task()
+        tasks = [task for task in self._lifecycle_tasks if task is not current and not task.done()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _drain_orphan_cleanup_tasks(self) -> None:
+        tasks = list(self._orphan_cleanup_tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._orphan_cleanup_tasks.difference_update(tasks)
+            for tab in list(self.active_orphans):
+                if getattr(tab, "_cleanup_task", None) in tasks:
+                    tab._cleanup_task = None
+                    self.active_orphans.discard(tab)
+
+    async def _cancel_pending_recovery(self) -> None:
+        task = self._recovery_task
+        if task and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            self._recovery_task = None
 
     @property
     def metrics(self) -> dict:
@@ -455,6 +516,7 @@ class ProviderSession:
 
         # Synchronously create the recovery task (100% atomic in single-threaded event loop)
         self._recovery_task = asyncio.create_task(self._do_session_recovery())
+        self._track_lifecycle_task(self._recovery_task, "recovery")
 
     async def _do_session_recovery(self):
         recovery_start = time.monotonic()
@@ -543,9 +605,11 @@ class ProviderSession:
             
             def safe_on_context_close(c):
                 try:
-                    asyncio.get_running_loop().create_task(
+                    task = asyncio.get_running_loop().create_task(
                         self._on_context_closed(c, context_generation)
                     )
+                    if task is not None:
+                        self._track_lifecycle_task(task, "context-close")
                 except RuntimeError as e:
                     logger.debug(
                         "ProviderSession(%s): Context close callback scheduling skipped - event loop already closed: %s",
@@ -604,7 +668,8 @@ class ProviderSession:
                     exc_info=True,
                     extra={"generation": self.last_browser_generation}
                 )
-                asyncio.create_task(self.handle_session_failure())
+                task = asyncio.create_task(self.handle_session_failure())
+                self._track_lifecycle_task(task, "recovery-request")
                 raise
             else:
                 logger.error(
@@ -681,7 +746,8 @@ class ProviderSession:
                     exc_info=True,
                     extra={"generation": self.last_browser_generation}
                 )
-                asyncio.create_task(self.handle_session_failure())
+                task = asyncio.create_task(self.handle_session_failure())
+                self._track_lifecycle_task(task, "recovery-request")
                 raise
             else:
                 logger.error(
@@ -787,7 +853,8 @@ class ProviderSession:
                     exc_info=True,
                     extra={"generation": self.last_browser_generation}
                 )
-                asyncio.create_task(self.handle_session_failure())
+                task = asyncio.create_task(self.handle_session_failure())
+                self._track_lifecycle_task(task, "recovery-request")
                 raise
             else:
                 logger.error(
@@ -893,6 +960,9 @@ class ProviderSession:
     async def _close_resources(self, save_state: bool = True):
         """Teardown all session resources and track tasks."""
         try:
+            if getattr(self.engine, "is_shutting_down", False) is True:
+                await self._cancel_pending_recovery()
+
             logger.info(
                 f"ProviderSession({self.name}): Closing session resources...",
                 extra={"generation": self.last_browser_generation}
@@ -945,16 +1015,9 @@ class ProviderSession:
                     )
                 self.reaper_task = None
     
-            # Drain orphan cleanup tasks
-            if hasattr(self, "_orphan_cleanup_tasks"):
-                orphan_tasks = list(self._orphan_cleanup_tasks)
-                for task in orphan_tasks:
-                    if not task.done():
-                        task.cancel()
-                if orphan_tasks:
-                    await asyncio.gather(*orphan_tasks, return_exceptions=True)
-    
+            await self._drain_orphan_cleanup_tasks()
             await self._purge_all_tabs()
+            await self._drain_orphan_cleanup_tasks()
     
             if self.keepalive_page:
                 try:
@@ -1022,6 +1085,9 @@ class ProviderSession:
                         extra={"generation": self.last_browser_generation}
                     )
 
+            await asyncio.sleep(0)
+            await self._drain_lifecycle_tasks()
+
             logger.info(
                 f"ProviderSession({self.name}): Session resources closed successfully.",
                 extra={"generation": self.last_browser_generation}
@@ -1086,6 +1152,7 @@ class ProviderSession:
         task = asyncio.create_task(_delayed_close())
         tab._cleanup_task = task
         self._orphan_cleanup_tasks.add(task)
+        self._track_lifecycle_task(task, "orphan-cleanup")
 
     async def _setup_page_bridge(
         self,

--- a/src/run.py
+++ b/src/run.py
@@ -18,6 +18,13 @@ class ApplicationServer(uvicorn.Server):
         super().handle_exit(sig, frame)
 
 
+def run_server(config):
+    try:
+        ApplicationServer(config).run()
+    except KeyboardInterrupt:
+        pass
+
+
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
@@ -65,4 +72,4 @@ if __name__ == "__main__":
         access_log=not resolved_disable_access,
         workers=1,
     )
-    ApplicationServer(config).run()
+    run_server(config)

--- a/src/run.py
+++ b/src/run.py
@@ -8,6 +8,16 @@ from app.config import CONFIG, resolve_logging_config
 from app.utils.startup import print_server_info, print_gemini_preflight_status
 
 
+class ApplicationServer(uvicorn.Server):
+    """Mark runtime shutdown intent before Uvicorn drains connections."""
+
+    def handle_exit(self, sig, frame):
+        from app.services.browser.engine import request_application_shutdown
+
+        request_application_shutdown()
+        super().handle_exit(sig, frame)
+
+
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
@@ -45,7 +55,7 @@ if __name__ == "__main__":
     print_server_info(args.host, args.port, "webai", default_model=default_model)
 
     # Run the Uvicorn server directly in the main thread
-    uvicorn.run(
+    config = uvicorn.Config(
         webai_app,
         host=args.host,
         port=args.port,
@@ -55,3 +65,4 @@ if __name__ == "__main__":
         access_log=not resolved_disable_access,
         workers=1,
     )
+    ApplicationServer(config).run()

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -77,7 +78,8 @@ async def test_ensure_healthy_browser_noops_after_shutdown(mocker):
     engine.is_shutting_down = True
     async_playwright = mocker.patch("app.services.browser.engine.async_playwright")
 
-    await engine._ensure_healthy_browser()
+    async with engine.management_lock:
+        await engine._ensure_healthy_browser()
 
     async_playwright.assert_not_called()
     assert engine.browser_generation == 4
@@ -92,3 +94,257 @@ async def test_get_page_after_shutdown_fails_fast():
 
     with pytest.raises(BrowserShuttingDownError):
         await engine.get_page("gemini")
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_closes_provider_context_before_old_browser(mocker):
+    engine = BrowserEngine(headless=True)
+    order = []
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_browser.close.side_effect = lambda: order.append("browser")
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock(side_effect=lambda: order.append("playwright"))
+    new_browser = make_browser()
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+
+    session = MagicMock()
+    session.name = "gemini"
+    session._has_resources_to_close.return_value = True
+    session.context = object()
+
+    async def close_resources(*, save_state):
+        assert save_state is False
+        assert session.context is not None
+        session.context = None
+        order.append("session")
+
+    session.close_resources = AsyncMock(side_effect=close_resources)
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.browser_generation = 4
+    engine.sessions = {"gemini": session}
+
+    async with engine.management_lock:
+        await engine._ensure_healthy_browser()
+
+    assert order == ["session", "browser", "playwright"]
+    assert session.context is None
+    assert engine.browser is new_browser
+    assert engine.browser_generation == 5
+    session.close_resources.assert_awaited_once_with(save_state=False)
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_skips_provider_sessions_without_resources(mocker):
+    engine = BrowserEngine(headless=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_browser = make_browser()
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+
+    session = MagicMock()
+    session._has_resources_to_close.return_value = False
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.sessions = {"empty": session}
+
+    async with engine.management_lock:
+        await engine._ensure_healthy_browser()
+
+    session.close_resources.assert_not_called()
+    assert engine.browser_generation == 1
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_cleans_multiple_provider_sessions(mocker):
+    engine = BrowserEngine(headless=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_browser = make_browser()
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+
+    sessions = []
+    for name in ("gemini", "other"):
+        session = MagicMock()
+        session.name = name
+        session._has_resources_to_close.return_value = True
+        session.close_resources = AsyncMock()
+        sessions.append(session)
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.sessions = {session.name: session for session in sessions}
+
+    async with engine.management_lock:
+        await engine._ensure_healthy_browser()
+
+    for session in sessions:
+        session.close_resources.assert_awaited_once_with(save_state=False)
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_cleanup_failure_stops_before_parent_close(mocker):
+    engine = BrowserEngine(headless=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    session = MagicMock()
+    session._has_resources_to_close.return_value = True
+    session.close_resources = AsyncMock(side_effect=RuntimeError("cleanup failed"))
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.sessions = {"gemini": session}
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        async with engine.management_lock:
+            await engine._ensure_healthy_browser()
+
+    old_browser.close.assert_not_awaited()
+    assert engine.browser_generation == 0
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_browser_close_failure_preserves_launch_policy(mocker):
+    engine = BrowserEngine(headless=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_browser.close.side_effect = RuntimeError("old browser close failed")
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_browser = make_browser()
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    session = MagicMock()
+    session._has_resources_to_close.return_value = False
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.sessions = {"gemini": session}
+
+    async with engine.management_lock:
+        await engine._ensure_healthy_browser()
+
+    assert engine.browser is new_browser
+    assert engine.browser_generation == 1
+
+
+@pytest.mark.asyncio
+async def test_replacement_setup_creates_context_on_new_generation(mocker):
+    engine = BrowserEngine(headless=True, is_bootstrap=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_context = MagicMock()
+    new_context.on = MagicMock()
+    new_context.new_page = AsyncMock(return_value=MagicMock())
+    new_browser = make_browser()
+    new_browser.new_context = AsyncMock(return_value=new_context)
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    from app.services.browser.session import ProviderSession
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    session.last_browser_generation = 1
+    session._eviction_loop = AsyncMock()
+    session._reaper_loop = AsyncMock()
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.browser_generation = 1
+    engine.sessions = {"gemini": session}
+
+    await session.ensure_healthy()
+    await session.close_resources(save_state=False)
+
+    assert new_browser.new_context.await_count == 1
+    assert session.last_browser_generation == 2
+    assert session.context is None
+
+
+@pytest.mark.asyncio
+async def test_browser_replacement_launch_failure_does_not_increment_generation(mocker):
+    engine = BrowserEngine(headless=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(side_effect=RuntimeError("launch failed"))
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    session = MagicMock()
+    session._has_resources_to_close.return_value = True
+    session.close_resources = AsyncMock()
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.browser_generation = 7
+    engine.sessions = {"gemini": session}
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        async with engine.management_lock:
+            await engine._ensure_healthy_browser()
+
+    assert engine.browser is None
+    assert engine.browser_generation == 7
+
+
+@pytest.mark.asyncio
+async def test_provider_health_replacement_does_not_deadlock_cleanup(mocker):
+    engine = BrowserEngine(headless=True, is_bootstrap=True)
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_context = MagicMock()
+    new_context.on = MagicMock()
+    new_context.new_page = AsyncMock(return_value=MagicMock())
+    new_browser = make_browser()
+    new_browser.new_context = AsyncMock(return_value=new_context)
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    from app.services.browser.session import ProviderSession
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    session.last_browser_generation = 1
+    session._eviction_loop = AsyncMock()
+    session._reaper_loop = AsyncMock()
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.browser_generation = 1
+    engine.sessions = {"gemini": session}
+
+    await asyncio.wait_for(session.ensure_healthy(), timeout=1)
+
+    assert engine.browser_generation == 2
+    assert new_browser.new_context.await_count == 1
+    assert session.last_browser_generation == 2
+    await session.close_resources(save_state=False)

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -1,5 +1,6 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+import time
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -94,6 +95,89 @@ async def test_shutdown_requested_rejects_new_page_admission():
 
     with pytest.raises(BrowserShuttingDownError):
         await engine.get_page("gemini")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_aborts_active_requests_after_drain_deadline(mocker):
+    engine = BrowserEngine(headless=True)
+    session = MagicMock()
+    session.name = "gemini"
+    session.active_lease_count = 1
+    session.close_resources = AsyncMock()
+
+    def abort_requests():
+        session.active_lease_count = 0
+
+    session.abort_active_requests.side_effect = abort_requests
+    engine.sessions = {"gemini": session}
+    clock_values = iter((0.0, 16.0))
+    real_monotonic = time.monotonic
+    mocker.patch(
+        "app.services.browser.engine.time.monotonic",
+        side_effect=lambda: next(clock_values, real_monotonic()),
+    )
+
+    await engine.close()
+
+    session.abort_active_requests.assert_called_once_with()
+    session.close_resources.assert_awaited_once_with(save_state=True)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_does_not_abort_request_that_releases_during_grace(mocker):
+    engine = BrowserEngine(headless=True)
+    session = MagicMock()
+    session.name = "gemini"
+    session.active_lease_count = 1
+    session.close_resources = AsyncMock()
+
+    async def release_during_grace(_delay):
+        session.active_lease_count = 0
+
+    session.abort_active_requests = Mock()
+    mocker.patch("app.services.browser.engine.asyncio.sleep", side_effect=release_during_grace)
+    engine.sessions = {"gemini": session}
+
+    await engine.close()
+
+    session.abort_active_requests.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_browser_disconnect_signals_all_active_requests(mocker):
+    engine = BrowserEngine(headless=True)
+    session = MagicMock()
+    engine.sessions = {"gemini": session}
+    engine.close = AsyncMock()
+    scheduled = []
+    loop = MagicMock()
+    loop.create_task.side_effect = lambda coroutine: scheduled.append(coroutine)
+    mocker.patch("app.services.browser.engine.asyncio.get_running_loop", return_value=loop)
+
+    engine._on_browser_disconnected()
+
+    session.signal_active_requests.assert_called_once()
+    assert engine.shutdown_source == "browser-disconnect"
+    assert len(scheduled) == 1
+    scheduled.pop().close()
+
+
+@pytest.mark.asyncio
+async def test_browser_disconnect_during_shutdown_signals_without_rescheduling(mocker):
+    engine = BrowserEngine(headless=True)
+    engine.is_shutting_down = True
+    session = MagicMock()
+    engine.sessions = {"gemini": session}
+    engine.close = AsyncMock()
+    loop = MagicMock()
+    loop.create_task = Mock()
+    mocker.patch("app.services.browser.engine.asyncio.get_running_loop", return_value=loop)
+
+    engine._on_browser_disconnected()
+
+    session.signal_active_requests.assert_called_once()
+    loop.create_task.assert_not_called()
+    engine.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -348,3 +348,159 @@ async def test_provider_health_replacement_does_not_deadlock_cleanup(mocker):
     assert new_browser.new_context.await_count == 1
     assert session.last_browser_generation == 2
     await session.close_resources(save_state=False)
+
+
+@pytest.mark.asyncio
+async def test_recovery_cleanup_completes_before_browser_replacement(mocker):
+    engine = BrowserEngine(headless=True, is_bootstrap=True)
+    order = []
+    old_browser = make_browser()
+    old_browser.is_connected.return_value = False
+    old_browser.close.side_effect = lambda: order.append("browser")
+    old_playwright = MagicMock()
+    old_playwright.stop = AsyncMock()
+    new_context = MagicMock()
+    new_context.on = MagicMock()
+    new_context.new_page = AsyncMock(return_value=MagicMock())
+    new_browser = make_browser()
+    new_browser.new_context = AsyncMock(side_effect=lambda **_: (order.append("context"), new_context)[1])
+    new_playwright = MagicMock()
+    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
+    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
+    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    from app.services.browser.session import ProviderSession
+
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    old_context = MagicMock()
+    old_context.is_closed.return_value = False
+
+    async def close_old_context():
+        close_started.set()
+        await release_close.wait()
+        order.append("recovery")
+
+    old_context.close = AsyncMock(side_effect=close_old_context)
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    session.context = old_context
+    session.last_browser_generation = 1
+    session._eviction_loop = AsyncMock()
+    session._reaper_loop = AsyncMock()
+    engine.browser = old_browser
+    engine.playwright = old_playwright
+    engine.browser_generation = 1
+    engine.sessions = {"gemini": session}
+
+    recovery = asyncio.create_task(session._do_session_recovery())
+    await close_started.wait()
+    replacement = asyncio.create_task(session.ensure_healthy())
+
+    release_close.set()
+    await asyncio.gather(recovery, replacement)
+    await session.close_resources(save_state=False)
+
+    assert order.index("recovery") < order.index("browser") < order.index("context")
+    assert session.last_browser_generation == 2
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_ensure_healthy_before_closing_browser(mocker):
+    engine = BrowserEngine(headless=True, is_bootstrap=True)
+    browser = make_browser()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    context = MagicMock()
+    context.is_closed.return_value = False
+    context.close = AsyncMock()
+    context.on = MagicMock()
+    context.new_page = AsyncMock(return_value=MagicMock())
+    browser.new_context = AsyncMock(return_value=context)
+    health_started = asyncio.Event()
+    release_health = asyncio.Event()
+
+    async def block_health():
+        health_started.set()
+        await release_health.wait()
+
+    engine._ensure_healthy_browser = block_health
+    engine.browser = browser
+    engine.playwright = playwright
+    engine.browser_generation = 1
+    from app.services.browser.session import ProviderSession
+
+    session = ProviderSession(engine, "gemini", enable_persistence=True)
+    session._eviction_loop = AsyncMock()
+    session._reaper_loop = AsyncMock()
+    engine.sessions = {"gemini": session}
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+
+    ensure_task = asyncio.create_task(session.ensure_healthy())
+    await health_started.wait()
+    shutdown_task = asyncio.create_task(engine.close())
+    assert engine._shutdown_started is False
+    release_health.set()
+    await ensure_task
+    await shutdown_task
+
+    assert engine._shutdown_started is True
+    assert browser.close.await_count == 1
+    assert context.close.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_first_rejects_ensure_without_context_creation():
+    engine = BrowserEngine(headless=True)
+    await engine.close()
+    from app.services.browser.session import ProviderSession
+
+    session = ProviderSession(engine, "gemini")
+    session._setup_locked = AsyncMock()
+
+    with pytest.raises(BrowserShuttingDownError):
+        await session.ensure_healthy()
+
+    session._setup_locked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_pending_recovery_cleanup(mocker):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    context = MagicMock()
+    context.is_closed.return_value = False
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def close_context():
+        close_started.set()
+        await release_close.wait()
+
+    context.close = AsyncMock(side_effect=close_context)
+    engine.browser = browser
+    engine.playwright = playwright
+    engine.browser_generation = 1
+    from app.services.browser.session import ProviderSession
+
+    session = ProviderSession(engine, "gemini")
+    session.context = context
+    engine.sessions = {"gemini": session}
+
+    recovery = asyncio.create_task(session._do_session_recovery())
+    await close_started.wait()
+    shutdown = asyncio.create_task(engine.close())
+    release_close.set()
+    await asyncio.gather(recovery, shutdown)
+
+    assert session.context is None
+    assert engine.is_shutting_down is True
+    assert browser.close.await_count == 1

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -42,6 +42,61 @@ async def test_engine_close_sets_terminal_shutdown_and_closes_owned_resources():
 
 
 @pytest.mark.asyncio
+async def test_application_shutdown_intent_is_idempotent_before_close():
+    engine = BrowserEngine(headless=True)
+
+    assert engine.request_shutdown("application") is True
+    assert engine.request_shutdown("application") is False
+    assert engine.shutdown_requested is True
+    assert engine.shutdown_source == "application"
+    assert engine._shutdown_started is False
+
+    engine.close = AsyncMock()
+    engine._on_browser_disconnected()
+
+    engine.close.assert_not_awaited()
+    assert engine._shutdown_started is False
+
+
+@pytest.mark.asyncio
+async def test_application_shutdown_close_preserves_application_source():
+    engine = BrowserEngine(headless=True)
+    engine.request_shutdown("application")
+
+    await engine.close(source="application")
+
+    assert engine.shutdown_source == "application"
+    assert engine._shutdown_started is True
+
+
+@pytest.mark.asyncio
+async def test_browser_disconnect_source_wins_before_application_intent(mocker):
+    engine = BrowserEngine(headless=True)
+    scheduled = []
+    loop = MagicMock()
+    loop.create_task.side_effect = lambda coroutine: scheduled.append(coroutine)
+    mocker.patch("app.services.browser.engine.asyncio.get_running_loop", return_value=loop)
+    engine.close = AsyncMock()
+
+    engine._on_browser_disconnected()
+    engine.request_shutdown("application")
+
+    assert engine.shutdown_source == "browser-disconnect"
+    assert len(scheduled) == 1
+    scheduled.pop().close()
+    engine.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_requested_rejects_new_page_admission():
+    engine = BrowserEngine(headless=True)
+    engine.request_shutdown("application")
+
+    with pytest.raises(BrowserShuttingDownError):
+        await engine.get_page("gemini")
+
+
+@pytest.mark.asyncio
 async def test_engine_close_is_idempotent():
     engine = BrowserEngine(headless=True)
     browser = make_browser()

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -3,6 +3,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from playwright.async_api import Error as PlaywrightError
 
 from app.services.browser.engine import BrowserEngine
 from app.services.browser.errors import BrowserShuttingDownError
@@ -68,6 +69,90 @@ async def test_application_shutdown_close_preserves_application_source():
 
     assert engine.shutdown_source == "application"
     assert engine._shutdown_started is True
+
+
+@pytest.mark.asyncio
+async def test_terminal_close_skips_disconnected_browser_and_stops_playwright():
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.return_value = False
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    engine.browser = browser
+    engine.playwright = playwright
+
+    await engine.close()
+
+    browser.close.assert_not_awaited()
+    playwright.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_browser_close_transport_race_is_benign_after_disconnect(caplog):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, False]
+    browser.close.side_effect = PlaywrightError("transport closed")
+    engine.browser = browser
+
+    await engine.close()
+
+    browser.close.assert_awaited_once()
+    assert not any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_browser_close_error_while_connected_remains_warning(caplog):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.return_value = True
+    browser.close.side_effect = PlaywrightError("close failed")
+    engine.browser = browser
+
+    await engine.close()
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_generic_browser_close_error_warns_after_disconnect(caplog):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, False]
+    browser.close.side_effect = RuntimeError("programming failure")
+    engine.browser = browser
+
+    await engine.close()
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_generic_browser_close_error_warns_while_connected(caplog):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.return_value = True
+    browser.close.side_effect = RuntimeError("programming failure")
+    engine.browser = browser
+
+    await engine.close()
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_playwright_close_inspection_failure_preserves_original_error(caplog):
+    engine = BrowserEngine(headless=True)
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, RuntimeError("inspection failed")]
+    browser.close.side_effect = PlaywrightError("close transport failure")
+    engine.browser = browser
+
+    await engine.close()
+
+    messages = [record.message for record in caplog.records]
+    assert any("close transport failure" in message for message in messages)
+    assert any("inspection failed" in message for message in messages)
 
 
 @pytest.mark.asyncio
@@ -181,6 +266,26 @@ async def test_browser_disconnect_during_shutdown_signals_without_rescheduling(m
 
 
 @pytest.mark.asyncio
+async def test_disconnect_close_task_is_tracked_and_exception_retrieved(caplog):
+    engine = BrowserEngine(headless=True)
+
+    async def fail_close(*_args, **_kwargs):
+        raise RuntimeError("disconnect close failed")
+
+    engine.close = fail_close
+    engine._on_browser_disconnected()
+    task = engine._disconnect_close_task
+
+    assert task is not None
+    with pytest.raises(RuntimeError, match="disconnect close failed"):
+        await task
+    await asyncio.sleep(0)
+
+    assert engine._disconnect_close_task is None
+    assert any("Disconnect shutdown task failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_engine_close_is_idempotent():
     engine = BrowserEngine(headless=True)
     browser = make_browser()
@@ -270,7 +375,7 @@ async def test_browser_replacement_closes_provider_context_before_old_browser(mo
     async with engine.management_lock:
         await engine._ensure_healthy_browser()
 
-    assert order == ["session", "browser", "playwright"]
+    assert order == ["session", "playwright"]
     assert session.context is None
     assert engine.browser is new_browser
     assert engine.browser_generation == 5
@@ -543,7 +648,7 @@ async def test_recovery_cleanup_completes_before_browser_replacement(mocker):
     await asyncio.gather(recovery, replacement)
     await session.close_resources(save_state=False)
 
-    assert order.index("recovery") < order.index("browser") < order.index("context")
+    assert order == ["recovery", "context"]
     assert session.last_browser_generation == 2
 
 

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -35,7 +35,7 @@ async def test_engine_close_sets_terminal_shutdown_and_closes_owned_resources():
 
     assert engine.is_shutting_down is True
     assert engine._shutdown_started is True
-    session.close_resources.assert_awaited_once_with(save_state=True)
+    session.close_resources.assert_awaited_once_with(save_state=False)
     browser.close.assert_awaited_once()
     playwright.stop.assert_awaited_once()
     assert engine.sessions == {}
@@ -69,6 +69,20 @@ async def test_application_shutdown_close_preserves_application_source():
 
     assert engine.shutdown_source == "application"
     assert engine._shutdown_started is True
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_engine_close_preserves_persistence_save():
+    engine = BrowserEngine(headless=True, is_bootstrap=True)
+    session = MagicMock()
+    session.name = "gemini"
+    session.active_lease_count = 0
+    session.close_resources = AsyncMock()
+    engine.sessions = {"gemini": session}
+
+    await engine.close()
+
+    session.close_resources.assert_awaited_once_with(save_state=True)
 
 
 @pytest.mark.asyncio
@@ -205,7 +219,7 @@ async def test_shutdown_aborts_active_requests_after_drain_deadline(mocker):
     await engine.close()
 
     session.abort_active_requests.assert_called_once_with()
-    session.close_resources.assert_awaited_once_with(save_state=True)
+    session.close_resources.assert_awaited_once_with(save_state=False)
 
 
 @pytest.mark.asyncio
@@ -303,7 +317,7 @@ async def test_engine_close_is_idempotent():
     await engine.close()
     await engine.close()
 
-    session.close_resources.assert_awaited_once_with(save_state=True)
+    session.close_resources.assert_awaited_once_with(save_state=False)
     browser.close.assert_awaited_once()
     playwright.stop.assert_awaited_once()
 

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -4,6 +4,7 @@ import asyncio
 import pytest
 from playwright.async_api import Error as PlaywrightError
 
+from app.services.browser.errors import BrowserDisconnectedError
 from app.services.browser.session import ProviderSession
 from app.services.providers.gemini.auth_selector import GeminiAuthCandidate
 
@@ -226,6 +227,27 @@ async def test_close_resources_is_idempotent_for_context(mocker):
 
     assert session.context is None
     context.close.assert_awaited_once()
+
+
+def test_active_request_handles_signal_and_abort_once():
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    signals = []
+    aborts = []
+
+    session.register_request_abort("request-1", signals.append, lambda: aborts.append("request-1"))
+    session.register_request_abort("request-2", signals.append, lambda: aborts.append("request-2"))
+    error = BrowserDisconnectedError("browser disconnected")
+
+    session.signal_active_requests(lambda: BrowserDisconnectedError(str(error)))
+    session.abort_active_requests()
+    session.unregister_request_abort("request-1")
+    session.abort_active_requests()
+
+    assert signals[0] is not signals[1]
+    assert [type(value) for value in signals] == [BrowserDisconnectedError, BrowserDisconnectedError]
+    assert [str(value) for value in signals] == [str(error), str(error)]
+    assert aborts == ["request-1", "request-2", "request-2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock
+import asyncio
 
 import pytest
+from playwright.async_api import Error as PlaywrightError
 
 from app.services.browser.session import ProviderSession
 from app.services.providers.gemini.auth_selector import GeminiAuthCandidate
@@ -208,3 +210,128 @@ async def test_gemini_bootstrap_without_persistence_still_requires_auth(mocker):
         await session._setup()
 
     assert "Gemini Playwright backend requires a valid storage state" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_close_resources_is_idempotent_for_context(mocker):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.return_value = False
+    context.close = AsyncMock()
+    session.context = context
+
+    await session.close_resources(save_state=False)
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    context.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_resources_serializes_concurrent_cleanup_and_detaches_context():
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    context = MagicMock()
+    context.is_closed.return_value = False
+
+    async def close_context():
+        close_started.set()
+        await release_close.wait()
+
+    context.close = AsyncMock(side_effect=close_context)
+    session.context = context
+
+    first = asyncio.create_task(session.close_resources(save_state=False))
+    await close_started.wait()
+    assert session.context is None
+
+    second = asyncio.create_task(session.close_resources(save_state=False))
+    await asyncio.sleep(0)
+    assert not second.done()
+
+    release_close.set()
+    await asyncio.gather(first, second)
+
+    context.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_resources_skips_already_closed_context(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.return_value = True
+    context.close = AsyncMock()
+    session.context = context
+
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    context.close.assert_not_awaited()
+    assert "Failed to close browser context" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_resources_tolerates_closed_public_playwright_error(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.side_effect = [False, True]
+    context.close = AsyncMock(side_effect=PlaywrightError("context closed during close"))
+    session.context = context
+
+    await session.close_resources(save_state=False)
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    context.close.assert_awaited_once()
+    assert "Failed to close browser context" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_resources_logs_open_context_public_playwright_error(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.side_effect = [False, False]
+    context.close = AsyncMock(side_effect=PlaywrightError("context close failed"))
+    session.context = context
+
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    assert "Failed to close browser context: context close failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_resources_preserves_close_error_when_state_inspection_fails(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.side_effect = [False, RuntimeError("inspection failed")]
+    context.close = AsyncMock(side_effect=PlaywrightError("original close failure"))
+    session.context = context
+
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    assert "original close failure" in caplog.text
+    assert "inspection failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_resources_logs_unexpected_context_close_error(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    context = MagicMock()
+    context.is_closed.return_value = False
+    context.close = AsyncMock(side_effect=RuntimeError("unexpected close failure"))
+    session.context = context
+
+    await session.close_resources(save_state=False)
+
+    assert session.context is None
+    assert "Failed to close browser context: unexpected close failure" in caplog.text

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -6,6 +6,7 @@ from playwright.async_api import Error as PlaywrightError
 
 from app.services.browser.errors import BrowserDisconnectedError
 from app.services.browser.session import ProviderSession
+from app.services.browser.tab import TabStatus
 from app.services.providers.gemini.auth_selector import GeminiAuthCandidate
 
 
@@ -248,6 +249,59 @@ def test_active_request_handles_signal_and_abort_once():
     assert [type(value) for value in signals] == [BrowserDisconnectedError, BrowserDisconnectedError]
     assert [str(value) for value in signals] == [str(error), str(error)]
     assert aborts == ["request-1", "request-2", "request-2"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_cleanup_drains_orphan_tasks_created_by_purge():
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    tab = MagicMock()
+    tab.status = TabStatus.LEASED
+    tab.lease_token = "token"
+    tab.invalidate.side_effect = lambda: setattr(tab, "status", TabStatus.INVALIDATING)
+    session.conversation_registry["conversation"] = tab
+
+    await session.close_resources(save_state=False)
+
+    assert not session._orphan_cleanup_tasks
+    assert tab._cleanup_task is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_cleanup_cancels_pending_recovery_task():
+    engine, _ = make_engine()
+    engine.is_shutting_down = True
+    session = ProviderSession(engine, "test_provider")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def pending_recovery():
+        started.set()
+        await release.wait()
+
+    session._recovery_task = asyncio.create_task(pending_recovery())
+    await started.wait()
+    await session.close_resources(save_state=False)
+
+    assert session._recovery_task is None
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_task_exception_is_retrieved(caplog):
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+
+    async def fail_task():
+        raise RuntimeError("lifecycle task failed")
+
+    task = asyncio.create_task(fail_task())
+    session._track_lifecycle_task(task, "context-close")
+
+    with pytest.raises(RuntimeError, match="lifecycle task failed"):
+        await task
+
+    assert not session._lifecycle_tasks
+    assert any("context-close task failed" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -9,7 +9,7 @@ from playwright.async_api import Error as PlaywrightError
 
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.auth_types import AuthStatus
-from app.services.browser.errors import BrowserDisconnectedError
+from app.services.browser.errors import BrowserDisconnectedError, BrowserShuttingDownError
 from app.services.factory import ProviderFactory
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter,
@@ -85,6 +85,37 @@ async def collect_stream_chunks(response: StreamingResponse) -> list[str]:
     async for chunk in response.body_iterator:
         chunks.append(chunk)
     return chunks
+
+
+async def run_streaming_response(response: StreamingResponse, on_start=None, messages=None) -> list[dict]:
+    messages = messages if messages is not None else []
+
+    async def receive():
+        await asyncio.sleep(3600)
+
+    async def send(message):
+        messages.append(message)
+        if message["type"] == "http.response.start" and on_start:
+            on_start()
+
+    await response(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/chat/completions",
+            "raw_path": b"/v1/chat/completions",
+            "query_string": b"",
+            "headers": [],
+            "client": ("test", 1),
+            "server": ("test", 80),
+        },
+        receive,
+        send,
+    )
+    return messages
 
 
 def parse_sse_chunk(chunk: str) -> dict:
@@ -331,7 +362,7 @@ async def test_buffered_request_abort_cancels_task_and_releases_lease(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_stream_fails_promptly_when_page_crashes(monkeypatch, caplog):
+async def test_stream_ends_without_done_when_page_crashes(monkeypatch, caplog):
     page = make_mock_page()
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
@@ -366,14 +397,180 @@ async def test_stream_fails_promptly_when_page_crashes(monkeypatch, caplog):
 
     crash_handler(page)
 
-    with pytest.raises(BrowserDisconnectedError):
-        await stream_task
+    chunks = await stream_task
 
+    assert chunks == []
     assert any(
         record.message == "Page crash detected" and record.levelname == "WARNING"
         for record in caplog.records
     )
     lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_handles_page_close_after_headers(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+    request_handles = {}
+
+    session.register_request_abort = MagicMock(side_effect=lambda request_id, signal, abort: request_handles.update({request_id: (signal, abort)}))
+    session.unregister_request_abort = MagicMock()
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    response = await GeminiProvider().chat_completions(make_request(stream=True))
+    close_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "close")
+    messages = await run_streaming_response(response, on_start=lambda: close_handler(page))
+
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == 200
+    assert not any(message.get("body") == b"data: [DONE]\n\n" for message in messages if message["type"] == "http.response.body")
+    assert isinstance(state_ref["state"].terminal_error, BrowserDisconnectedError)
+    session.unregister_request_abort.assert_called_once_with(state_ref["state"].request_id)
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_handles_application_shutdown_page_close(monkeypatch, caplog):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    engine = await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+    engine.shutdown_requested = True
+
+    response = await GeminiProvider().chat_completions(make_request(stream=True))
+    close_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "close")
+    messages = await run_streaming_response(response, on_start=lambda: close_handler(page))
+
+    assert messages[0]["status"] == 200
+    assert not any(message.get("body") == b"data: [DONE]\n\n" for message in messages if message["type"] == "http.response.body")
+    assert isinstance(state_ref["state"].terminal_error, BrowserDisconnectedError)
+    assert not any(record.levelname == "WARNING" and record.message == "Page close detected" for record in caplog.records)
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_handles_forced_shutdown_abort(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    response = await GeminiProvider().chat_completions(make_request(stream=True))
+    messages = await run_streaming_response(
+        response,
+        on_start=lambda: state_ref["state"].signal_terminal(
+            BrowserShuttingDownError("Browser request aborted during engine shutdown")
+        ),
+    )
+
+    assert messages[0]["status"] == 200
+    assert not any(message.get("body") == b"data: [DONE]\n\n" for message in messages if message["type"] == "http.response.body")
+    assert isinstance(state_ref["state"].terminal_error, BrowserShuttingDownError)
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_handles_real_request_abort(monkeypatch, caplog):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+    request_handles = {}
+    payload_wait_started = asyncio.Event()
+    messages = []
+    created_tasks = []
+    real_create_task = asyncio.create_task
+
+    def track_create_task(coro, *args, **kwargs):
+        task = real_create_task(coro, *args, **kwargs)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", track_create_task)
+
+    session.register_request_abort = MagicMock(
+        side_effect=lambda request_id, signal, abort: request_handles.update({request_id: (signal, abort)})
+    )
+    session.unregister_request_abort = MagicMock()
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+    provider = GeminiProvider()
+    original_wait = provider.playwright_adapter.executor._wait_for_payload
+
+    async def wait_for_payload(*args, **kwargs):
+        payload_wait_started.set()
+        return await original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(provider.playwright_adapter.executor, "_wait_for_payload", wait_for_payload)
+    response = await provider.chat_completions(make_request(stream=True))
+
+    abort_task_ref = {}
+
+    async def abort_after_payload_wait():
+        await payload_wait_started.wait()
+        request_id = state_ref["state"].request_id
+        request_handles[request_id][1]()
+
+    def on_start():
+        state_ref["state"].request_task = asyncio.current_task()
+        abort_task_ref["task"] = asyncio.create_task(abort_after_payload_wait())
+
+    response_task = asyncio.create_task(run_streaming_response(response, on_start, messages))
+    await response_task
+    await abort_task_ref["task"]
+
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == 200
+    assert not any(message.get("body") == b"data: [DONE]\n\n" for message in messages if message["type"] == "http.response.body")
+    assert isinstance(state_ref["state"].terminal_error, BrowserShuttingDownError)
+    session.unregister_request_abort.assert_called_once_with(state_ref["state"].request_id)
+    lease.close.assert_awaited_once()
+    assert any(record.message == "Stream cancelled: " + state_ref["state"].request_id for record in caplog.records)
+    assert not any(record.message == "Stream completed: " + state_ref["state"].request_id for record in caplog.records)
+    assert all(task.done() for task in created_tasks)
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -8,6 +8,7 @@ from fastapi.responses import StreamingResponse
 
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.auth_types import AuthStatus
+from app.services.browser.errors import BrowserDisconnectedError
 from app.services.factory import ProviderFactory
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter,
@@ -173,6 +174,114 @@ async def test_stream_started_confirms_submission_without_emitting_content(monke
     assert isinstance(response, StreamingResponse)
     chunks = await collect_stream_chunks(response)
     assert chunks == ["data: [DONE]\n\n"]
+
+
+@pytest.mark.asyncio
+async def test_buffered_request_fails_promptly_when_page_closes(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ready = asyncio.Event()
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        state_ready.set()
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    request_task = asyncio.create_task(provider.chat_completions(make_request(stream=False)))
+    await state_ready.wait()
+    close_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "close")
+
+    close_handler(page)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await request_task
+
+    assert exc_info.value.status_code == 502
+    assert "timed out" not in str(exc_info.value.detail).lower()
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_buffered_request_abort_cancels_task_and_releases_lease(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ready = asyncio.Event()
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        state_ready.set()
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    request_task = asyncio.create_task(provider.chat_completions(make_request(stream=False)))
+    await state_ready.wait()
+    state_ref["state"].abort()
+
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_fails_promptly_when_page_crashes(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ready = asyncio.Event()
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        state_ready.set()
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    original_wait = provider.playwright_adapter.executor._wait_for_payload
+    wait_started = asyncio.Event()
+
+    async def wait_for_payload(*args, **kwargs):
+        wait_started.set()
+        return await original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(provider.playwright_adapter.executor, "_wait_for_payload", wait_for_payload)
+    stream_task = asyncio.create_task(collect_stream_chunks(response))
+    await wait_started.wait()
+    crash_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "crash")
+
+    crash_handler(page)
+
+    with pytest.raises(BrowserDisconnectedError):
+        await stream_task
+
+    lease.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
+from playwright.async_api import Error as PlaywrightError
 
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.auth_types import AuthStatus
@@ -213,6 +214,41 @@ async def test_buffered_request_fails_promptly_when_page_closes(monkeypatch, cap
         record.message == "Page close detected" and record.levelname == "WARNING"
         for record in caplog.records
     )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_terminal_browser_error_precedes_later_playwright_close_error(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    operation_started = asyncio.Event()
+    release_operation = asyncio.Event()
+
+    async def submit_prompt(_page, _prompt, _state):
+        operation_started.set()
+        await release_operation.wait()
+        raise PlaywrightError("Target page, context or browser has been closed")
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    request_task = asyncio.create_task(provider.chat_completions(make_request(stream=False)))
+    await operation_started.wait()
+    close_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "close")
+    close_handler(page)
+    release_operation.set()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await request_task
+
+    assert exc_info.value.status_code == 502
+    assert "timed out" not in str(exc_info.value.detail).lower()
     lease.close.assert_awaited_once()
 
 

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -103,6 +103,7 @@ async def configure_playwright_success(
     mock_engine = MagicMock()
     mock_engine.browser_generation = 1
     mock_engine.get_session = AsyncMock(return_value=session)
+    session.engine = mock_engine
 
     async def mock_get_browser_engine():
         return mock_engine
@@ -177,7 +178,7 @@ async def test_stream_started_confirms_submission_without_emitting_content(monke
 
 
 @pytest.mark.asyncio
-async def test_buffered_request_fails_promptly_when_page_closes(monkeypatch):
+async def test_buffered_request_fails_promptly_when_page_closes(monkeypatch, caplog):
     page = make_mock_page()
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
@@ -208,6 +209,57 @@ async def test_buffered_request_fails_promptly_when_page_closes(monkeypatch):
 
     assert exc_info.value.status_code == 502
     assert "timed out" not in str(exc_info.value.detail).lower()
+    assert any(
+        record.message == "Page close detected" and record.levelname == "WARNING"
+        for record in caplog.records
+    )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_page_close_during_application_shutdown_is_not_warning(monkeypatch, caplog):
+    page = make_mock_page()
+    persistent_tab = MagicMock(browser_generation=1)
+    lease = make_mock_lease(page, persistent_tab=persistent_tab)
+    session = make_mock_session(lease)
+    state_ready = asyncio.Event()
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        state_ready.set()
+        return True
+
+    engine = await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+    engine.shutdown_requested = True
+
+    provider = GeminiProvider()
+    request_task = asyncio.create_task(provider.chat_completions(make_request(stream=False)))
+    await state_ready.wait()
+    close_handler = next(call.args[1] for call in page.on.call_args_list if call.args[0] == "close")
+
+    close_handler(page)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await request_task
+
+    assert exc_info.value.status_code == 502
+    assert not any(
+        record.message == "Page close detected" and record.levelname == "WARNING"
+        for record in caplog.records
+    )
+    assert any(
+        record.message == "Page close detected" and record.levelname in {"INFO", "DEBUG"}
+        for record in caplog.records
+    )
+    assert state_ref["state"].page_poisoned is True
+    persistent_tab.invalidate.assert_called()
+    assert state_ref["state"].terminal_event.is_set()
     lease.close.assert_awaited_once()
 
 
@@ -243,7 +295,7 @@ async def test_buffered_request_abort_cancels_task_and_releases_lease(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_stream_fails_promptly_when_page_crashes(monkeypatch):
+async def test_stream_fails_promptly_when_page_crashes(monkeypatch, caplog):
     page = make_mock_page()
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
@@ -281,6 +333,10 @@ async def test_stream_fails_promptly_when_page_crashes(monkeypatch):
     with pytest.raises(BrowserDisconnectedError):
         await stream_task
 
+    assert any(
+        record.message == "Page crash detected" and record.levelname == "WARNING"
+        for record in caplog.records
+    )
     lease.close.assert_awaited_once()
 
 

--- a/tests/test_generation_invalidation.py
+++ b/tests/test_generation_invalidation.py
@@ -42,7 +42,7 @@ async def test_ensure_healthy_purges_tabs_on_generation_rollover(mocker):
         session.keepalive_page = keepalive_page
         session.last_browser_generation = engine.browser_generation
 
-    session._setup = AsyncMock(side_effect=mark_session_healthy)
+    session._setup_locked = AsyncMock(side_effect=mark_session_healthy)
     schedule_orphan_cleanup = mocker.patch.object(session, "_schedule_orphan_cleanup")
 
     idle_page = make_page()

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from unittest.mock import Mock, AsyncMock, MagicMock
 from app.services.browser.session import ProviderSession
-from app.services.browser.errors import TransientSessionError
+from app.services.browser.errors import BrowserDisconnectedError, TransientSessionError
 from app.services.browser.engine import BrowserEngine
 from app.services.providers.gemini.provider import GeminiProvider
 from app.schemas.request import OpenAIChatRequest
@@ -249,6 +249,28 @@ async def test_application_shutdown_context_close_does_not_trigger_crash_shutdow
     await session._on_context_closed(context, mock_engine.browser_generation)
 
     mock_engine._on_browser_disconnected.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_context_close_during_engine_shutdown_signals_active_requests(tmp_path):
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = True
+    mock_engine.shutdown_requested = False
+
+    session = ProviderSession(mock_engine, "test_provider")
+    context = MagicMock()
+    session.context = context
+    signal_terminal = Mock()
+    session.register_request_abort("request-1", signal_terminal, Mock())
+
+    await session._on_context_closed(context, mock_engine.browser_generation)
+
+    signal_terminal.assert_called_once()
+    error = signal_terminal.call_args.args[0]
+    assert isinstance(error, BrowserDisconnectedError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -232,6 +232,26 @@ async def test_unexpected_provider_context_close_triggers_engine_shutdown(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_application_shutdown_context_close_does_not_trigger_crash_shutdown(tmp_path):
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+    mock_engine.shutdown_requested = True
+    mock_engine.shutdown_source = "application"
+    mock_engine._on_browser_disconnected = Mock()
+
+    session = ProviderSession(mock_engine, "test_provider")
+    context = MagicMock()
+    session.context = context
+
+    await session._on_context_closed(context, mock_engine.browser_generation)
+
+    mock_engine._on_browser_disconnected.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_delayed_intentional_context_callback_cannot_shutdown_new_generation(tmp_path, mocker):
     old_context = MagicMock()
     old_context.is_closed.return_value = False

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -201,6 +201,7 @@ async def test_intentional_provider_context_cleanup_does_not_shutdown_engine(tmp
 
     session = ProviderSession(mock_engine, "test_provider")
     context = MagicMock()
+    context.is_closed.return_value = False
     async def close_context():
         await session._on_context_closed(context)
     context.close = AsyncMock(side_effect=close_context)
@@ -833,4 +834,3 @@ async def test_www_authenticate_header_exists_on_401(monkeypatch):
     assert "Authentication expired." in excinfo.value.detail
     assert excinfo.value.headers is not None
     assert excinfo.value.headers.get("WWW-Authenticate") == "Bearer"
-

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -203,7 +203,7 @@ async def test_intentional_provider_context_cleanup_does_not_shutdown_engine(tmp
     context = MagicMock()
     context.is_closed.return_value = False
     async def close_context():
-        await session._on_context_closed(context)
+        await session._on_context_closed(context, session.engine.browser_generation)
     context.close = AsyncMock(side_effect=close_context)
     session.context = context
 
@@ -224,10 +224,58 @@ async def test_unexpected_provider_context_close_triggers_engine_shutdown(tmp_pa
 
     session = ProviderSession(mock_engine, "test_provider")
     context = MagicMock()
+    session.context = context
 
-    await session._on_context_closed(context)
+    await session._on_context_closed(context, session.engine.browser_generation)
 
     mock_engine._on_browser_disconnected.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delayed_intentional_context_callback_cannot_shutdown_new_generation(tmp_path, mocker):
+    old_context = MagicMock()
+    old_context.is_closed.return_value = False
+    old_context.close = AsyncMock()
+    old_context.new_page = AsyncMock(return_value=MagicMock())
+
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+    mock_engine.is_bootstrap = True
+    mock_engine.browser.new_context = AsyncMock(return_value=old_context)
+    mock_engine._on_browser_disconnected = Mock()
+
+    session = ProviderSession(mock_engine, "test_provider", enable_persistence=True)
+    mocker.patch(
+        "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
+        return_value=iter([]),
+    )
+    mocker.patch.object(session, "_eviction_loop", AsyncMock())
+    mocker.patch.object(session, "_reaper_loop", AsyncMock())
+
+    await session._setup()
+    delayed_callback = old_context.on.call_args.args[1]
+
+    await session.close_resources(save_state=False)
+
+    new_context = MagicMock()
+    mock_engine.browser_generation = 2
+    session.context = new_context
+    session.last_browser_generation = 2
+
+    scheduled = []
+    loop = MagicMock()
+    loop.create_task.side_effect = lambda coroutine: scheduled.append(coroutine)
+    mocker.patch("app.services.browser.session.asyncio.get_running_loop", return_value=loop)
+
+    delayed_callback(old_context)
+    assert len(scheduled) == 1
+    await scheduled.pop()
+
+    mock_engine._on_browser_disconnected.assert_not_called()
+    assert session.context is new_context
 
 
 @pytest.mark.asyncio

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -67,6 +67,65 @@ async def test_recovery_orchestration_atomic_non_blocking(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_shutdown_requested_skips_recovery_task(tmp_path):
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+    mock_engine.shutdown_requested = True
+    session = ProviderSession(mock_engine, "test_provider")
+    session._do_session_recovery = AsyncMock()
+
+    await session.handle_session_failure()
+
+    assert session._recovery_task is None
+    session._do_session_recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_engine_shutdown_skips_recovery_task(tmp_path):
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = True
+    mock_engine.shutdown_requested = False
+    session = ProviderSession(mock_engine, "test_provider")
+    session._do_session_recovery = AsyncMock()
+
+    await session.handle_session_failure()
+
+    assert session._recovery_task is None
+    session._do_session_recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_requested_between_recovery_schedule_and_worker_exit(tmp_path):
+    mock_engine = MagicMock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+    mock_engine.shutdown_requested = False
+    session = ProviderSession(mock_engine, "test_provider")
+    session.close_resources = AsyncMock()
+
+    await session.init_lock.acquire()
+    try:
+        await session.handle_session_failure()
+        recovery_task = session._recovery_task
+        mock_engine.shutdown_requested = True
+    finally:
+        session.init_lock.release()
+
+    await recovery_task
+
+    session.close_resources.assert_not_awaited()
+    assert session._recovery_task is recovery_task
+
+
+@pytest.mark.asyncio
 async def test_transient_auth_failure_retry_and_lease_release(monkeypatch):
     """Verify that a transient auth failure during pre-submission triggers retry,
 

--- a/tests/test_server_shutdown.py
+++ b/tests/test_server_shutdown.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import uvicorn
 
 from app.services.browser.engine import BrowserEngine
-from run import ApplicationServer
+from run import ApplicationServer, run_server
 
 
 def make_server():
@@ -50,3 +50,35 @@ def test_application_shutdown_hook_does_not_require_existing_engine(mocker):
 
     uvicorn_exit.assert_called_once()
     assert uvicorn_exit.call_args.args[1:] == (sig, frame)
+
+
+def test_run_server_suppresses_top_level_keyboard_interrupt(mocker):
+    config = MagicMock()
+    server = mocker.patch("run.ApplicationServer")
+    server.return_value.run.side_effect = KeyboardInterrupt
+
+    run_server(config)
+
+    server.assert_called_once_with(config)
+    server.return_value.run.assert_called_once_with()
+
+
+def test_run_server_propagates_runtime_error(mocker):
+    config = MagicMock()
+    server = mocker.patch("run.ApplicationServer")
+    server.return_value.run.side_effect = RuntimeError("startup failed")
+
+    try:
+        run_server(config)
+    except RuntimeError as error:
+        assert str(error) == "startup failed"
+    else:
+        raise AssertionError("RuntimeError was suppressed")
+
+
+def test_run_server_returns_normally_when_server_returns(mocker):
+    config = MagicMock()
+    server = mocker.patch("run.ApplicationServer")
+
+    assert run_server(config) is None
+    server.return_value.run.assert_called_once_with()

--- a/tests/test_server_shutdown.py
+++ b/tests/test_server_shutdown.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import uvicorn
+
+from app.services.browser.engine import BrowserEngine
+from run import ApplicationServer
+
+
+def make_server():
+    return ApplicationServer(uvicorn.Config(lambda scope, receive, send: None))
+
+
+def test_application_shutdown_intent_precedes_uvicorn_exit(mocker):
+    calls = []
+    sig = object()
+    frame = object()
+
+    request_shutdown = mocker.patch(
+        "app.services.browser.engine.request_application_shutdown",
+        side_effect=lambda: calls.append("application-shutdown"),
+    )
+    uvicorn_exit = mocker.patch.object(
+        uvicorn.Server,
+        "handle_exit",
+        autospec=True,
+        side_effect=lambda server, received_sig, received_frame: calls.append(
+            ("uvicorn-exit", received_sig, received_frame)
+        ),
+    )
+
+    make_server().handle_exit(sig, frame)
+
+    assert calls == ["application-shutdown", ("uvicorn-exit", sig, frame)]
+    request_shutdown.assert_called_once_with()
+    uvicorn_exit.assert_called_once()
+    assert uvicorn_exit.call_args.args[1:] == (sig, frame)
+
+
+def test_application_shutdown_hook_does_not_require_existing_engine(mocker):
+    frame = MagicMock()
+    sig = object()
+    mocker.patch.object(BrowserEngine, "_instance", None)
+    uvicorn_exit = mocker.patch.object(
+        uvicorn.Server,
+        "handle_exit",
+        autospec=True,
+    )
+
+    make_server().handle_exit(sig, frame)
+
+    uvicorn_exit.assert_called_once()
+    assert uvicorn_exit.call_args.args[1:] == (sig, frame)


### PR DESCRIPTION
## Summary

Hardens the Playwright browser lifecycle across shutdown, browser replacement, session recovery, active requests, and streaming responses.

This removes shutdown/recovery races, establishes explicit lifecycle ownership, and ensures browser resource loss terminates active requests deterministically without leaking tasks or producing misleading stream completion.

## Changes

- Serialize browser replacement, setup, recovery, and shutdown with a canonical lock order.
- Clean provider-owned resources before closing/replacing the parent Browser and Playwright runtime.
- Make browser generation publication atomic and ignore stale context callbacks.
- Introduce explicit application shutdown intent before Uvicorn begins draining.
- Reject new browser work after shutdown intent while allowing existing requests to drain.
- Signal active requests immediately on page/context/browser loss.
- Abort remaining requests after the graceful drain deadline.
- Preserve request-owned lease/semaphore cleanup.
- Prevent recovery from starting or continuing during application shutdown.
- Track and drain lifecycle, recovery, orphan-cleanup, and disconnect tasks.
- Guard browser close using Playwright connection state and distinguish benign
  transport-close races from real close failures.
- Preserve terminal `BrowserDisconnectedError` over secondary Playwright close
  errors.
- Keep runtime shutdown from persisting browser state while preserving bootstrap
  persistence behavior.
- Suppress the expected top-level `KeyboardInterrupt` after clean Ctrl+C shutdown.

## Streaming

- Preserve HTTP 502 for browser loss before streaming headers are sent.
- Handle expected browser/shutdown termination inside the SSE iterator after
  HTTP 200 has started.
- Prevent expected terminal conditions from escaping as ASGI application errors.
- Do not emit `[DONE]` for terminally truncated streams.
- Preserve `[DONE]` for successful stream completion.
- Keep cleanup and lease release deterministic for terminated and cancelled streams.

## Documentation

Updated browser runtime, lifecycle/recovery, concurrency, error, provider, API, and streaming contracts to match the implemented ownership and shutdown model.

## Validation

- Full suite: `588 passed`
- `git diff --check`: passed
- Manual Ctrl+C testing confirmed clean shutdown without traceback or leaked Playwright futures.
- Manual active-request and streaming shutdown testing confirmed prompt request termination and clean resource teardown.