### PR TITLE
fix: Playwright Gemini stream completion detection

### DIFF
--- a/src/app/services/browser/adapters/scripts/gemini_scripts.py
+++ b/src/app/services/browser/adapters/scripts/gemini_scripts.py
@@ -120,16 +120,16 @@ STREAM_EXTRACTOR_SCRIPT = f"""
         return !element.disabled && element.getAttribute("aria-disabled") !== "true";
     }};
 
-    const getSendState = () => {{
+    const hasBusySend = () => {{
         const visible = getMatchingElements('{SELECTORS["SEND_BUTTON"]}').filter(isElementVisible);
-        return {{
-            hasReady: visible.some(isControlEnabled),
-            hasBusy: visible.some((element) => !isControlEnabled(element))
-        }};
+        return visible.some((element) => !isControlEnabled(element));
     }};
 
-    const hasVisibleStopButton = () => {{
-        return getMatchingElements('{SELECTORS["STOP_BUTTON"]}').some(isElementVisible);
+    const getStopState = () => {{
+        const candidates = getMatchingElements('{SELECTORS["STOP_BUTTON"]}');
+        return {{
+            visible: candidates.filter(isElementVisible)
+        }};
     }};
 
     // Initialize Global Request Registry (Singleton for the window)
@@ -193,7 +193,8 @@ STREAM_EXTRACTOR_SCRIPT = f"""
         started: false,
         done: false,
         cleanedUp: false,
-        intervals: []
+        intervals: [],
+        generationActiveObserved: false
     }};
 
     try {{
@@ -255,7 +256,6 @@ STREAM_EXTRACTOR_SCRIPT = f"""
                 const payload = computeDelta(currentSnapshot);
                 state.lastSnapshot = currentSnapshot;
                 state.lastTextContent = textContent;
-                
                 emit(payload);
             }} catch (e) {{
                 console.warn(`[${{requestId}}] Observer callback error:`, e.message);
@@ -292,9 +292,13 @@ STREAM_EXTRACTOR_SCRIPT = f"""
         try {{
             if (state.cleanedUp || state.done) return;
             
-            const sendState = getSendState();
-            const isStopVisible = hasVisibleStopButton();
-            const isGenerating = (state.responseContainer && sendState.hasBusy) || isStopVisible;
+            const stopState = getStopState();
+            const isStopVisible = stopState.visible.length > 0;
+            const isGenerating = (state.responseContainer && hasBusySend()) || isStopVisible;
+
+            if (isGenerating) {{
+                state.generationActiveObserved = true;
+            }}
 
             // INVARIANT: Transition to 'started' is strictly one-way
             if (isGenerating && !state.started) {{
@@ -302,8 +306,13 @@ STREAM_EXTRACTOR_SCRIPT = f"""
                 emit({{type: "started"}});
             }}
 
-            // INVARIANT: Completion required a detected start and a stable idle state
-            if (state.started && state.responseContainer && sendState.hasReady && !isStopVisible) {{
+            if (
+                state.started &&
+                state.generationActiveObserved &&
+                state.responseContainer &&
+                state.responseContainer.isConnected &&
+                !isStopVisible
+            ) {{
                 // Terminal State Transition
                 state.done = true;
                 
@@ -316,7 +325,6 @@ STREAM_EXTRACTOR_SCRIPT = f"""
                     }}
                 }} catch (err) {{}}
                 
-                console.log(`[${{requestId}}] Generation finished.`);
                 emit({{type: "done"}});
                 
                 // Self-Cleanup

--- a/src/app/services/browser/adapters/scripts/gemini_scripts.py
+++ b/src/app/services/browser/adapters/scripts/gemini_scripts.py
@@ -8,7 +8,7 @@ Stream lifecycle and orchestration remain completely owned by the Python orchest
 
 SELECTORS = {
     "INPUT": 'div[contenteditable="true"][role="textbox"], textarea.gds-body-l, textarea[placeholder*="Gemini"]',
-    "SEND_BUTTON": 'button.send-button, button[aria-label*="Send message"], [data-test-id="send-button"]',
+    "SEND_BUTTON": 'button.send-button, button[aria-label*="Send message"], button[aria-label="Send"], [data-test-id="send-button"]',
     "STOP_BUTTON": 'button[aria-label*="Stop"], .stop-button',
     "RESPONSE_CONTAINER": 'message-content, .message-content, [data-test-id="message-content"]',
     "MODEL_PICKER": 'button[aria-label*="Open mode picker"]',
@@ -79,7 +79,11 @@ STREAM_EXTRACTOR_SCRIPT = f"""
                 return false;
             }}
             const style = window.getComputedStyle(el);
-            return style.display !== 'none' && style.visibility !== 'hidden';
+            return (
+                style.display !== 'none' &&
+                style.visibility !== 'hidden' &&
+                el.getAttribute('aria-hidden') !== 'true'
+            );
         }} catch (e) {{
             return !!el;
         }}
@@ -102,6 +106,30 @@ STREAM_EXTRACTOR_SCRIPT = f"""
     const hasMeaningfulContent = (text) => {{
         if (!text) return false;
         return text.replace(/[\\s\\u200B\\u200C\\u200D\\uFEFF]+/g, "").length > 0;
+    }};
+
+    const getMatchingElements = (selector) => {{
+        try {{
+            return Array.from(document.querySelectorAll(selector));
+        }} catch (e) {{
+            return [];
+        }}
+    }};
+
+    const isControlEnabled = (element) => {{
+        return !element.disabled && element.getAttribute("aria-disabled") !== "true";
+    }};
+
+    const getSendState = () => {{
+        const visible = getMatchingElements('{SELECTORS["SEND_BUTTON"]}').filter(isElementVisible);
+        return {{
+            hasReady: visible.some(isControlEnabled),
+            hasBusy: visible.some((element) => !isControlEnabled(element))
+        }};
+    }};
+
+    const hasVisibleStopButton = () => {{
+        return getMatchingElements('{SELECTORS["STOP_BUTTON"]}').some(isElementVisible);
     }};
 
     // Initialize Global Request Registry (Singleton for the window)
@@ -264,10 +292,9 @@ STREAM_EXTRACTOR_SCRIPT = f"""
         try {{
             if (state.cleanedUp || state.done) return;
             
-            const sendButton = document.querySelector('{SELECTORS["SEND_BUTTON"]}');
-            const stopButton = document.querySelector('{SELECTORS["STOP_BUTTON"]}');
-            const isStopVisible = isElementVisible(stopButton);
-            const isGenerating = (state.responseContainer && sendButton && sendButton.disabled) || isStopVisible;
+            const sendState = getSendState();
+            const isStopVisible = hasVisibleStopButton();
+            const isGenerating = (state.responseContainer && sendState.hasBusy) || isStopVisible;
 
             // INVARIANT: Transition to 'started' is strictly one-way
             if (isGenerating && !state.started) {{
@@ -276,7 +303,7 @@ STREAM_EXTRACTOR_SCRIPT = f"""
             }}
 
             // INVARIANT: Completion required a detected start and a stable idle state
-            if (state.started && state.responseContainer && sendButton && !sendButton.disabled && !isStopVisible) {{
+            if (state.started && state.responseContainer && sendState.hasReady && !isStopVisible) {{
                 // Terminal State Transition
                 state.done = true;
                 

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -447,33 +447,40 @@ class BrowserRequestExecutor:
                 raise QueueOverflowError("Event queue saturated")
 
             while True:
+                await self._register_conversation_if_available(page, state, session, lease)
+
                 try:
-                    await self._register_conversation_if_available(page, state, session, lease)
-
                     payload = await self._wait_for_payload(queue, state, self.config.chunk_timeout)
-                    if payload.get("type") == "done":
-                        break
-
-                    if state.active_tab:
-                        self._validate_tab_generation(state.active_tab, engine.browser_generation)
-
-                    text_to_send = ""
-                    if payload.get("type") == "chunk":
-                        text_to_send = payload["delta"]
-                    elif payload.get("type") == "rewrite" and not state.has_sent_text:
-                        text_to_send = payload["full_text"]
-
-                    if text_to_send:
-                        state.has_sent_text = True
-                        chunk = self.hooks.convert_to_openai_format(text_to_send, model, True)
-                        if state.conversation_id:
-                            chunk["conversation_id"] = state.conversation_id
-                            chunk["reused_conversation"] = state.reused_conversation
-                        yield await format_sse_chunk(chunk)
                 except asyncio.TimeoutError:
+                    stream_terminated = True
+                    logger.info(
+                        f"Stream terminated: {request_id}",
+                        extra={"request_id": request_id, "reason": "chunk_timeout"},
+                    )
                     break
 
-            yield await get_done_chunk()
+                if payload.get("type") == "done":
+                    break
+
+                if state.active_tab:
+                    self._validate_tab_generation(state.active_tab, engine.browser_generation)
+
+                text_to_send = ""
+                if payload.get("type") == "chunk":
+                    text_to_send = payload["delta"]
+                elif payload.get("type") == "rewrite" and not state.has_sent_text:
+                    text_to_send = payload["full_text"]
+
+                if text_to_send:
+                    state.has_sent_text = True
+                    chunk = self.hooks.convert_to_openai_format(text_to_send, model, True)
+                    if state.conversation_id:
+                        chunk["conversation_id"] = state.conversation_id
+                        chunk["reused_conversation"] = state.reused_conversation
+                    yield await format_sse_chunk(chunk)
+
+            if not stream_terminated:
+                yield await get_done_chunk()
 
         except (BrowserDisconnectedError, BrowserShuttingDownError) as error:
             stream_terminated = True

--- a/tests/test_gemini_observer_script.py
+++ b/tests/test_gemini_observer_script.py
@@ -1,0 +1,186 @@
+import pytest
+import pytest_asyncio
+from playwright.async_api import Error as PlaywrightError
+from playwright.async_api import async_playwright
+
+from app.services.browser.adapters.scripts.gemini_scripts import (
+    STOP_OBSERVER_SCRIPT,
+    STREAM_EXTRACTOR_SCRIPT,
+)
+
+
+@pytest_asyncio.fixture
+async def observer_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+        except PlaywrightError as error:
+            pytest.skip(f"Chromium unavailable: {error}")
+
+        context = await browser.new_context()
+        page = await context.new_page()
+        events = []
+        await page.expose_function("__test_emit", lambda payload: events.append(payload))
+        await page.set_content('<main id="app"></main>')
+        await page.evaluate(f"({STREAM_EXTRACTOR_SCRIPT})('__test_emit', 'test-request')")
+
+        yield page, events
+
+        await page.evaluate(f"({STOP_OBSERVER_SCRIPT})('test-request')")
+        await context.close()
+        await browser.close()
+
+
+async def add_response(page, text="answer"):
+    await page.evaluate(
+        """
+        () => {
+            const response = document.createElement("message-content");
+            document.querySelector("#app").append(response);
+        }
+        """
+    )
+    await page.wait_for_timeout(150)
+    await page.evaluate(
+        """
+        (value) => {
+            document.querySelector("message-content").textContent = value;
+        }
+        """,
+        text,
+    )
+    await page.wait_for_timeout(150)
+
+
+@pytest.mark.asyncio
+async def test_hidden_disabled_send_does_not_block_visible_ready_send(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML = `
+            <button class="send-button" disabled style="display: none">stale</button>
+            <button aria-label="Send">current</button>
+        `
+        """
+    )
+
+    await add_response(page)
+    await page.wait_for_timeout(150)
+
+    assert [event["type"] for event in events].count("done") == 1
+
+
+@pytest.mark.asyncio
+async def test_hidden_stale_stop_does_not_block_completion(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML = `
+            <button aria-label="Send">current</button>
+            <button class="stop-button" style="display: none">stale</button>
+        `
+        """
+    )
+
+    await add_response(page)
+    await page.wait_for_timeout(150)
+
+    assert [event["type"] for event in events].count("done") == 1
+
+
+@pytest.mark.asyncio
+async def test_visible_stop_prevents_completion(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML = `
+            <button aria-label="Send">current</button>
+            <button class="stop-button">active</button>
+        `
+        """
+    )
+
+    await add_response(page)
+    await page.wait_for_timeout(200)
+
+    assert [event["type"] for event in events].count("done") == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_send_control_does_not_emit_done(observer_page):
+    page, events = observer_page
+
+    await add_response(page)
+    await page.wait_for_timeout(200)
+
+    assert [event["type"] for event in events].count("done") == 0
+
+
+@pytest.mark.asyncio
+async def test_completed_response_emits_done_once(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML =
+            '<button aria-label="Send">current</button>'
+        """
+    )
+
+    await add_response(page)
+    await page.wait_for_timeout(400)
+
+    assert [event["type"] for event in events].count("done") == 1
+
+
+@pytest.mark.asyncio
+async def test_response_chunks_remain_before_single_done(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML =
+            '<button aria-label="Send" disabled>current</button>'
+        """
+    )
+    await page.evaluate(
+        """
+        () => {
+            const response = document.createElement("message-content");
+            document.querySelector("#app").append(response);
+        }
+        """
+    )
+    await page.wait_for_timeout(150)
+    await page.evaluate('document.querySelector("message-content").textContent = "hello"')
+    await page.wait_for_timeout(150)
+    await page.evaluate('document.querySelector("message-content").textContent = "hello world"')
+    await page.wait_for_timeout(150)
+    await page.evaluate(
+        """
+        () => document.querySelector('button[aria-label="Send"]').disabled = false
+        """
+    )
+    await page.wait_for_timeout(300)
+
+    done_indexes = [index for index, event in enumerate(events) if event["type"] == "done"]
+    assert len(done_indexes) == 1
+
+    done_index = done_indexes[0]
+    text_events = [
+        event
+        for index, event in enumerate(events)
+        if index < done_index and event["type"] in {"chunk", "rewrite"}
+    ]
+    assert text_events
+    assert not any(
+        index > done_index and event["type"] in {"chunk", "rewrite"}
+        for index, event in enumerate(events)
+    )
+
+    response_text = ""
+    for event in text_events:
+        if event["type"] == "chunk":
+            response_text += event["delta"]
+        else:
+            response_text = event["full_text"]
+
+    assert response_text == "hello world"

--- a/tests/test_gemini_observer_script.py
+++ b/tests/test_gemini_observer_script.py
@@ -53,39 +53,31 @@ async def add_response(page, text="answer"):
 
 
 @pytest.mark.asyncio
-async def test_hidden_disabled_send_does_not_block_visible_ready_send(observer_page):
+async def test_stop_disappears_after_generation_and_emits_done(observer_page):
     page, events = observer_page
     await page.evaluate(
         """
         () => document.querySelector("#app").innerHTML = `
-            <button class="send-button" disabled style="display: none">stale</button>
-            <button aria-label="Send">current</button>
+            <button class="stop-button">active</button>
         `
         """
     )
 
     await add_response(page)
+    await page.evaluate('document.querySelector(".stop-button").style.display = "none"')
     await page.wait_for_timeout(150)
 
     assert [event["type"] for event in events].count("done") == 1
 
 
 @pytest.mark.asyncio
-async def test_hidden_stale_stop_does_not_block_completion(observer_page):
+async def test_no_active_generation_signal_does_not_emit_done(observer_page):
     page, events = observer_page
-    await page.evaluate(
-        """
-        () => document.querySelector("#app").innerHTML = `
-            <button aria-label="Send">current</button>
-            <button class="stop-button" style="display: none">stale</button>
-        `
-        """
-    )
 
     await add_response(page)
     await page.wait_for_timeout(150)
 
-    assert [event["type"] for event in events].count("done") == 1
+    assert [event["type"] for event in events].count("done") == 0
 
 
 @pytest.mark.asyncio
@@ -94,7 +86,6 @@ async def test_visible_stop_prevents_completion(observer_page):
     await page.evaluate(
         """
         () => document.querySelector("#app").innerHTML = `
-            <button aria-label="Send">current</button>
             <button class="stop-button">active</button>
         `
         """
@@ -107,13 +98,46 @@ async def test_visible_stop_prevents_completion(observer_page):
 
 
 @pytest.mark.asyncio
-async def test_missing_send_control_does_not_emit_done(observer_page):
+async def test_detached_response_container_does_not_emit_done(observer_page):
     page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML =
+            '<button class="stop-button">active</button>'
+        """
+    )
 
     await add_response(page)
+    await page.evaluate(
+        """
+        () => {
+            document.querySelector("message-content").remove();
+            document.querySelector(".stop-button").style.display = "none";
+        }
+        """
+    )
     await page.wait_for_timeout(200)
 
     assert [event["type"] for event in events].count("done") == 0
+
+
+@pytest.mark.asyncio
+async def test_hidden_stale_stop_does_not_block_after_active_generation(observer_page):
+    page, events = observer_page
+    await page.evaluate(
+        """
+        () => document.querySelector("#app").innerHTML = `
+            <button class="stop-button active">active</button>
+            <button class="stop-button stale" style="display: none">stale</button>
+        `
+        """
+    )
+
+    await add_response(page)
+    await page.evaluate('document.querySelector(".stop-button.active").style.display = "none"')
+    await page.wait_for_timeout(150)
+
+    assert [event["type"] for event in events].count("done") == 1
 
 
 @pytest.mark.asyncio
@@ -122,11 +146,12 @@ async def test_completed_response_emits_done_once(observer_page):
     await page.evaluate(
         """
         () => document.querySelector("#app").innerHTML =
-            '<button aria-label="Send">current</button>'
+            '<button class="stop-button">active</button>'
         """
     )
 
     await add_response(page)
+    await page.evaluate('document.querySelector(".stop-button").style.display = "none"')
     await page.wait_for_timeout(400)
 
     assert [event["type"] for event in events].count("done") == 1
@@ -138,7 +163,7 @@ async def test_response_chunks_remain_before_single_done(observer_page):
     await page.evaluate(
         """
         () => document.querySelector("#app").innerHTML =
-            '<button aria-label="Send" disabled>current</button>'
+            '<button class="stop-button">active</button>'
         """
     )
     await page.evaluate(
@@ -154,11 +179,7 @@ async def test_response_chunks_remain_before_single_done(observer_page):
     await page.wait_for_timeout(150)
     await page.evaluate('document.querySelector("message-content").textContent = "hello world"')
     await page.wait_for_timeout(150)
-    await page.evaluate(
-        """
-        () => document.querySelector('button[aria-label="Send"]').disabled = false
-        """
-    )
+    await page.evaluate('document.querySelector(".stop-button").style.display = "none"')
     await page.wait_for_timeout(300)
 
     done_indexes = [index for index, event in enumerate(events) if event["type"] == "done"]

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -404,6 +405,11 @@ async def test_stream_ends_without_done_when_page_crashes(monkeypatch, caplog):
         record.message == "Page crash detected" and record.levelname == "WARNING"
         for record in caplog.records
     )
+    assert any(
+        record.message == "Stream terminated: " + state_ref["state"].request_id
+        and record.reason == "BrowserDisconnectedError"
+        for record in caplog.records
+    )
     lease.close.assert_awaited_once()
 
 
@@ -641,12 +647,14 @@ async def test_stream_rewrite_emits_only_initial_full_text_before_first_chunk(mo
 
 
 @pytest.mark.asyncio
-async def test_stream_done_terminates_with_done_chunk(monkeypatch):
+async def test_stream_done_terminates_with_done_chunk(monkeypatch, caplog):
     page = make_mock_page()
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
+    state_ref = {}
 
-    async def submit_prompt(_page, _prompt, _state):
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
         async def emit_events():
             await asyncio.sleep(0)
             await emit_bridge_event(page, {"type": "started"})
@@ -668,6 +676,111 @@ async def test_stream_done_terminates_with_done_chunk(monkeypatch):
     chunks = await collect_stream_chunks(response)
     assert chunks[-1] == "data: [DONE]\n\n"
     assert chunks == ["data: [DONE]\n\n"]
+    request_id = state_ref["state"].request_id
+    assert any(record.message == "Stream completed: " + request_id for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_stream_chunk_timeout_terminates_without_done_after_text(monkeypatch, caplog):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        async def emit_events():
+            await asyncio.sleep(0)
+            await emit_bridge_event(page, {"type": "started"})
+            await emit_bridge_event(page, {"type": "chunk", "delta": "hello"})
+
+        asyncio.create_task(emit_events())
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    provider.playwright_adapter.executor.config = replace(
+        provider.playwright_adapter.executor.config,
+        chunk_timeout=0.01,
+    )
+    response = await provider.chat_completions(make_request(stream=True))
+
+    chunks = await collect_stream_chunks(response)
+
+    assert len(chunks) == 1
+    assert parse_sse_chunk(chunks[0])["choices"][0]["delta"]["content"] == "hello"
+    assert not any(chunk == "data: [DONE]\n\n" for chunk in chunks)
+    request_id = state_ref["state"].request_id
+    terminated = [record for record in caplog.records if record.message == "Stream terminated: " + request_id]
+    assert len(terminated) == 1
+    assert terminated[0].reason == "chunk_timeout"
+    assert not any(record.message == "Stream completed: " + request_id for record in caplog.records)
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stream_chunk_timeout_terminates_without_payload(monkeypatch, caplog):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    provider.playwright_adapter.executor.config = replace(
+        provider.playwright_adapter.executor.config,
+        chunk_timeout=0.01,
+    )
+    response = await provider.chat_completions(make_request(stream=True))
+
+    assert await collect_stream_chunks(response) == []
+    request_id = state_ref["state"].request_id
+    terminated = [record for record in caplog.records if record.message == "Stream terminated: " + request_id]
+    assert len(terminated) == 1
+    assert terminated[0].reason == "chunk_timeout"
+    assert lease.close.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_buffered_chunk_timeout_remains_total_timeout_504(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=lambda *_args, **_kwargs: asyncio.sleep(0, result=True),
+    )
+
+    provider = GeminiProvider()
+    provider.playwright_adapter.executor.config = replace(
+        provider.playwright_adapter.executor.config,
+        total_request_timeout=0.01,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await provider.chat_completions(make_request(stream=False))
+
+    assert exc_info.value.status_code == 504
+    assert lease.close.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix Playwright Gemini requests failing to detect generation completion.

Gemini UI can remove the matching Send control after generation finishes. Previous completion logic required an enabled Send button, causing:

* streaming requests to remain open until the 90s chunk timeout
* non-streaming requests to wait until total request timeout and return 504
* stream timeout to incorrectly emit `[DONE]` as successful completion

## Changes

* Make Gemini completion detection rely on observed generation lifecycle instead of idle Send-button presence.
* Track generation-active state once Stop/busy state is observed.
* Complete only after generation was active, response container remains connected, and visible Stop control disappears.
* Improve Send/Stop candidate handling for stale or hidden controls.
* Prevent Playwright chunk timeout from emitting false `[DONE]`.
* Treat chunk timeout as terminal stream truncation with normal cleanup.
* Preserve buffered timeout behavior as HTTP 504.
* Add browser-level observer and Playwright parity regression coverage.

## Validation

* Verified against real Gemini Playwright request.
* Streaming response now completes immediately after generation instead of waiting 90 seconds.
* Full test suite: `598 passed`.
* `git diff --check`: passed.
