### PR TITLE
feat: add Gemini Playwright Extended Thinking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ WebAI-to-API uses model prefixes to route requests to specific backends.
 > [!TIP]
 > Model prefixes force backend selection and override the default Gemini backend configured in `config.conf`. Use `playwright/...` model prefixes to force the Playwright backend explicitly.
 
+Gemini Playwright Extended Thinking is available through `provider_options.gemini.extended_thinking`; see [API Documentation](docs/api.md).
+
 ---
 
 ## Documentation

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,32 @@ OpenAI-compatible chat completion endpoint.
 }
 ```
 
+#### Gemini Playwright Extended Thinking
+
+Gemini Playwright requests may control Gemini Web UI Extended thinking through typed provider options:
+
+```json
+{
+  "model": "playwright/gemini-3.5-flash",
+  "messages": [
+    {"role": "user", "content": "Solve this problem"}
+  ],
+  "provider_options": {
+    "gemini": {
+      "extended_thinking": true
+    }
+  }
+}
+```
+
+`extended_thinking` defaults to `false` for every request. The Playwright adapter normalizes UI state before each prompt, so omitted options force Extended thinking off instead of inheriting state from a persistent tab. The option is unsupported by Gemini WebAPI and Atlas and returns HTTP 400. Unknown provider namespaces/options and invalid types return HTTP 422. This UI toggle is not equivalent to `reasoning_effort`.
+
+Do not use this form. `extended_thinking` must be nested under `provider_options.gemini`; a top-level `extended_thinking` field is not part of the API contract and may be ignored.
+
+```json
+{"extended_thinking": true}
+```
+
 #### File Inputs
 
 For Gemini WebAPI requests, `messages[].content` may be either:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -184,6 +184,8 @@ curl -X POST http://localhost:6969/v1/chat/completions \
   }'
 ```
 
+Gemini Playwright also supports request-scoped Extended Thinking through `provider_options.gemini`; see [API Documentation](api.md) for the request fragment and semantics.
+
 ---
 
 ## Configuration & Persistence

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -32,11 +32,27 @@ WebAI-to-API exposes multiple API surfaces to balance standard compatibility, le
 
 The `/v1/chat/completions` endpoint is the authoritative API surface of the project. All maintainers must prioritize its stability and feature parity with the OpenAI Chat Completion spec.
 
-- **Schema**: Strictly follows the OpenAI request/response format.
+- **Schema**: Follows the OpenAI request/response format plus documented provider-scoped request options.
 - **Streaming**: Supported via Server-Sent Events (SSE).
 - **Provider Routing**: Requests are routed through the `ProviderFactory`.
 - **Persistence**: Provider/backend-dependent. The selected provider and adapter define whether `conversation_id` maps to local snapshots, provider-side conversation URLs, or no persisted state.
 - **Isolation**: Every request is isolated by its `conversation_id`.
+
+### Provider Options
+
+Requests may use typed provider-scoped options:
+
+```json
+{
+  "provider_options": {
+    "gemini": {
+      "extended_thinking": true
+    }
+  }
+}
+```
+
+`gemini.extended_thinking` applies only to Gemini Playwright models. Effective value is normalized on every request: omitted provider options, omitted Gemini options, and omitted `extended_thinking` all mean `false`. This prevents state leakage across persistent Playwright tabs. Gemini WebAPI and non-Gemini providers reject the option with HTTP 400. Unknown namespaces, unknown Gemini options, and invalid value types fail schema validation with HTTP 422. Gemini Web UI Extended thinking is a provider UI toggle and is not declared equivalent to `reasoning_effort`.
 
 ### 3.1 Multimodal Content Parts
 

--- a/src/app/openapi/chat_completions.py
+++ b/src/app/openapi/chat_completions.py
@@ -32,6 +32,23 @@ CHAT_COMPLETIONS_REQUEST_EXAMPLES = {
             ],
         },
     },
+    "playwrightExtendedThinking": {
+        "summary": "Gemini Playwright request with Extended thinking",
+        "value": {
+            "model": "playwright/gemini-3.5-flash",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Solve this problem.",
+                }
+            ],
+            "provider_options": {
+                "gemini": {
+                    "extended_thinking": True,
+                }
+            },
+        },
+    },
 }
 
 

--- a/src/app/schemas/request.py
+++ b/src/app/schemas/request.py
@@ -1,7 +1,7 @@
 # src/app/schemas/request.py
 from typing import Any, Annotated, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 class GeminiRequest(BaseModel):
     message: str
@@ -72,6 +72,22 @@ class OpenAIChatMessage(BaseModel):
     name: Optional[str] = None
 
 
+class GeminiProviderOptions(BaseModel):
+    """Gemini-specific request options."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    extended_thinking: StrictBool = False
+
+
+class ProviderOptions(BaseModel):
+    """Provider-scoped options for OpenAI-compatible requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gemini: Optional[GeminiProviderOptions] = None
+
+
 class OpenAIChatRequest(BaseModel):
     """OpenAI-compatible chat request. Gemini WebAPI supports multimodal file content parts; supported formats are documented in docs/api.md."""
 
@@ -83,6 +99,7 @@ class OpenAIChatRequest(BaseModel):
     tool_choice: Optional[Any] = None
     gem: Optional[str] = Field(default=None, description="Gem ID or name to use as system prompt.")
     conversation_id: Optional[str] = Field(default=None, description="ID to continue an existing browser conversation.")
+    provider_options: Optional[ProviderOptions] = None
 
 class Part(BaseModel):
     text: Optional[str] = None

--- a/src/app/services/browser/adapters/gemini_adapter.py
+++ b/src/app/services/browser/adapters/gemini_adapter.py
@@ -105,6 +105,91 @@ class GeminiProviderAdapter(BaseProviderAdapter):
                 
         return confirmed
 
+    async def set_extended_thinking(self, page: Page, enabled: bool, state: Optional[Any] = None) -> None:
+        """Normalize Gemini mode-picker Extended thinking state for one request."""
+        await self._open_mode_menu(page)
+        item = page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
+        try:
+            await item.wait_for(state="visible", timeout=1000)
+        except PlaywrightTimeoutError as error:
+            if not enabled:
+                verification_error = None
+                try:
+                    picker = await self._find_model_picker(page)
+                    label = await picker.get_attribute("aria-label") if picker else None
+                except Exception as exc:
+                    picker = None
+                    label = None
+                    verification_error = exc
+                finally:
+                    try:
+                        await page.keyboard.press("Escape")
+                    except Exception:
+                        pass
+
+                if not picker or label is None:
+                    raise TransientSessionError(
+                        "Gemini Extended thinking state could not be verified off."
+                    ) from (verification_error or error)
+                if re.search(r"\bExtended\b", label, re.I):
+                    raise TransientSessionError(
+                        "Gemini Extended thinking state could not be normalized off."
+                    )
+                return
+            try:
+                await page.keyboard.press("Escape")
+            except Exception:
+                pass
+            raise ModelNotFoundError("Gemini Extended thinking control is unavailable.") from error
+
+        aria_disabled = await item.get_attribute("aria-disabled")
+        selected = "selected" in (await item.get_attribute("class") or "").split()
+        if selected == enabled:
+            await page.keyboard.press("Escape")
+            return
+        if aria_disabled == "true":
+            await page.keyboard.press("Escape")
+            raise GatedModelError("Gemini Extended thinking is disabled for this model or account.")
+
+        await item.click()
+
+        for _ in range(12):
+            picker = await self._find_model_picker(page)
+            label = await picker.get_attribute("aria-label") if picker else None
+            label_enabled = bool(label and re.search(r"\bExtended\b", label, re.I))
+            if label_enabled == enabled:
+                await self._open_mode_menu(page)
+                verified_item = page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
+                try:
+                    await verified_item.wait_for(state="visible", timeout=1000)
+                except PlaywrightTimeoutError:
+                    await page.keyboard.press("Escape")
+                    raise TransientSessionError("Gemini Extended thinking state verification failed.")
+                verified = "selected" in (await verified_item.get_attribute("class") or "").split()
+                await page.keyboard.press("Escape")
+                if verified == enabled:
+                    return
+            await asyncio.sleep(0.25)
+
+        raise TransientSessionError("Gemini Extended thinking state transition could not be verified.")
+
+    async def _open_mode_menu(self, page: Page) -> Any:
+        picker = await self._find_model_picker(page)
+        if not picker:
+            raise TransientSessionError("Gemini mode picker is unavailable while configuring Extended thinking.")
+
+        await picker.click()
+        menu = page.locator('[role="menu"][data-test-id="gem-mode-menu"]').first
+        try:
+            await menu.wait_for(state="visible", timeout=3000)
+        except PlaywrightTimeoutError as error:
+            try:
+                await page.keyboard.press("Escape")
+            except Exception:
+                pass
+            raise TransientSessionError("Gemini mode picker menu failed to render.") from error
+        return menu
+
     async def _find_model_picker(self, page: Page) -> Optional[Any]:
         """
         Locate the model picker button using primary and fallback selectors.

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -100,6 +100,7 @@ class BrowserRequestExecutorHooks:
     extract_conversation_id: Callable[[str], Optional[str]]
     convert_to_openai_format: Callable[[str, str, bool], dict]
     orchestrate_model_selection: Callable[[Any, Page, str, PlaywrightRequestState], Awaitable[None]]
+    configure_request_options: Callable[[Any, Page, OpenAIChatRequest, PlaywrightRequestState], Awaitable[None]]
 
 
 class BrowserRequestExecutor:
@@ -309,6 +310,7 @@ class BrowserRequestExecutor:
             async with session.submit_lock:
                 self._validate_tab_generation(state.active_tab, engine.browser_generation)
                 await self.hooks.orchestrate_model_selection(browser_adapter, page, request.model, state)
+                await self.hooks.configure_request_options(browser_adapter, page, request, state)
                 confirmed = await browser_adapter.submit_prompt(page, prompt, state)
 
             if not confirmed:

--- a/src/app/services/providers/atlas/provider.py
+++ b/src/app/services/providers/atlas/provider.py
@@ -26,6 +26,11 @@ class AtlasProvider(BaseProvider):
     async def chat_completions(self, request: OpenAIChatRequest) -> Any:
         # Atlas logic currently splitting model name occurs in Factory, 
         # so we just need to ensure the request is mapped correctly.
+        if request.provider_options and request.provider_options.gemini is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="provider_options.gemini is not supported by the Atlas provider.",
+            )
         try:
             normalized = normalize_openai_chat_messages(
                 request.messages,

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -53,6 +53,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                 extract_conversation_id=self._extract_conversation_id,
                 convert_to_openai_format=convert_to_openai_format,
                 orchestrate_model_selection=self._orchestrate_model_selection,
+                configure_request_options=self._configure_request_options,
             ),
         )
 
@@ -121,6 +122,22 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         stop_button = page.locator(SELECTORS["STOP_BUTTON"]).first
         if await stop_button.is_visible():
             await stop_button.click()
+
+    async def _configure_request_options(
+        self,
+        browser_adapter: GeminiProviderAdapter,
+        page: Page,
+        request,
+        state: PlaywrightRequestState,
+    ) -> None:
+        provider_options = getattr(request, "provider_options", None)
+        gemini_options = getattr(provider_options, "gemini", None) if provider_options else None
+        extended_thinking = bool(getattr(gemini_options, "extended_thinking", False))
+
+        try:
+            await browser_adapter.set_extended_thinking(page, extended_thinking, state)
+        except (ModelNotFoundError, GatedModelError) as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
 
     def _extract_conversation_id(self, url: str):
         return GeminiProviderAdapter().extract_conversation_id(url)

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -60,6 +60,12 @@ class GeminiProvider(BaseProvider):
         # Select adapter to determine target backend
         adapter = self._get_adapter(request.model)
         is_playwright = isinstance(adapter, GeminiPlaywrightAdapter)
+        gemini_options = getattr(request.provider_options, "gemini", None) if request.provider_options else None
+        if gemini_options is not None and not is_playwright:
+            raise HTTPException(
+                status_code=400,
+                detail="provider_options.gemini is supported only by the Gemini Playwright backend.",
+            )
         
         if cid:
             if len(cid) > 128:

--- a/src/app/services/providers/gemini/temporary_chat.py
+++ b/src/app/services/providers/gemini/temporary_chat.py
@@ -61,6 +61,12 @@ def _resolve_temporary_chat_model(request: OpenAIChatRequest, gemini_client) -> 
             detail="Only the Gemini provider is supported on the temporary chat endpoint.",
         )
 
+    if request.provider_options and request.provider_options.gemini is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="provider_options.gemini is not supported by the Gemini WebAPI backend.",
+        )
+
     model = request.model or CONFIG["Gemini"].get("default_model", "gemini-3-flash")
     model = model.strip()
 

--- a/tests/test_gemini_extended_thinking.py
+++ b/tests/test_gemini_extended_thinking.py
@@ -1,0 +1,312 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from playwright.async_api import Error as PlaywrightError
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from playwright.async_api import async_playwright
+from pydantic import ValidationError
+
+from app.main import app
+from app.schemas.request import OpenAIChatRequest
+from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
+from app.services.browser.errors import GatedModelError, ModelNotFoundError, TransientSessionError
+from app.services.providers.atlas.provider import AtlasProvider
+from app.services.providers.gemini.provider import GeminiProvider
+from app.services.providers.gemini.temporary_chat import _resolve_temporary_chat_model
+
+
+def make_request(**kwargs):
+    return OpenAIChatRequest(
+        model=kwargs.pop("model", "playwright/gemini-3.5-flash"),
+        messages=[{"role": "user", "content": "hello"}],
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"provider_options": {"atlas": {"extended_thinking": True}}},
+        {"provider_options": {"gemini": {"unknown": True}}},
+        {"provider_options": {"gemini": {"extended_thinking": "yes"}}},
+    ],
+)
+def test_provider_options_schema_rejects_invalid_shapes(payload):
+    with pytest.raises(ValidationError):
+        OpenAIChatRequest.model_validate({**payload, "messages": [{"role": "user", "content": "hello"}]})
+
+
+def test_provider_options_schema_accepts_extended_thinking_and_defaults_off():
+    request = make_request(provider_options={"gemini": {"extended_thinking": True}})
+    assert request.provider_options.gemini.extended_thinking is True
+    assert make_request().provider_options is None
+    assert make_request(provider_options={"gemini": {}}).provider_options.gemini.extended_thinking is False
+
+
+@pytest.mark.asyncio
+async def test_http_schema_errors_are_422():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for options in (
+            {"atlas": {"extended_thinking": True}},
+            {"gemini": {"unknown": True}},
+            {"gemini": {"extended_thinking": "yes"}},
+        ):
+            response = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hello"}], "provider_options": options},
+            )
+            assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_gemini_webapi_rejects_playwright_options():
+    provider = GeminiProvider()
+    provider.webapi_adapter.chat_completions = AsyncMock()
+    with pytest.raises(HTTPException) as error:
+        await provider.chat_completions(
+            make_request(model="gemini-3-flash", provider_options={"gemini": {"extended_thinking": True}})
+        )
+    assert error.value.status_code == 400
+
+
+def test_gemini_temporary_webapi_rejects_playwright_options():
+    with pytest.raises(HTTPException) as error:
+        _resolve_temporary_chat_model(
+            make_request(model="gemini-3-flash", provider_options={"gemini": {"extended_thinking": True}}),
+            MagicMock(),
+        )
+    assert error.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_atlas_rejects_gemini_options():
+    with pytest.raises(HTTPException) as error:
+        await AtlasProvider().chat_completions(
+            make_request(model="atlas/model", provider_options={"gemini": {"extended_thinking": True}})
+        )
+    assert error.value.status_code == 400
+
+
+@pytest_asyncio.fixture
+async def extended_page():
+    async with async_playwright() as playwright:
+        try:
+            browser = await playwright.chromium.launch(headless=True)
+        except PlaywrightError as error:
+            pytest.skip(f"Chromium unavailable: {error}")
+        context = await browser.new_context()
+        page = await context.new_page()
+        await page.set_content(
+            """
+            <button id="picker" aria-label="Open mode picker, currently Flash"></button>
+            <div id="menu" role="menu" data-test-id="gem-mode-menu" hidden>
+              <gem-menu-item role="menuitem" aria-disabled="false">Extended thinking</gem-menu-item>
+            </div>
+            <script>
+              const picker = document.querySelector('#picker');
+              const menu = document.querySelector('#menu');
+              const item = document.querySelector('gem-menu-item');
+              picker.onclick = () => menu.hidden = false;
+              item.onclick = () => {
+                const enabled = item.classList.toggle('selected');
+                picker.setAttribute('aria-label', `Open mode picker, currently Flash${enabled ? ' Extended' : ''}`);
+                menu.hidden = true;
+              };
+            </script>
+            """
+        )
+        yield page
+        await context.close()
+        await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_extended_thinking_on_off_and_idempotent(extended_page):
+    adapter = GeminiProviderAdapter()
+    item = extended_page.get_by_role("menuitem", name="Extended thinking")
+
+    await adapter.set_extended_thinking(extended_page, True)
+    assert "selected" in (await item.get_attribute("class") or "").split()
+    assert "Extended" in await extended_page.locator("#picker").get_attribute("aria-label")
+
+    await adapter.set_extended_thinking(extended_page, True)
+    assert "selected" in (await item.get_attribute("class") or "").split()
+
+    await adapter.set_extended_thinking(extended_page, False)
+    assert "selected" not in (await item.get_attribute("class") or "").split()
+    assert "Extended" not in await extended_page.locator("#picker").get_attribute("aria-label")
+
+    await adapter.set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_picker_missing_fails_for_false_and_true(extended_page):
+    await extended_page.locator("#picker").evaluate("element => element.remove()")
+    adapter = GeminiProviderAdapter()
+
+    with pytest.raises(TransientSessionError):
+        await adapter.set_extended_thinking(extended_page, False)
+    with pytest.raises(TransientSessionError):
+        await adapter.set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_missing_item_after_menu_render_false_succeeds_true_fails(extended_page):
+    picker = MagicMock()
+    picker.click = AsyncMock()
+    picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
+    item = MagicMock()
+    item.first = item
+    item.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("missing"))
+    extended_page.get_by_role = MagicMock(return_value=item)
+    await extended_page.locator("#menu").evaluate("element => element.hidden = false")
+    adapter = GeminiProviderAdapter()
+    adapter._find_model_picker = AsyncMock(return_value=picker)
+
+    await adapter.set_extended_thinking(extended_page, False)
+    with pytest.raises(ModelNotFoundError):
+        await adapter.set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_missing_item_with_extended_label_fails_off(extended_page):
+    picker = MagicMock()
+    picker.click = AsyncMock()
+    picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash Extended")
+    item = MagicMock()
+    item.first = item
+    item.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("missing"))
+    extended_page.get_by_role = MagicMock(return_value=item)
+    await extended_page.locator("#menu").evaluate("element => element.hidden = false")
+    adapter = GeminiProviderAdapter()
+    adapter._find_model_picker = AsyncMock(return_value=picker)
+
+    with pytest.raises(TransientSessionError, match="normalized off"):
+        await adapter.set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_missing_item_with_disappeared_picker_fails_off(extended_page):
+    picker = MagicMock()
+    picker.click = AsyncMock()
+    item = MagicMock()
+    item.first = item
+    item.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("missing"))
+    extended_page.get_by_role = MagicMock(return_value=item)
+    await extended_page.locator("#menu").evaluate("element => element.hidden = false")
+    adapter = GeminiProviderAdapter()
+    adapter._find_model_picker = AsyncMock(side_effect=[picker, None])
+
+    with pytest.raises(TransientSessionError, match="verified off"):
+        await adapter.set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_mode_menu_not_ready_fails_for_false_and_true(extended_page):
+    picker = MagicMock()
+    picker.click = AsyncMock()
+    menu = MagicMock()
+    menu.first = menu
+    menu.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("menu missing"))
+    extended_page.locator = MagicMock(return_value=menu)
+    adapter = GeminiProviderAdapter()
+    adapter._find_model_picker = AsyncMock(return_value=picker)
+
+    with pytest.raises(TransientSessionError):
+        await adapter.set_extended_thinking(extended_page, False)
+    with pytest.raises(TransientSessionError):
+        await adapter.set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_disabled_control_rejects_enable(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('aria-disabled', 'true')"
+    )
+    with pytest.raises(GatedModelError):
+        await GeminiProviderAdapter().set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_disabled_control_already_off_succeeds(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('aria-disabled', 'true')"
+    )
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_disabled_selected_control_cannot_be_forced_off(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => { element.setAttribute('aria-disabled', 'true'); element.classList.add('selected'); }"
+    )
+    with pytest.raises(GatedModelError):
+        await GeminiProviderAdapter().set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_menu_item_render_race_is_waited_out(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate("element => element.remove()")
+    await extended_page.evaluate(
+        """
+        () => {
+            const picker = document.querySelector('#picker');
+            const menu = document.querySelector('#menu');
+            picker.onclick = () => setTimeout(() => {
+                const item = document.createElement('gem-menu-item');
+                item.setAttribute('role', 'menuitem');
+                item.setAttribute('aria-disabled', 'false');
+                item.textContent = 'Extended thinking';
+                item.onclick = () => {
+                    const enabled = item.classList.toggle('selected');
+                    picker.setAttribute('aria-label', `Open mode picker, currently Flash${enabled ? ' Extended' : ''}`);
+                    menu.hidden = true;
+                };
+                menu.append(item);
+                menu.hidden = false;
+            }, 50);
+        }
+        """
+    )
+
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, True)
+    assert "Extended" in await extended_page.locator("#picker").get_attribute("aria-label")
+
+
+@pytest.mark.asyncio
+async def test_failed_extended_thinking_verification_is_explicit(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.onclick = () => { document.querySelector('#menu').hidden = true; }"
+    )
+    with pytest.raises(TransientSessionError):
+        await GeminiProviderAdapter().set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_request_option_normalization_forces_off_when_omitted_or_false():
+    provider = GeminiProvider()
+    browser_adapter = type("Adapter", (), {"set_extended_thinking": AsyncMock()})()
+
+    await provider.playwright_adapter._configure_request_options(
+        browser_adapter,
+        object(),
+        make_request(provider_options={"gemini": {"extended_thinking": True}}),
+        None,
+    )
+    await provider.playwright_adapter._configure_request_options(
+        browser_adapter,
+        object(),
+        make_request(),
+        None,
+    )
+    await provider.playwright_adapter._configure_request_options(
+        browser_adapter,
+        object(),
+        make_request(provider_options={"gemini": {"extended_thinking": False}}),
+        None,
+    )
+
+    assert [call.args[1] for call in browser_adapter.set_extended_thinking.await_args_list] == [True, False, False]

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -163,6 +163,14 @@ async def configure_playwright_success(
         "app.services.providers.gemini.playwright_adapter.GeminiProviderAdapter.check_authentication",
         check_authentication,
     )
+
+    async def configure_request_options(_self, *_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.GeminiProviderAdapter.set_extended_thinking",
+        configure_request_options,
+    )
     async def submit_prompt_bound(_self, *args, **kwargs):
         return await submit_side_effect(*args, **kwargs)
 
@@ -678,6 +686,45 @@ async def test_stream_done_terminates_with_done_chunk(monkeypatch, caplog):
     assert chunks == ["data: [DONE]\n\n"]
     request_id = state_ref["state"].request_id
     assert any(record.message == "Stream completed: " + request_id for record in caplog.records)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.asyncio
+async def test_request_options_configure_after_model_selection_before_submit(monkeypatch, stream):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    events = []
+
+    async def submit_prompt(_page, _prompt, _state):
+        events.append("submit")
+        await emit_bridge_event(page, {"type": "done"})
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    hooks = replace(
+        provider.playwright_adapter.executor.hooks,
+        orchestrate_model_selection=lambda *_args: _record_event(events, "model"),
+        configure_request_options=lambda *_args: _record_event(events, "options"),
+    )
+    provider.playwright_adapter.executor.hooks = hooks
+
+    response = await provider.chat_completions(make_request(stream=stream))
+    if stream:
+        await collect_stream_chunks(response)
+
+    assert events == ["model", "options", "submit"]
+
+
+async def _record_event(events, value):
+    events.append(value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_recovery_orchestration.py
+++ b/tests/test_recovery_orchestration.py
@@ -8,6 +8,18 @@ from app.services.providers.gemini.provider import GeminiProvider
 from app.schemas.request import OpenAIChatRequest
 from fastapi import HTTPException
 
+
+@pytest.fixture(autouse=True)
+def mock_extended_thinking_configuration(monkeypatch):
+    async def configure(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.playwright_adapter.GeminiProviderAdapter.set_extended_thinking",
+        configure,
+    )
+
+
 @pytest.mark.asyncio
 async def test_recovery_orchestration_atomic_non_blocking(tmp_path):
     # 1. Mock BrowserEngine


### PR DESCRIPTION
## Summary

Add request-scoped Extended Thinking support for Gemini Playwright through provider-specific options.

```json
{
  "provider_options": {
    "gemini": {
      "extended_thinking": true
    }
  }
}
````

## Changes

* Add typed `provider_options.gemini.extended_thinking` request schema.
* Normalize Extended Thinking state before every Gemini Playwright prompt.
* Default omitted `extended_thinking` to `false` to prevent state leakage across reused tabs.
* Configure request options after model selection and before prompt submission.
* Detect and toggle Extended Thinking through Gemini mode-picker UI.
* Handle missing, disabled, delayed, and unverifiable UI states explicitly.
* Reject Gemini-specific options for unsupported backends.
* Add OpenAPI and API contract documentation.
* Add user-facing documentation for Extended Thinking usage.

## Validation

* Extended Thinking tests: 20 passed.
* Targeted Gemini tests: 100 passed.
* Full suite: 620 passed.
* `git diff --check`: passed.

Refs: #115