### PR TITLE
refactor: establish clean browser runtime boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ conversation_snapshots.db-wal
 conversation_snapshots.db-shm
 
 # Runtime state
-runtime/
+/runtime/
 
 # Legacy auth directory (backward compatibility)
 auth_state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,12 @@ This document specifies the architectural governance, runtime contracts, and ope
 The system operates according to a strict ownership hierarchy and state machine.
 
 ### 2.1 Component Hierarchy
-1. **BrowserEngine**: Global singleton. Authoritative owner of Playwright, Browser, browser generation, shutdown intent/source, provider-session registry, and terminal orchestration.
-2. **ProviderSession**: Created per provider (Gemini, etc.). Authoritative owner of the `BrowserContext`, `keepalive_page`, PersistentTabs/pages, lifecycle tasks, active-request abort/signal handles, and session-scoped recovery logic.
-3. **AuthManager**: Provider-agnostic orchestrator for authentication lifecycle, concurrency locks, and background login tasks.
-4. **ManagedPage**: Request-scoped resource container. Authoritatively owns exactly one semaphore permit and one `PersistentTab` lease.
-5. **PersistentTab**: Long-lived browser page in the session registry. Owns its individual `_lock` and internal state.
+1. **BrowserEngine**: Global singleton. Authoritative owner of the active `BrowserRuntime`, Browser handle, browser generation, shutdown intent/source, provider-session registry, and terminal orchestration.
+2. **BrowserRuntime**: Browser-process launch mechanics only (start, launch, disconnect binding, connection checks, browser close, driver stop). Selected by `create_browser_runtime()` via `[Browser] runtime`; only `playwright` is supported (`PlaywrightChromiumRuntime`). Never owns recovery, session, or shutdown policy. It does not abstract Page/Context APIs.
+3. **ProviderSession**: Created per provider (Gemini, etc.). Authoritative owner of the `BrowserContext`, `keepalive_page`, PersistentTabs/pages, lifecycle tasks, active-request abort/signal handles, and session-scoped recovery logic.
+4. **AuthManager**: Provider-agnostic orchestrator for authentication lifecycle, concurrency locks, and background login tasks.
+5. **ManagedPage**: Request-scoped resource container. Authoritatively owns exactly one semaphore permit and one `PersistentTab` lease.
+6. **PersistentTab**: Long-lived browser page in the session registry. Owns its individual `_lock` and internal state.
 
 ### 2.2 Lifecycle & Ownership
 - **Generation Invalidation**: Tracks browser process generations to automatically invalidate stale contexts, `PersistentTab` objects, active leases, cached references, and request-scoped bridge state after a browser generation rollover or fatal disconnect.
@@ -73,7 +74,7 @@ Providers must implement:
 - **Ordered Processing**: Bridge events for a single `request_id` must be processed in strict FIFO order.
 - **Failure Isolation**: Bounded queue overflow or request-level errors result in terminal request failure but must not poison the broader `ProviderSession`.
 - **Bridge Cleanup**: Request-scoped bridge state MUST be deterministically removed after stream termination.
-- **Post-Header Terminal Streams**: Expected `BrowserDisconnectedError` and `BrowserShuttingDownError` must be handled inside the stream iterator after SSE headers are sent; do not let them escape to ASGI or emit `[DONE]` for terminal truncation.
+- **Post-Header Terminal Streams**: Expected terminal conditions (`BrowserDisconnectedError`, `BrowserShuttingDownError`, `BrowserGenerationMismatchError`, `QueueOverflowError`, `ConversationBusyError`) must be handled inside the stream iterator after SSE headers are sent; do not let them escape to ASGI or emit `[DONE]` for terminal truncation.
 
 ---
 
@@ -91,6 +92,7 @@ Providers must implement:
 Authoritative technical invariants and behavioral guarantees are codified in the following specifications. **If any summary in this guide conflicts with a detailed contract document, the contract document takes precedence.**
 
 - **[Concurrency Model](docs/specs/concurrency-model.md)**: Governs lock hierarchy, semaphore ownership, lease invalidation, cancellation safety, and background loop authority.
+- **[Browser Runtime Architecture](docs/specs/browser-runtime-architecture.md)**: Governs engine state machine, BrowserRuntime launch mechanics boundary, zombie Chromium/window liveness, and terminal browser cleanup.
 - **[Lifecycle and Recovery](docs/specs/lifecycle-and-recovery.md)**: Governs engine state machine, terminal shutdown invariants, generation rollover semantics, and authoritative recovery boundaries.
 - **[Provider Contract](docs/specs/provider-contract.md)**: Governs provider adapter responsibilities, page poisoning rules, page ownership boundaries, and escalation semantics.
 - **[Streaming Pipeline](docs/specs/streaming-pipeline.md)**: Governs SSE ordering guarantees, rewrite-resilient normalization, bridge callback lifecycle, and queue overflow semantics.
@@ -120,6 +122,7 @@ AI Agents working on this runtime MUST adhere to these strict constraints:
 
 ### 8.1 Key Directory Structure
 - `src/app/services/browser/`: Core engine, session, and tab management.
+- `src/app/services/browser/runtime/`: Browser launch mechanics (`BrowserRuntime`, `PlaywrightChromiumRuntime`, `create_browser_runtime()`).
 - `src/app/services/providers/`: Provider-specific implementation logic.
 - `docs/`: authoritative runtime contracts (normative specs).
 

--- a/config.conf.example
+++ b/config.conf.example
@@ -3,13 +3,12 @@
 # ⚠️ Note: This file is *only* used by the WebAI-to-API server.
 
 # --- Browser Settings ---
-# Set the browser that will be used for any required operations.
-# Only modify this section in most use cases.
-# Supported options: chrome, firefox, brave, edge, safari
+# name: Host browser used for local cookie discovery (chrome, firefox, brave, edge, safari).
+#       This does NOT select the browser automation runtime.
+# runtime: Browser automation runtime backend.
+#       Supported options: playwright
 [Browser]
 name = chrome
-# Browser runtime backend used by the runtime engine.
-# Supported options: playwright
 runtime = playwright
 
 # --- Authentication Methods ---

--- a/config.conf.example
+++ b/config.conf.example
@@ -8,6 +8,9 @@
 # Supported options: chrome, firefox, brave, edge, safari
 [Browser]
 name = chrome
+# Browser runtime backend used by the runtime engine.
+# Supported options: playwright
+runtime = playwright
 
 # --- Authentication Methods ---
 # WebAI-to-API supports multiple authentication approaches:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,7 @@ The browser runtime manages browser-backed execution.
 Responsibilities:
 
 * `BrowserEngine`: browser process lifecycle, generation invalidation, terminal shutdown
+* `BrowserRuntime`: browser-process launch mechanics (start, launch, disconnect binding, connection checks, browser close, driver stop); current implementation `PlaywrightChromiumRuntime`, selected via `create_browser_runtime()` with `[Browser] runtime = playwright`
 * `ProviderSession`: browser context lifecycle, keepalive page ownership, provider-scoped recovery
 * `BrowserRequestExecutor`: request-scoped execution, bridge lifecycle, streaming integration, cleanup
 * `AuthManager`: status caching and orchestration
@@ -218,6 +219,7 @@ Provider auth strategies own selection and fallback policy.
 Detailed runtime guarantees are documented separately:
 
 * [Runtime Architecture Overview](specs/runtime-architecture-overview.md)
+* [Browser Runtime Architecture](specs/browser-runtime-architecture.md)
 * [Provider Contract](specs/provider-contract.md)
 * [Concurrency Model](specs/concurrency-model.md)
 * [Streaming Pipeline](specs/streaming-pipeline.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,7 +175,8 @@ The following keys are accepted for manual cookie configuration:
 
 | Option | Description                       |
 | ------ | --------------------------------- |
-| `name` | Browser used for cookie discovery |
+| `name` | Host browser used for local cookie discovery (`chrome`, `firefox`, `brave`, `edge`, `safari`). Does not select the browser automation runtime. |
+| `runtime` | Browser automation runtime backend. Supported value: `playwright`. |
 
 ### Proxy
 

--- a/docs/specs/browser-runtime-architecture.md
+++ b/docs/specs/browser-runtime-architecture.md
@@ -25,17 +25,36 @@ The `BrowserEngine` operates according to a strict state machine. Transitions in
 
 The runtime follows a strict ownership hierarchy. Resource cleanup must cascade down this chain.
 
-1. **BrowserEngine**: Global singleton. Owns the Playwright instance, Browser process, browser generation, shutdown intent/source, provider-session registry, and terminal lifecycle orchestration.
-2. **ProviderSession**: Created per provider. Owns the `BrowserContext`, `keepalive_page`, `PersistentTab` pages, lifecycle tasks, and active-request abort/signal handles.
+1. **BrowserEngine**: Global singleton. Owns the active `BrowserRuntime`, the Browser handle, browser generation, shutdown intent/source, provider-session registry, and terminal lifecycle orchestration.
+2. **BrowserRuntime**: Browser-process launch mechanics only. Owns the concrete driver instance and executes browser-process launch, connection, and close mechanics. Selected through `create_browser_runtime()` based on `[Browser] runtime`; the only supported value is `playwright`, producing `PlaywrightChromiumRuntime`. `BrowserRuntime` must NOT own lifecycle/recovery/shutdown policy.
+3. **ProviderSession**: Created per provider. Owns the `BrowserContext`, `keepalive_page`, `PersistentTab` pages, lifecycle tasks, and active-request abort/signal handles.
    - **Page Ownership**: `ProviderSession` is solely responsible for the creation, monitoring, and cleanup of its `keepalive_page`.
    - **Separation of Concerns**: `BrowserEngine` must not manipulate the `keepalive_page` directly outside of session teardown orchestration.
-3. **ManagedPage**: Request-scoped lease. Owns exactly one semaphore permit and potentially one `PersistentTab` lease.
-4. **PersistentTab**: Long-lived browser page. Owns its individual `_lock` and state.
-5. **BrowserRequestExecutor**: Owns one request lifecycle state, terminal event/error, request task, observer/queue tasks, and lease release through request cleanup.
+4. **ManagedPage**: Request-scoped lease. Owns exactly one semaphore permit and potentially one `PersistentTab` lease.
+5. **PersistentTab**: Long-lived browser page. Owns its individual `_lock` and state.
+6. **BrowserRequestExecutor**: Owns one request lifecycle state, terminal event/error, request task, observer/queue tasks, and lease release through request cleanup.
 
-### Authority Rules:
-- **Teardown Authority**: `BrowserEngine.close()` is the ONLY authoritative entry point for terminal shutdown. 
-- **Parent-Child Teardown**: ProviderSession resources close before the parent Browser, and the Browser closes before Playwright stops, during both replacement and terminal shutdown.
+### 2.1 BrowserRuntime Contract
+
+`BrowserRuntime` is the launch-mechanics boundary between `BrowserEngine` and the concrete browser driver. It exposes:
+
+- `start()`: initialize the underlying browser driver.
+- `launch_browser()`: launch a fresh browser instance and return its handle.
+- `bind_disconnect()`: register a callback for unexpected browser disconnect.
+- `is_browser_connected()`: report whether the browser transport is still connected.
+- `close_browser()`: best-effort, never-raising close of a browser instance.
+- `stop()`: tear down the driver; best-effort and idempotent.
+
+Ownership invariants:
+
+- **Mechanics Only**: A `BrowserRuntime` never initiates recovery or shutdown. Lifecycle authority (generation, shutdown, session coordination) stays with `BrowserEngine`.
+- **Current Implementation**: `PlaywrightChromiumRuntime` is the sole implementation, selected by `create_browser_runtime()` when `[Browser] runtime = playwright`. No other runtime value is supported; configuring one raises `ValueError`.
+- **Not an API Abstraction**: `BrowserRuntime` does NOT abstract page, context, or `PersistentTab` APIs. `ProviderSession` continues to own `BrowserContext` creation/closure, page/session resources, `storage_state` persistence, and conversation/session state. Runtime selection does not change that boundary.
+
+### 2.2 Authority Rules
+- **Teardown Authority**: `BrowserEngine.close()` is the ONLY authoritative entry point for terminal shutdown.
+- **Parent-Child Teardown**: ProviderSession resources close before the parent Browser, and the Browser closes before the runtime stops the driver, during both replacement and terminal shutdown.
+- **Runtime Delegation**: `BrowserEngine` performs browser-process lifecycle decisions but executes the mechanics through the `BrowserRuntime` boundary (e.g., `runtime.stop()`, `runtime.start()`, `runtime.launch_browser()`, `runtime.close_browser()`, `runtime.bind_disconnect()`). It does not drive Playwright launch/stop mechanics directly.
 - **Context Closure Authority**: Arbitrary callers and provider adapters must not close the context directly. ProviderSession lifecycle cleanup is the authorized BrowserContext owner.
 - **Cleanup Ownership**: `ManagedPage` is responsible for releasing its own permits and leases, even during request cancellation (must be wrapped in `asyncio.shield`).
 
@@ -84,8 +103,8 @@ Unhealthy-browser replacement follows this order:
 
 1. Detect unhealthy Browser under `management_lock`.
 2. Clean ProviderSessions bound to old lifecycle/resources and wait for in-progress cleanup.
-3. Close or skip old Browser, then stop old Playwright.
-4. Launch new Playwright and Browser.
+3. Close or skip old Browser via the runtime, then stop the driver via the runtime.
+4. Start the driver and launch a new Browser through the runtime.
 5. Increment `browser_generation` only after successful Browser launch.
 6. Set up ProviderSession contexts against the new generation.
 
@@ -109,10 +128,10 @@ Failed launch leaves the generation unchanged. ProviderSessions observe and stor
 
 ## 8. Terminal Browser Cleanup
 
-- If public Browser state confirms disconnection, explicit `browser.close()` is skipped.
+- If public Browser state confirms disconnection, explicit browser close is skipped.
 - A public Playwright close error is benign only when state confirms disconnection afterward.
 - If Browser remains connected, close failure remains a warning; generic non-Playwright close exceptions remain visible regardless of connection state.
-- Browser cleanup always precedes Playwright stop and uses no private Playwright exception or API.
+- Browser cleanup always precedes driver stop and uses no private Playwright exception or API. Both are executed through the `BrowserRuntime` boundary (`close_browser()`, `stop()`).
 
 ## 9. AI Agent Rules
 

--- a/docs/specs/concurrency-model.md
+++ b/docs/specs/concurrency-model.md
@@ -33,6 +33,16 @@ This document specifies the concurrency contracts, resource ownership, and synch
     - Engine shutdown is initiated.
 - **Enforcement**: Operations on invalid leases MUST fail fast.
 
+### 1.6 Browser Conversation Ownership
+
+This contract governs `conversation_id` ownership for browser-native requests (e.g., Gemini Playwright). It is independent of the Gemini WebAPI `SessionManager.lock` semantics in [Section 6](#6-gemini-conversation-sessions).
+
+- **Single Owner Invariant**: An active browser conversation has exactly one request owner at any time. The owner is recorded in the session's `active_conversations` map, guarded by `conversation_lock`.
+- **Competing Registration**: A request that registers an already-owned active `conversation_id` is rejected with `ConversationBusyError`. Pre-header this maps to HTTP 409; post-header it terminates the stream internally (see [Error Policy](error-policy.md)).
+- **Winner Preservation**: When a collision occurs, the current winner remains the owner. The winner's registry entry and tab are never mutated or displaced by the losing request.
+- **Conditional Release**: Ownership release must be conditional on request identity. A cleanup path only removes the ownership entry if it still maps to its own request id; it must never unregister or mutate another request's ownership.
+- **Losing-Request Cleanup**: A losing request's cleanup must not unregister the winner's ownership or alter the winner's `PersistentTab`/registry state.
+
 ## 2. Lock Hierarchy & Deadlock Prevention
 
 Locks MUST be acquired in the following order. Acquiring out-of-order is strictly **forbidden** and results in deterministic deadlocks.

--- a/docs/specs/error-policy.md
+++ b/docs/specs/error-policy.md
@@ -55,10 +55,15 @@ Failures are formally classified into four levels of impact:
 ### 3.5 Browser Resource Loss During a Request
 - `BrowserDisconnectedError` represents terminal browser/page/context loss for the active request. The terminal signal wakes request waits immediately and preserves the existing HTTP 502 mapping.
 - Before streaming response headers are sent, this error is mapped through the normal HTTP 502 policy. After SSE status 200 is sent, the status cannot be rewritten; the stream iterator terminates cleanly instead.
-- Post-header `BrowserDisconnectedError` and `BrowserShuttingDownError` must not escape into Starlette/AnyIO as an ASGI application error and must not emit `[DONE]`.
-- If a request already recorded that terminal state, it takes precedence over a later raw Playwright close error caused by the same resource loss.
+- Post-header `BrowserDisconnectedError`, `BrowserShuttingDownError`, `BrowserGenerationMismatchError`, `QueueOverflowError`, and `ConversationBusyError` must not escape into Starlette/AnyIO as an ASGI application error and must not emit `[DONE]`.
+- If a request already recorded a terminal `BrowserDisconnectedError` or `BrowserShuttingDownError`, that recorded terminal state takes precedence over a later raw Playwright close error caused by the same resource loss during lazy conversation registration.
 - Raw Playwright errors without recorded terminal browser-disconnect state retain existing classification, including the existing 503 mapping for a closed page/context.
 - A true timeout remains a timeout and maps through existing timeout policy; browser death is not a timeout fallback.
+
+### 3.6 Conversation Contention
+- A competing request registering the same `conversation_id` as an already-owned active conversation is rejected with `ConversationBusyError`.
+- **Pre-header**: `ConversationBusyError` maps to HTTP 409 Conflict before streaming headers are sent.
+- **Post-header**: `ConversationBusyError` is an expected terminal request condition handled inside the stream iterator; the stream terminates without `[DONE]` and without escaping to ASGI.
 
 ---
 
@@ -93,6 +98,7 @@ The runtime implements a dedicated, minimal, lifecycle-scoped exception hierarch
   - `RequestError`: Base exception for request-scoped failures.
     - `LeaseInvalidatedError`: Raised when attempting to operate on an invalidated or stale tab lease.
     - `QueueOverflowError`: Raised when the request-scoped event buffer reaches saturation limit during bridge enqueuing.
+    - `ConversationBusyError`: Raised when a competing request registers the same active `conversation_id` that already has an owner.
 
 **Invariant**: Exception classification MUST reflect the runtime scope and recovery authority boundaries. Exception hierarchy is strictly scoped to lifecycle and resource-management concerns; it does not model domain-level or business-level failures.
 

--- a/docs/specs/lifecycle-and-recovery.md
+++ b/docs/specs/lifecycle-and-recovery.md
@@ -25,9 +25,9 @@ This document specifies the browser lifecycle, state transitions, and self-heali
 Unhealthy-browser replacement runs under `BrowserEngine.management_lock`:
 
 1. Clean ProviderSessions bound to old lifecycle/resources and wait for active cleanup.
-2. Close or skip old Browser.
-3. Stop old Playwright.
-4. Launch new Playwright and Browser.
+2. Close or skip old Browser through the runtime (`runtime.close_browser()`).
+3. Stop the driver through the runtime (`runtime.stop()`).
+4. Start the driver and launch a new Browser through the runtime (`runtime.start()`, `runtime.launch_browser()`).
 5. Publish the successful launch by incrementing `browser_generation`.
 6. Set up ProviderSession contexts.
 
@@ -48,9 +48,9 @@ Application shutdown follows:
 3. FastAPI lifespan calls `BrowserEngine.close(source="application")`.
 4. Existing requests receive up to 15 seconds to finish; remaining requests receive request-owned abort callbacks.
 5. ProviderSession lifecycle tasks are cancelled/drained and ProviderSession resources close.
-6. Browser closes or is skipped, then Playwright stops.
+6. Browser closes or is skipped, then the driver stops — both executed through the `BrowserRuntime` boundary (`runtime.close_browser()`, `runtime.stop()`).
 
-ProviderSession resources always close before Browser, and Browser before Playwright. Runtime terminal cleanup uses `save_state=False`; bootstrap/manual auth cleanup may use `save_state=True`.
+ProviderSession resources always close before Browser, and Browser before the driver stops. `BrowserEngine` owns this ordering and all shutdown/recovery decisions; the runtime only executes the mechanics. Runtime terminal cleanup uses `save_state=False`; bootstrap/manual auth cleanup may use `save_state=True`.
 
 **Shutdown Invariant**: Once shutdown intent exists, no new recovery or admission may begin. Workers recheck shutdown state after acquiring `init_lock` and before cleanup. Existing recovery may be cancelled and awaited during terminal cleanup.
 

--- a/docs/specs/provider-contract.md
+++ b/docs/specs/provider-contract.md
@@ -31,7 +31,7 @@ Authentication ownership is split by responsibility:
 Each auth strategy owns its own `provider_name` and may contribute provider-specific status reporting. The registry, not Gemini-specific code, determines which strategy is active for a given provider.
 
 ### Forbidden Behaviors:
-- Providers/Adapters must never close the Browser directly and must not close BrowserContext directly. ProviderSession lifecycle cleanup is the authorized BrowserContext owner; BrowserEngine owns Browser and Playwright teardown.
+- Providers/Adapters must never close the Browser directly and must not close BrowserContext directly. ProviderSession lifecycle cleanup is the authorized BrowserContext owner; BrowserEngine owns Browser teardown and executes it through the `BrowserRuntime` boundary (`runtime.close_browser()`, `runtime.stop()`).
 - Providers/Adapters must NEVER recreate `BrowserContext` or sessions directly; they must escalate to the authoritative session layer.
 - Browser-native Adapters must NEVER bypass `ProviderSession.acquire_lease()` to obtain pages.
 - Providers/Adapters must NEVER manipulate `is_shutting_down` or other engine state flags.

--- a/docs/specs/runtime-architecture-overview.md
+++ b/docs/specs/runtime-architecture-overview.md
@@ -22,6 +22,7 @@ The architecture is built for **isolation**, **concurrency safety**, and **lifec
 
 ### 2. Browser Engine (`BrowserEngine`)
 - **Active Lifecycle Orchestration:** A global singleton managing the active Chromium process and coordinating cross-provider synchronization. Recovery is valid only within an active engine lifecycle; it is NOT a resurrection authority after terminal shutdown begins.
+- **Runtime Boundary:** Browser-process launch mechanics are delegated to a `BrowserRuntime` (`PlaywrightChromiumRuntime`, selected via `create_browser_runtime()` with `[Browser] runtime = playwright`). The engine owns lifecycle ordering and decisions; the runtime executes start/launch/close/stop mechanics. See [Browser Runtime Architecture](browser-runtime-architecture.md).
 - **Generation Invalidation:** Tracks browser process generations to automatically invalidate stale contexts, `PersistentTab` objects, active leases, cached page references, and request-scoped bridge state after a process restart or fatal disconnect. Newly created sessions are not associated with any generation until their first successful context initialization.
 - **Terminal Shutdown Authority:** The authoritative coordinator for irreversible shutdown. It ensures all background activity is halted and requests are drained before process termination.
 
@@ -88,6 +89,7 @@ The architecture is built for **isolation**, **concurrency safety**, and **lifec
 This document provides a high-level strategic overview. Detailed behavioral guarantees and implementation invariants are codified in the following specifications. **The runtime contracts are authoritative; if this overview conflicts with a detailed contract, the specific contract document takes precedence.**
 
 - **[Concurrency Model](concurrency-model.md)**: Semaphore ownership, lock hierarchy, and cancellation safety.
+- **[Browser Runtime Architecture](browser-runtime-architecture.md)**: Engine state machine and the BrowserRuntime launch-mechanics boundary.
 - **[Provider Contract](provider-contract.md)**: Ownership boundaries for logical providers and their technical adapters, poisoning rules, and escalation semantics.
 - **[Streaming Pipeline](streaming-pipeline.md)**: Event flow, normalization, and rewrite-resilience.
 - **[Error Policy](error-policy.md)**: Runtime error semantics, classification boundaries, and recovery authority.

--- a/docs/specs/streaming-pipeline.md
+++ b/docs/specs/streaming-pipeline.md
@@ -50,7 +50,7 @@ The pipeline is designed to handle providers that "rewrite" the full response te
 - **Capacity**: The queue is **bounded** (typically `maxsize=100`) to prevent unbounded memory growth.
 - **Overflow Contract**: Queue saturation is considered a **terminal request-stream failure**. 
     - **No Silent Drops**: Bridge callbacks MUST NEVER silently drop `chunk` or `rewrite` events, as this corrupts the stream state.
-    - **Fatal Termination**: If enqueue fails, the request stream must transition into a failed state and terminate immediately.
+    - **Fatal Termination**: If enqueue fails, the request stream must transition into a failed state and terminate immediately. The generator rechecks the overflow state on its loop so an overflow surfaced after stream start still terminates the stream as `QueueOverflowError` rather than stalling or completing.
     - **Isolation**: The affected `request_id` is invalidated, but the broader `ProviderSession` must remain healthy.
 
 ### 5.2 Non-Blocking Callbacks
@@ -68,11 +68,11 @@ The pipeline is designed to handle providers that "rewrite" the full response te
 - **Format**: All events are normalized to OpenAI-compatible Server-Sent Events (SSE).
 - **Finalization**: Every successful stream MUST terminate with a literal `data: [DONE]` chunk.
 
-### 7.2 Terminal Browser Conditions
+### 7.2 Post-Header Terminal Conditions
 - **Before response start**: The request executor owns terminal browser loss and applies normal HTTP error policy. `BrowserDisconnectedError` retains its existing HTTP 502 mapping.
-- **After response start**: Once SSE status 200 and headers are sent, HTTP status cannot be rewritten. The SSE body iterator owns expected terminal browser conditions.
-- **Expected terminal conditions**: `BrowserDisconnectedError` and `BrowserShuttingDownError` terminate the iterator internally and MUST NOT escape into Starlette/AnyIO. No new SSE error event or schema is emitted.
-- **Terminal truncation**: A browser/page/context loss or forced shutdown ends the stream without `data: [DONE]` and logs `Stream terminated`, not `Stream completed`. Absence of `[DONE]` means the stream did not complete successfully; clients MUST NOT interpret it as successful completion.
+- **After response start**: Once SSE status 200 and headers are sent, HTTP status cannot be rewritten. The SSE body iterator owns expected terminal request conditions.
+- **Expected terminal conditions**: `BrowserDisconnectedError`, `BrowserShuttingDownError`, `BrowserGenerationMismatchError`, `QueueOverflowError`, and `ConversationBusyError` terminate the iterator internally and MUST NOT escape into Starlette/AnyIO. No new SSE error event or schema is emitted.
+- **Terminal truncation**: A browser/page/context loss, forced shutdown, generation mismatch, queue overflow, or conversation contention ends the stream without `data: [DONE]` and logs `Stream terminated`, not `Stream completed`. Absence of `[DONE]` means the stream did not complete successfully; clients MUST NOT interpret it as successful completion.
 
 Successful completion remains:
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -43,6 +43,8 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
     # Set default sections and values if they don't exist
     if "Browser" not in config:
         config["Browser"] = {"name": "chrome"}
+    if "runtime" not in config["Browser"]:
+        config["Browser"]["runtime"] = "playwright"
     if "Cookies" not in config:
         config["Cookies"] = {}
     if "Proxy" not in config:

--- a/src/app/endpoints/system.py
+++ b/src/app/endpoints/system.py
@@ -58,7 +58,7 @@ async def ready():
         return Response(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
         
     # 3. Browser must be connected
-    if not engine.browser or not engine.browser.is_connected():
+    if not engine.browser or not engine.runtime.is_browser_connected(engine.browser):
         return Response(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
         
     # 4. At least one session must be structurally alive
@@ -98,7 +98,7 @@ async def runtime_status():
     status_payload = {
         "engine": {
             "status": "SHUTTING_DOWN" if engine.is_shutting_down else "RUNNING",
-            "browser_connected": engine.browser.is_connected() if engine.browser else False,
+            "browser_connected": engine.runtime.is_browser_connected(engine.browser) if engine.browser else False,
             "browser_generation": engine.browser_generation,
             "is_bootstrap": engine.is_bootstrap
         },

--- a/src/app/services/browser/engine.py
+++ b/src/app/services/browser/engine.py
@@ -1,21 +1,14 @@
-import os
 import asyncio
-import json
 import time
-import re
-import uuid
-import weakref
-from enum import Enum
-from typing import Optional, Dict, Any, List
-from collections import OrderedDict
-from playwright.async_api import async_playwright, Playwright, BrowserContext, Page, Browser, Error as PlaywrightError
+from typing import Optional, Dict, Any
 from app.logger import logger
-from app.config import CONFIG, get_default_playwright_cache_dir
+from app.config import CONFIG
 
 from app.services.browser.errors import BrowserDisconnectedError
 from app.services.browser.tab import TabStatus, PersistentTab, ManagedPage
 
 from app.services.browser.session import ProviderSession
+from app.services.browser.runtime import BrowserRuntime, create_browser_runtime
 
 class BrowserEngine:
     """
@@ -26,19 +19,17 @@ class BrowserEngine:
     _SHUTDOWN_SOURCES = {"application", "browser-disconnect", "manual/internal"}
 
     def __init__(self, headless: Optional[bool] = None, is_bootstrap: bool = False):
-        self.playwright: Optional[Playwright] = None
-        self.browser: Optional[Browser] = None
+        self.browser: Optional[Any] = None
         self.browser_generation = 0
         self.sessions: Dict[str, ProviderSession] = {}
         self.sessions_lock = asyncio.Lock()
         self.management_lock = asyncio.Lock()
-        self.user_data_dir = get_default_playwright_cache_dir()
-        os.makedirs(self.user_data_dir, exist_ok=True)
         self.is_bootstrap = is_bootstrap
         if headless is not None:
             self.headless = headless
         else:
             self.headless = CONFIG["Playwright"].getboolean("headless", False)
+        self.runtime: BrowserRuntime = create_browser_runtime(headless=self.headless)
         self.max_pages = CONFIG["Playwright"].getint("max_concurrent_pages", 5)
         self.max_total_tabs = CONFIG["Playwright"].getint("max_total_tabs", 50)
         self.is_shutting_down = False
@@ -102,64 +93,6 @@ class BrowserEngine:
             )
             await session.close_resources(save_state=False)
 
-    async def _close_browser_best_effort(self, phase: str) -> None:
-        if not self.browser:
-            return
-
-        browser = self.browser
-        try:
-            connected = browser.is_connected()
-        except Exception as inspection_error:
-            logger.warning(
-                "BrowserEngine: Failed to inspect browser connection before close: %s",
-                inspection_error,
-                exc_info=True,
-                extra={"phase": phase, "generation": self.browser_generation},
-            )
-            connected = True
-
-        if not connected:
-            logger.debug(
-                "BrowserEngine: Skipping browser close; transport already disconnected.",
-                extra={"phase": phase, "generation": self.browser_generation},
-            )
-            return
-
-        try:
-            await browser.close()
-        except PlaywrightError as close_error:
-            try:
-                connected_after_error = browser.is_connected()
-            except Exception as inspection_error:
-                logger.warning(
-                    "BrowserEngine: Browser close failed (%s); post-close connection inspection failed: %s",
-                    close_error,
-                    inspection_error,
-                    exc_info=(type(close_error), close_error, close_error.__traceback__),
-                    extra={"phase": phase, "generation": self.browser_generation},
-                )
-                return
-
-            if connected_after_error:
-                logger.warning(
-                    "BrowserEngine: Error closing browser: %s",
-                    close_error,
-                    exc_info=True,
-                    extra={"phase": phase, "generation": self.browser_generation},
-                )
-            else:
-                logger.debug(
-                    "BrowserEngine: Browser transport disconnected during close.",
-                    extra={"phase": phase, "generation": self.browser_generation},
-                )
-        except Exception as close_error:
-            logger.warning(
-                "BrowserEngine: Error closing browser: %s",
-                close_error,
-                exc_info=(type(close_error), close_error, close_error.__traceback__),
-                extra={"phase": phase, "generation": self.browser_generation},
-            )
-
     def _track_disconnect_close_task(self, task: asyncio.Task) -> None:
         self._disconnect_close_task = task
 
@@ -192,29 +125,22 @@ class BrowserEngine:
             logger.debug("BrowserEngine: Initialization skipped - engine is shutting down.", extra={"generation": self.browser_generation})
             return
 
-        if not self.playwright or not self.browser or not self.browser.is_connected():
+        if not self.browser or not self.runtime.is_browser_connected(self.browser):
             logger.info("BrowserEngine: Initializing Browser...", extra={"generation": self.browser_generation})
 
             await self._close_sessions_before_browser_replacement()
             
             if self.browser:
-                await self._close_browser_best_effort("replacement")
-            if self.playwright:
-                try: 
-                    await self.playwright.stop()
-                except Exception as e:
-                    logger.debug(f"BrowserEngine: Best-effort playwright stop failed: {e}", extra={"generation": self.browser_generation})
+                await self.runtime.close_browser(self.browser, "replacement")
+            await self.runtime.stop()
             
             try:
-                self.playwright = await async_playwright().start()
-                self.browser = await self.playwright.chromium.launch(
-                    headless=self.headless,
-                    args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"]
-                )
+                await self.runtime.start()
+                self.browser = await self.runtime.launch_browser()
                 
                 # Bind disconnect listener for manual closure detection
                 self._disconnect_handled = False
-                self.browser.on("disconnected", lambda b: self._on_browser_disconnected())
+                self.runtime.bind_disconnect(self.browser, lambda: self._on_browser_disconnected())
                 
                 self.browser_generation += 1
                 logger.info("BrowserEngine: New generation active.", extra={"generation": self.browser_generation})
@@ -399,23 +325,14 @@ class BrowserEngine:
                 
                 if self.browser:
                     logger.info("BrowserEngine: Closing browser process.", extra={"generation": self.browser_generation})
-                    await self._close_browser_best_effort("terminal")
+                    await self.runtime.close_browser(self.browser, "terminal")
                 else:
                     logger.info("BrowserEngine: No browser process to close.", extra={"generation": self.browser_generation})
                 
-                if self.playwright:
-                    try: 
-                        logger.info("BrowserEngine: Stopping playwright.", extra={"generation": self.browser_generation})
-                        await self.playwright.stop()
-                        logger.info("BrowserEngine: Playwright instance stopped successfully.", extra={"generation": self.browser_generation})
-                    except Exception as e:
-                        logger.warning(f"BrowserEngine: Error stopping playwright: {e}", exc_info=True, extra={"generation": self.browser_generation})
-                else:
-                    logger.info("BrowserEngine: No playwright instance to stop.", extra={"generation": self.browser_generation})
+                await self.runtime.stop()
                 
                 self.sessions.clear()
                 self.browser = None
-                self.playwright = None
                 logger.info("BrowserEngine: Shutdown complete.", extra={"generation": self.browser_generation})
         except Exception as e:
             logger.error(f"BrowserEngine: Shutdown failed midway: {e}", exc_info=True)

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -459,6 +459,9 @@ class BrowserRequestExecutor:
                         raise state.terminal_error
                     raise
 
+                if state.queue_overflow:
+                    raise QueueOverflowError("Event queue saturated")
+
                 try:
                     payload = await self._wait_for_payload(queue, state, self.config.chunk_timeout)
                 except asyncio.TimeoutError:
@@ -492,7 +495,12 @@ class BrowserRequestExecutor:
             if not stream_terminated:
                 yield await get_done_chunk()
 
-        except (BrowserDisconnectedError, BrowserShuttingDownError) as error:
+        except (
+            BrowserDisconnectedError,
+            BrowserShuttingDownError,
+            BrowserGenerationMismatchError,
+            QueueOverflowError,
+        ) as error:
             stream_terminated = True
             logger.info(
                 f"Stream terminated: {request_id}",

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -500,6 +500,7 @@ class BrowserRequestExecutor:
             BrowserShuttingDownError,
             BrowserGenerationMismatchError,
             QueueOverflowError,
+            ConversationBusyError,
         ) as error:
             stream_terminated = True
             logger.info(

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -449,7 +449,15 @@ class BrowserRequestExecutor:
                 raise QueueOverflowError("Event queue saturated")
 
             while True:
-                await self._register_conversation_if_available(page, state, session, lease)
+                try:
+                    await self._register_conversation_if_available(page, state, session, lease)
+                except PlaywrightError:
+                    if isinstance(
+                        state.terminal_error,
+                        (BrowserDisconnectedError, BrowserShuttingDownError),
+                    ):
+                        raise state.terminal_error
+                    raise
 
                 try:
                     payload = await self._wait_for_payload(queue, state, self.config.chunk_timeout)

--- a/src/app/services/browser/request_executor.py
+++ b/src/app/services/browser/request_executor.py
@@ -27,7 +27,7 @@ from app.services.browser.tab import ManagedPage
 
 
 @dataclass(frozen=True)
-class PlaywrightAdapterConfig:
+class BrowserRequestConfig:
     """Consolidated configuration for browser-native request execution."""
     navigation_timeout: int
     ui_wait_timeout: int
@@ -35,7 +35,7 @@ class PlaywrightAdapterConfig:
     total_request_timeout: int
 
     @classmethod
-    def load(cls) -> "PlaywrightAdapterConfig":
+    def load(cls) -> "BrowserRequestConfig":
         return cls(
             navigation_timeout=CONFIG["Playwright"].getint("navigation_timeout", 30000),
             ui_wait_timeout=CONFIG["Playwright"].getint("ui_wait_timeout", 15000),
@@ -45,7 +45,7 @@ class PlaywrightAdapterConfig:
 
 
 @dataclass
-class PlaywrightRequestState:
+class BrowserRequestState:
     """Shared state for a single browser-native request lifecycle."""
     request_id: str
     start_time: float
@@ -92,15 +92,15 @@ class BrowserRequestExecutorHooks:
     get_browser_engine: Callable[[], Awaitable[Any]]
     sleep: Callable[[float], Awaitable[None]]
     timeout: Callable[[float], Any]
-    navigate: Callable[[Page, PlaywrightRequestState, OpenAIChatRequest, PlaywrightAdapterConfig], Awaitable[None]]
-    wait_for_ready_ui: Callable[[Page, PlaywrightRequestState, PlaywrightAdapterConfig], Awaitable[None]]
+    navigate: Callable[[Page, BrowserRequestState, OpenAIChatRequest, BrowserRequestConfig], Awaitable[None]]
+    wait_for_ready_ui: Callable[[Page, BrowserRequestState, BrowserRequestConfig], Awaitable[None]]
     start_observer: Callable[[Page, str, str], Awaitable[Any]]
     stop_observer: Callable[[Page, str], Awaitable[None]]
     stop_generation: Callable[[Page], Awaitable[None]]
     extract_conversation_id: Callable[[str], Optional[str]]
     convert_to_openai_format: Callable[[str, str, bool], dict]
-    orchestrate_model_selection: Callable[[Any, Page, str, PlaywrightRequestState], Awaitable[None]]
-    configure_request_options: Callable[[Any, Page, OpenAIChatRequest, PlaywrightRequestState], Awaitable[None]]
+    orchestrate_model_selection: Callable[[Any, Page, str, BrowserRequestState], Awaitable[None]]
+    configure_request_options: Callable[[Any, Page, OpenAIChatRequest, BrowserRequestState], Awaitable[None]]
 
 
 class BrowserRequestExecutor:
@@ -110,7 +110,7 @@ class BrowserRequestExecutor:
     Provider-specific DOM behavior remains delegated through hooks.
     """
 
-    def __init__(self, config: PlaywrightAdapterConfig, hooks: BrowserRequestExecutorHooks):
+    def __init__(self, config: BrowserRequestConfig, hooks: BrowserRequestExecutorHooks):
         self.config = config
         self.hooks = hooks
 
@@ -148,7 +148,7 @@ class BrowserRequestExecutor:
             for attempt in range(1, max_retries + 1):
                 page_lease = None
                 observer_task = None
-                state = PlaywrightRequestState(request_id=request_id, start_time=start_time)
+                state = BrowserRequestState(request_id=request_id, start_time=start_time)
                 state.request_task = asyncio.current_task()
 
                 def on_close(_page):
@@ -423,7 +423,7 @@ class BrowserRequestExecutor:
         queue: asyncio.Queue,
         model: str,
         page: Page,
-        state: PlaywrightRequestState,
+        state: BrowserRequestState,
         observer_task: Optional[asyncio.Task],
         engine: Any,
         session: Any,
@@ -534,7 +534,7 @@ class BrowserRequestExecutor:
         queue: asyncio.Queue,
         model: str,
         page: Page,
-        state: PlaywrightRequestState,
+        state: BrowserRequestState,
         observer_task: Optional[asyncio.Task],
         engine: Any,
         session: Any,
@@ -568,7 +568,7 @@ class BrowserRequestExecutor:
         finally:
             await self._cleanup(observer_task, state, lease, session)
 
-    async def _register_conversation_if_available(self, page: Page, state: PlaywrightRequestState, session: Any, lease: ManagedPage):
+    async def _register_conversation_if_available(self, page: Page, state: BrowserRequestState, session: Any, lease: ManagedPage):
         if state.conversation_id or state.active_tab:
             return
         async with state.lock:
@@ -579,7 +579,7 @@ class BrowserRequestExecutor:
                 state.conversation_id = conversation_id
                 state.active_tab = await session.register_conversation(conversation_id, lease)
 
-    async def _cleanup(self, observer_task: Optional[asyncio.Task], state: Optional[PlaywrightRequestState], lease: Optional[ManagedPage], session: Any):
+    async def _cleanup(self, observer_task: Optional[asyncio.Task], state: Optional[BrowserRequestState], lease: Optional[ManagedPage], session: Any):
         if not state and not lease and not observer_task:
             return
         await asyncio.shield(self._do_cleanup(observer_task, state, lease, session))
@@ -651,7 +651,7 @@ class BrowserRequestExecutor:
     async def _wait_for_payload(
         self,
         queue: asyncio.Queue,
-        state: PlaywrightRequestState,
+        state: BrowserRequestState,
         timeout: Optional[float] = None,
     ):
         if state.terminal_event.is_set():

--- a/src/app/services/browser/runtime/__init__.py
+++ b/src/app/services/browser/runtime/__init__.py
@@ -1,0 +1,5 @@
+from app.services.browser.runtime.base import BrowserRuntime
+from app.services.browser.runtime.factory import create_browser_runtime
+from app.services.browser.runtime.playwright_runtime import PlaywrightChromiumRuntime
+
+__all__ = ["BrowserRuntime", "PlaywrightChromiumRuntime", "create_browser_runtime"]

--- a/src/app/services/browser/runtime/base.py
+++ b/src/app/services/browser/runtime/base.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional
+
+
+class BrowserRuntime(ABC):
+    """Launch mechanics for a concrete browser engine.
+
+    Mechanics only. Lifecycle authority (generation, shutdown, session
+    coordination) stays with BrowserEngine; a runtime never initiates
+    recovery or shutdown.
+    """
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Initialize the underlying browser driver (e.g. async_playwright().start())."""
+
+    @abstractmethod
+    async def launch_browser(self) -> Any:
+        """Launch a fresh browser instance and return its handle."""
+
+    @abstractmethod
+    def bind_disconnect(self, browser: Any, callback: Callable[[], None]) -> None:
+        """Register a callback for unexpected browser disconnect."""
+
+    @abstractmethod
+    def is_browser_connected(self, browser: Any) -> bool:
+        """Report whether the browser transport is still connected."""
+
+    @abstractmethod
+    async def close_browser(self, browser: Any, phase: str) -> None:
+        """Best-effort close of a browser instance. Must never raise."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Tear down the driver (e.g. playwright.stop()). Best-effort, idempotent."""

--- a/src/app/services/browser/runtime/factory.py
+++ b/src/app/services/browser/runtime/factory.py
@@ -1,0 +1,12 @@
+from app.config import CONFIG
+from app.services.browser.runtime.base import BrowserRuntime
+from app.services.browser.runtime.playwright_runtime import PlaywrightChromiumRuntime
+
+
+def create_browser_runtime(*, headless=None) -> BrowserRuntime:
+    runtime_name = CONFIG.get("Browser", "runtime", fallback="playwright").strip().lower()
+    if runtime_name == "playwright":
+        return PlaywrightChromiumRuntime(headless=headless)
+    raise ValueError(
+        f"Unsupported browser runtime configured: '{runtime_name}'. Supported values: 'playwright'."
+    )

--- a/src/app/services/browser/runtime/playwright_runtime.py
+++ b/src/app/services/browser/runtime/playwright_runtime.py
@@ -1,0 +1,97 @@
+from typing import Any, Callable, Optional
+
+from playwright.async_api import async_playwright, Playwright, Error as PlaywrightError
+
+from app.logger import logger
+from app.services.browser.runtime.base import BrowserRuntime
+
+
+class PlaywrightChromiumRuntime(BrowserRuntime):
+    """Playwright/Chromium launcher. Launch mechanics only; lifecycle authority stays in BrowserEngine."""
+
+    def __init__(self, headless: Optional[bool] = None):
+        self.headless = headless
+        self._playwright: Optional[Playwright] = None
+
+    async def start(self) -> None:
+        self._playwright = await async_playwright().start()
+
+    async def launch_browser(self) -> Any:
+        return await self._playwright.chromium.launch(
+            headless=self.headless,
+            args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"]
+        )
+
+    def bind_disconnect(self, browser: Any, callback: Callable[[], None]) -> None:
+        browser.on("disconnected", lambda b: callback())
+
+    def is_browser_connected(self, browser: Any) -> bool:
+        return browser.is_connected()
+
+    async def close_browser(self, browser: Any, phase: str) -> None:
+        if not browser:
+            return
+
+        try:
+            connected = self.is_browser_connected(browser)
+        except Exception as inspection_error:
+            logger.warning(
+                "BrowserRuntime: Failed to inspect browser connection before close: %s",
+                inspection_error,
+                exc_info=True,
+                extra={"phase": phase},
+            )
+            connected = True
+
+        if not connected:
+            logger.debug(
+                "BrowserRuntime: Skipping browser close; transport already disconnected.",
+                extra={"phase": phase},
+            )
+            return
+
+        try:
+            await browser.close()
+        except PlaywrightError as close_error:
+            try:
+                connected_after_error = self.is_browser_connected(browser)
+            except Exception as inspection_error:
+                logger.warning(
+                    "BrowserRuntime: Browser close failed (%s); post-close connection inspection failed: %s",
+                    close_error,
+                    inspection_error,
+                    exc_info=(type(close_error), close_error, close_error.__traceback__),
+                    extra={"phase": phase},
+                )
+                return
+
+            if connected_after_error:
+                logger.warning(
+                    "BrowserRuntime: Error closing browser: %s",
+                    close_error,
+                    exc_info=True,
+                    extra={"phase": phase},
+                )
+            else:
+                logger.debug(
+                    "BrowserRuntime: Browser transport disconnected during close.",
+                    extra={"phase": phase},
+                )
+        except Exception as close_error:
+            logger.warning(
+                "BrowserRuntime: Error closing browser: %s",
+                close_error,
+                exc_info=(type(close_error), close_error, close_error.__traceback__),
+                extra={"phase": phase},
+            )
+
+    async def stop(self) -> None:
+        if not self._playwright:
+            return
+        playwright = self._playwright
+        try:
+            await playwright.stop()
+        except Exception as e:
+            logger.warning(f"BrowserRuntime: Error stopping playwright: {e}", exc_info=True)
+        finally:
+            self._playwright = None

--- a/src/app/services/browser/session.py
+++ b/src/app/services/browser/session.py
@@ -74,7 +74,7 @@ class ProviderSession:
         return (
             self.context is not None and 
             self.engine.browser is not None and 
-            self.engine.browser.is_connected() and
+            self.engine.runtime.is_browser_connected(self.engine.browser) and
             self.keepalive_page is not None and
             not self.keepalive_page.is_closed() and
             self.last_browser_generation == self.engine.browser_generation

--- a/src/app/services/providers/gemini/auth.py
+++ b/src/app/services/providers/gemini/auth.py
@@ -105,7 +105,7 @@ class GeminiAuthStrategy:
         """
         Orchestrate the headful login workflow for Gemini.
         """
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
         
         # Robust selectors for verification
         SIGN_IN_SELECTORS = [

--- a/src/app/services/providers/gemini/browser_adapter.py
+++ b/src/app/services/providers/gemini/browser_adapter.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional, Any
 from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 from app.services.browser.base_adapter import BaseProviderAdapter
-from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS, MODEL_PICKER_FALLBACK_SELECTORS
+from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS, MODEL_PICKER_FALLBACK_SELECTORS
 from app.logger import logger
 from app.services.browser.errors import TransientSessionError, ModelNotFoundError, GatedModelError
 

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -5,8 +5,8 @@ from fastapi import HTTPException
 from playwright.async_api import Error as PlaywrightError, Page, TimeoutError as PlaywrightTimeoutError
 
 from app.services.browser.engine import get_browser_engine
-from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
-from app.services.browser.adapters.scripts.gemini_scripts import (
+from app.services.providers.gemini.browser_adapter import GeminiProviderAdapter
+from app.services.providers.gemini.scripts.gemini_scripts import (
     SELECTORS,
     STOP_OBSERVER_SCRIPT,
     STREAM_EXTRACTOR_SCRIPT,

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -15,8 +15,8 @@ from app.services.browser.errors import GatedModelError, ModelNotFoundError, Tra
 from app.services.browser.request_executor import (
     BrowserRequestExecutor,
     BrowserRequestExecutorHooks,
-    PlaywrightAdapterConfig,
-    PlaywrightRequestState,
+    BrowserRequestConfig,
+    BrowserRequestState,
 )
 from app.services.browser.tab import TabStatus
 from app.config import CONFIG
@@ -33,7 +33,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
 
     def __init__(self, provider):
         self.provider = provider
-        self.config = PlaywrightAdapterConfig.load()
+        self.config = BrowserRequestConfig.load()
         self.executor = BrowserRequestExecutor(
             config=self.config,
             hooks=BrowserRequestExecutorHooks(
@@ -73,7 +73,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
     def _timeout(self, delay: float):
         return asyncio.timeout(delay)
 
-    async def _navigate(self, page: Page, state: PlaywrightRequestState, request, config: PlaywrightAdapterConfig) -> None:
+    async def _navigate(self, page: Page, state: BrowserRequestState, request, config: BrowserRequestConfig) -> None:
         if state.reused_conversation:
             target_url = f"https://gemini.google.com/app/{state.conversation_id}"
             if page.url != target_url:
@@ -100,7 +100,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
                 if state.active_tab:
                     state.active_tab.heartbeat("navigation_end")
 
-    async def _wait_for_ready_ui(self, page: Page, state: PlaywrightRequestState, config: PlaywrightAdapterConfig) -> None:
+    async def _wait_for_ready_ui(self, page: Page, state: BrowserRequestState, config: BrowserRequestConfig) -> None:
         input_locator = page.locator(SELECTORS["INPUT"]).first
         if state.active_tab:
             state.active_tab.heartbeat("input_wait")
@@ -129,7 +129,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         browser_adapter: GeminiProviderAdapter,
         page: Page,
         request,
-        state: PlaywrightRequestState,
+        state: BrowserRequestState,
     ) -> None:
         provider_options = getattr(request, "provider_options", None)
         gemini_options = getattr(provider_options, "gemini", None) if provider_options else None
@@ -151,7 +151,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
     async def _cleanup(self, observer_task, state, lease, session):
         await self.executor._cleanup(observer_task, state, lease, session)
 
-    async def _orchestrate_model_selection(self, browser_adapter: GeminiProviderAdapter, page: Page, model_id: str, state: PlaywrightRequestState):
+    async def _orchestrate_model_selection(self, browser_adapter: GeminiProviderAdapter, page: Page, model_id: str, state: BrowserRequestState):
         if not model_id:
             return
 

--- a/src/app/services/providers/gemini/scripts/gemini_scripts.py
+++ b/src/app/services/providers/gemini/scripts/gemini_scripts.py
@@ -1,4 +1,4 @@
-# src/app/services/browser/adapters/scripts/gemini_scripts.py
+# src/app/services/providers/gemini/scripts/gemini_scripts.py
 
 """
 Javascript snippets for Playwright's page.evaluate to interact with Gemini Web.

--- a/tests/test_browser_engine_lifecycle.py
+++ b/tests/test_browser_engine_lifecycle.py
@@ -3,7 +3,6 @@ import time
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
-from playwright.async_api import Error as PlaywrightError
 
 from app.services.browser.engine import BrowserEngine
 from app.services.browser.errors import BrowserShuttingDownError
@@ -16,19 +15,29 @@ def make_browser():
     return browser
 
 
+def make_runtime():
+    runtime = MagicMock()
+    runtime.is_browser_connected.return_value = True
+    runtime.close_browser = AsyncMock()
+    runtime.stop = AsyncMock()
+    runtime.start = AsyncMock()
+    runtime.launch_browser = AsyncMock(return_value=make_browser())
+    runtime.bind_disconnect = MagicMock()
+    return runtime
+
+
 @pytest.mark.asyncio
 async def test_engine_close_sets_terminal_shutdown_and_closes_owned_resources():
     engine = BrowserEngine(headless=True)
     browser = make_browser()
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
+    runtime = make_runtime()
     session = MagicMock()
     session.name = "gemini"
     session.active_lease_count = 0
     session.close_resources = AsyncMock()
 
+    engine.runtime = runtime
     engine.browser = browser
-    engine.playwright = playwright
     engine.sessions = {"gemini": session}
 
     await engine.close()
@@ -36,11 +45,10 @@ async def test_engine_close_sets_terminal_shutdown_and_closes_owned_resources():
     assert engine.is_shutting_down is True
     assert engine._shutdown_started is True
     session.close_resources.assert_awaited_once_with(save_state=False)
-    browser.close.assert_awaited_once()
-    playwright.stop.assert_awaited_once()
+    runtime.close_browser.assert_awaited_once_with(browser, "terminal")
+    runtime.stop.assert_awaited_once()
     assert engine.sessions == {}
     assert engine.browser is None
-    assert engine.playwright is None
 
 
 @pytest.mark.asyncio
@@ -86,87 +94,17 @@ async def test_bootstrap_engine_close_preserves_persistence_save():
 
 
 @pytest.mark.asyncio
-async def test_terminal_close_skips_disconnected_browser_and_stops_playwright():
+async def test_terminal_close_delegates_to_runtime_and_stops_it():
     engine = BrowserEngine(headless=True)
     browser = make_browser()
-    browser.is_connected.return_value = False
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
-    engine.browser = browser
-    engine.playwright = playwright
-
-    await engine.close()
-
-    browser.close.assert_not_awaited()
-    playwright.stop.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_browser_close_transport_race_is_benign_after_disconnect(caplog):
-    engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    browser.is_connected.side_effect = [True, False]
-    browser.close.side_effect = PlaywrightError("transport closed")
+    runtime = make_runtime()
+    engine.runtime = runtime
     engine.browser = browser
 
     await engine.close()
 
-    browser.close.assert_awaited_once()
-    assert not any("Error closing browser" in record.message for record in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_browser_close_error_while_connected_remains_warning(caplog):
-    engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    browser.is_connected.return_value = True
-    browser.close.side_effect = PlaywrightError("close failed")
-    engine.browser = browser
-
-    await engine.close()
-
-    assert any("Error closing browser" in record.message for record in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_generic_browser_close_error_warns_after_disconnect(caplog):
-    engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    browser.is_connected.side_effect = [True, False]
-    browser.close.side_effect = RuntimeError("programming failure")
-    engine.browser = browser
-
-    await engine.close()
-
-    assert any("Error closing browser" in record.message for record in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_generic_browser_close_error_warns_while_connected(caplog):
-    engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    browser.is_connected.return_value = True
-    browser.close.side_effect = RuntimeError("programming failure")
-    engine.browser = browser
-
-    await engine.close()
-
-    assert any("Error closing browser" in record.message for record in caplog.records)
-
-
-@pytest.mark.asyncio
-async def test_playwright_close_inspection_failure_preserves_original_error(caplog):
-    engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    browser.is_connected.side_effect = [True, RuntimeError("inspection failed")]
-    browser.close.side_effect = PlaywrightError("close transport failure")
-    engine.browser = browser
-
-    await engine.close()
-
-    messages = [record.message for record in caplog.records]
-    assert any("close transport failure" in message for message in messages)
-    assert any("inspection failed" in message for message in messages)
+    runtime.close_browser.assert_awaited_once_with(browser, "terminal")
+    runtime.stop.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -303,46 +241,41 @@ async def test_disconnect_close_task_is_tracked_and_exception_retrieved(caplog):
 async def test_engine_close_is_idempotent():
     engine = BrowserEngine(headless=True)
     browser = make_browser()
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
+    runtime = make_runtime()
     session = MagicMock()
     session.name = "gemini"
     session.active_lease_count = 0
     session.close_resources = AsyncMock()
 
+    engine.runtime = runtime
     engine.browser = browser
-    engine.playwright = playwright
     engine.sessions = {"gemini": session}
 
     await engine.close()
     await engine.close()
 
     session.close_resources.assert_awaited_once_with(save_state=False)
-    browser.close.assert_awaited_once()
-    playwright.stop.assert_awaited_once()
+    runtime.close_browser.assert_awaited_once()
+    runtime.stop.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_ensure_healthy_browser_noops_after_shutdown(mocker):
+async def test_ensure_healthy_browser_noops_after_shutdown():
     engine = BrowserEngine(headless=True)
     browser = make_browser()
-    browser.is_connected.return_value = False
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
-
+    runtime = make_runtime()
+    engine.runtime = runtime
     engine.browser = browser
-    engine.playwright = playwright
     engine.browser_generation = 4
     engine.is_shutting_down = True
-    async_playwright = mocker.patch("app.services.browser.engine.async_playwright")
 
     async with engine.management_lock:
         await engine._ensure_healthy_browser()
 
-    async_playwright.assert_not_called()
+    runtime.start.assert_not_awaited()
+    runtime.launch_browser.assert_not_awaited()
     assert engine.browser_generation == 4
     assert engine.browser is browser
-    assert engine.playwright is playwright
 
 
 @pytest.mark.asyncio
@@ -355,19 +288,16 @@ async def test_get_page_after_shutdown_fails_fast():
 
 
 @pytest.mark.asyncio
-async def test_browser_replacement_closes_provider_context_before_old_browser(mocker):
+async def test_browser_replacement_closes_provider_context_before_old_browser():
     engine = BrowserEngine(headless=True)
     order = []
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_browser.close.side_effect = lambda: order.append("browser")
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock(side_effect=lambda: order.append("playwright"))
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
+    runtime.close_browser = AsyncMock(side_effect=lambda browser, phase: order.append("browser"))
+    runtime.stop = AsyncMock(side_effect=lambda: order.append("playwright"))
     new_browser = make_browser()
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
 
     session = MagicMock()
     session.name = "gemini"
@@ -381,15 +311,15 @@ async def test_browser_replacement_closes_provider_context_before_old_browser(mo
         order.append("session")
 
     session.close_resources = AsyncMock(side_effect=close_resources)
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.browser_generation = 4
     engine.sessions = {"gemini": session}
 
     async with engine.management_lock:
         await engine._ensure_healthy_browser()
 
-    assert order == ["session", "playwright"]
+    assert order == ["session", "browser", "playwright"]
     assert session.context is None
     assert engine.browser is new_browser
     assert engine.browser_generation == 5
@@ -397,22 +327,18 @@ async def test_browser_replacement_closes_provider_context_before_old_browser(mo
 
 
 @pytest.mark.asyncio
-async def test_browser_replacement_skips_provider_sessions_without_resources(mocker):
+async def test_browser_replacement_skips_provider_sessions_without_resources():
     engine = BrowserEngine(headless=True)
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     new_browser = make_browser()
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
 
     session = MagicMock()
     session._has_resources_to_close.return_value = False
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.sessions = {"empty": session}
 
     async with engine.management_lock:
@@ -423,17 +349,13 @@ async def test_browser_replacement_skips_provider_sessions_without_resources(moc
 
 
 @pytest.mark.asyncio
-async def test_browser_replacement_cleans_multiple_provider_sessions(mocker):
+async def test_browser_replacement_cleans_multiple_provider_sessions():
     engine = BrowserEngine(headless=True)
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     new_browser = make_browser()
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
 
     sessions = []
     for name in ("gemini", "other"):
@@ -442,8 +364,8 @@ async def test_browser_replacement_cleans_multiple_provider_sessions(mocker):
         session._has_resources_to_close.return_value = True
         session.close_resources = AsyncMock()
         sessions.append(session)
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.sessions = {session.name: session for session in sessions}
 
     async with engine.management_lock:
@@ -454,69 +376,38 @@ async def test_browser_replacement_cleans_multiple_provider_sessions(mocker):
 
 
 @pytest.mark.asyncio
-async def test_browser_replacement_cleanup_failure_stops_before_parent_close(mocker):
+async def test_browser_replacement_cleanup_failure_stops_before_parent_close():
     engine = BrowserEngine(headless=True)
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
     session = MagicMock()
     session._has_resources_to_close.return_value = True
     session.close_resources = AsyncMock(side_effect=RuntimeError("cleanup failed"))
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.sessions = {"gemini": session}
 
     with pytest.raises(RuntimeError, match="cleanup failed"):
         async with engine.management_lock:
             await engine._ensure_healthy_browser()
 
-    old_browser.close.assert_not_awaited()
+    runtime.close_browser.assert_not_awaited()
     assert engine.browser_generation == 0
-
-
-@pytest.mark.asyncio
-async def test_browser_replacement_browser_close_failure_preserves_launch_policy(mocker):
-    engine = BrowserEngine(headless=True)
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_browser.close.side_effect = RuntimeError("old browser close failed")
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
-    new_browser = make_browser()
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
-    session = MagicMock()
-    session._has_resources_to_close.return_value = False
-    engine.browser = old_browser
-    engine.playwright = old_playwright
-    engine.sessions = {"gemini": session}
-
-    async with engine.management_lock:
-        await engine._ensure_healthy_browser()
-
-    assert engine.browser is new_browser
-    assert engine.browser_generation == 1
 
 
 @pytest.mark.asyncio
 async def test_replacement_setup_creates_context_on_new_generation(mocker):
     engine = BrowserEngine(headless=True, is_bootstrap=True)
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     new_context = MagicMock()
     new_context.on = MagicMock()
     new_context.new_page = AsyncMock(return_value=MagicMock())
     new_browser = make_browser()
     new_browser.new_context = AsyncMock(return_value=new_context)
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
     mocker.patch(
         "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
         return_value=iter([]),
@@ -528,8 +419,8 @@ async def test_replacement_setup_creates_context_on_new_generation(mocker):
     session.last_browser_generation = 1
     session._eviction_loop = AsyncMock()
     session._reaper_loop = AsyncMock()
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.browser_generation = 1
     engine.sessions = {"gemini": session}
 
@@ -542,21 +433,17 @@ async def test_replacement_setup_creates_context_on_new_generation(mocker):
 
 
 @pytest.mark.asyncio
-async def test_browser_replacement_launch_failure_does_not_increment_generation(mocker):
+async def test_browser_replacement_launch_failure_does_not_increment_generation():
     engine = BrowserEngine(headless=True)
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
+    runtime.launch_browser = AsyncMock(side_effect=RuntimeError("launch failed"))
     old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(side_effect=RuntimeError("launch failed"))
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
     session = MagicMock()
     session._has_resources_to_close.return_value = True
     session.close_resources = AsyncMock()
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.browser_generation = 7
     engine.sessions = {"gemini": session}
 
@@ -571,19 +458,15 @@ async def test_browser_replacement_launch_failure_does_not_increment_generation(
 @pytest.mark.asyncio
 async def test_provider_health_replacement_does_not_deadlock_cleanup(mocker):
     engine = BrowserEngine(headless=True, is_bootstrap=True)
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     new_context = MagicMock()
     new_context.on = MagicMock()
     new_context.new_page = AsyncMock(return_value=MagicMock())
     new_browser = make_browser()
     new_browser.new_context = AsyncMock(return_value=new_context)
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
     mocker.patch(
         "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
         return_value=iter([]),
@@ -595,8 +478,8 @@ async def test_provider_health_replacement_does_not_deadlock_cleanup(mocker):
     session.last_browser_generation = 1
     session._eviction_loop = AsyncMock()
     session._reaper_loop = AsyncMock()
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.browser_generation = 1
     engine.sessions = {"gemini": session}
 
@@ -612,20 +495,15 @@ async def test_provider_health_replacement_does_not_deadlock_cleanup(mocker):
 async def test_recovery_cleanup_completes_before_browser_replacement(mocker):
     engine = BrowserEngine(headless=True, is_bootstrap=True)
     order = []
-    old_browser = make_browser()
-    old_browser.is_connected.return_value = False
-    old_browser.close.side_effect = lambda: order.append("browser")
-    old_playwright = MagicMock()
-    old_playwright.stop = AsyncMock()
+    runtime = make_runtime()
+    runtime.is_browser_connected.return_value = False
     new_context = MagicMock()
     new_context.on = MagicMock()
     new_context.new_page = AsyncMock(return_value=MagicMock())
     new_browser = make_browser()
     new_browser.new_context = AsyncMock(side_effect=lambda **_: (order.append("context"), new_context)[1])
-    new_playwright = MagicMock()
-    new_playwright.chromium.launch = AsyncMock(return_value=new_browser)
-    playwright_factory = mocker.patch("app.services.browser.engine.async_playwright")
-    playwright_factory.return_value.start = AsyncMock(return_value=new_playwright)
+    runtime.launch_browser = AsyncMock(return_value=new_browser)
+    old_browser = make_browser()
     mocker.patch(
         "app.services.providers.gemini.auth_selector.GeminiAuthSelector.iter_candidates",
         return_value=iter([]),
@@ -649,8 +527,8 @@ async def test_recovery_cleanup_completes_before_browser_replacement(mocker):
     session.last_browser_generation = 1
     session._eviction_loop = AsyncMock()
     session._reaper_loop = AsyncMock()
+    engine.runtime = runtime
     engine.browser = old_browser
-    engine.playwright = old_playwright
     engine.browser_generation = 1
     engine.sessions = {"gemini": session}
 
@@ -669,14 +547,13 @@ async def test_recovery_cleanup_completes_before_browser_replacement(mocker):
 @pytest.mark.asyncio
 async def test_shutdown_waits_for_ensure_healthy_before_closing_browser(mocker):
     engine = BrowserEngine(headless=True, is_bootstrap=True)
-    browser = make_browser()
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
+    runtime = make_runtime()
     context = MagicMock()
     context.is_closed.return_value = False
     context.close = AsyncMock()
     context.on = MagicMock()
     context.new_page = AsyncMock(return_value=MagicMock())
+    browser = make_browser()
     browser.new_context = AsyncMock(return_value=context)
     health_started = asyncio.Event()
     release_health = asyncio.Event()
@@ -686,8 +563,8 @@ async def test_shutdown_waits_for_ensure_healthy_before_closing_browser(mocker):
         await release_health.wait()
 
     engine._ensure_healthy_browser = block_health
+    engine.runtime = runtime
     engine.browser = browser
-    engine.playwright = playwright
     engine.browser_generation = 1
     from app.services.browser.session import ProviderSession
 
@@ -709,7 +586,7 @@ async def test_shutdown_waits_for_ensure_healthy_before_closing_browser(mocker):
     await shutdown_task
 
     assert engine._shutdown_started is True
-    assert browser.close.await_count == 1
+    assert runtime.close_browser.await_count == 1
     assert context.close.await_count == 1
 
 
@@ -731,9 +608,7 @@ async def test_shutdown_first_rejects_ensure_without_context_creation():
 @pytest.mark.asyncio
 async def test_shutdown_waits_for_pending_recovery_cleanup(mocker):
     engine = BrowserEngine(headless=True)
-    browser = make_browser()
-    playwright = MagicMock()
-    playwright.stop = AsyncMock()
+    runtime = make_runtime()
     context = MagicMock()
     context.is_closed.return_value = False
     close_started = asyncio.Event()
@@ -744,8 +619,8 @@ async def test_shutdown_waits_for_pending_recovery_cleanup(mocker):
         await release_close.wait()
 
     context.close = AsyncMock(side_effect=close_context)
-    engine.browser = browser
-    engine.playwright = playwright
+    engine.runtime = runtime
+    engine.browser = make_browser()
     engine.browser_generation = 1
     from app.services.browser.session import ProviderSession
 
@@ -761,4 +636,4 @@ async def test_shutdown_waits_for_pending_recovery_cleanup(mocker):
 
     assert session.context is None
     assert engine.is_shutting_down is True
-    assert browser.close.await_count == 1
+    assert runtime.close_browser.await_count == 1

--- a/tests/test_browser_runtime.py
+++ b/tests/test_browser_runtime.py
@@ -1,0 +1,215 @@
+import configparser
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from playwright.async_api import Error as PlaywrightError
+
+from app.services.browser.runtime.factory import create_browser_runtime
+from app.services.browser.runtime.playwright_runtime import PlaywrightChromiumRuntime
+
+
+def make_config(runtime=None):
+    cfg = configparser.ConfigParser()
+    cfg["Browser"] = {"name": "chrome"}
+    if runtime is not None:
+        cfg["Browser"]["runtime"] = runtime
+    return cfg
+
+
+def make_browser():
+    browser = MagicMock()
+    browser.close = AsyncMock()
+    browser.is_connected.return_value = True
+    return browser
+
+
+def make_runtime():
+    return PlaywrightChromiumRuntime(headless=True)
+
+
+def test_default_runtime_resolves_to_playwright(mocker):
+    mocker.patch("app.services.browser.runtime.factory.CONFIG", new=make_config("playwright"))
+    runtime = create_browser_runtime(headless=True)
+    assert isinstance(runtime, PlaywrightChromiumRuntime)
+    assert runtime.headless is True
+
+
+def test_missing_runtime_key_falls_back_to_playwright(mocker):
+    mocker.patch("app.services.browser.runtime.factory.CONFIG", new=make_config())
+    assert isinstance(create_browser_runtime(headless=True), PlaywrightChromiumRuntime)
+
+
+def test_unsupported_runtime_fails_explicitly(mocker):
+    mocker.patch("app.services.browser.runtime.factory.CONFIG", new=make_config("firefox"))
+    with pytest.raises(ValueError, match="firefox"):
+        create_browser_runtime(headless=True)
+
+
+@pytest.mark.asyncio
+async def test_start_delegates_to_async_playwright(mocker):
+    playwright = MagicMock()
+    playwright.start = AsyncMock(return_value=playwright)
+    mocker.patch(
+        "app.services.browser.runtime.playwright_runtime.async_playwright",
+        return_value=playwright,
+    )
+    runtime = make_runtime()
+
+    await runtime.start()
+
+    playwright.start.assert_awaited_once_with()
+    assert runtime._playwright is playwright
+
+
+@pytest.mark.asyncio
+async def test_launch_uses_chromium_with_headless_config(mocker):
+    browser = MagicMock()
+    playwright = MagicMock()
+    playwright.start = AsyncMock(return_value=playwright)
+    playwright.chromium.launch = AsyncMock(return_value=browser)
+    mocker.patch(
+        "app.services.browser.runtime.playwright_runtime.async_playwright",
+        return_value=playwright,
+    )
+    runtime = make_runtime()
+
+    await runtime.start()
+    launched = await runtime.launch_browser()
+
+    assert launched is browser
+    playwright.chromium.launch.assert_awaited_once_with(
+        headless=True,
+        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+    )
+
+
+def test_bind_disconnect_installs_callback():
+    runtime = make_runtime()
+    browser = MagicMock()
+    callback = MagicMock()
+
+    runtime.bind_disconnect(browser, callback)
+
+    browser.on.assert_called_once()
+    handler = browser.on.call_args.args[1]
+    handler(None)
+    callback.assert_called_once()
+
+
+def test_is_browser_connected_delegates():
+    runtime = make_runtime()
+    browser = MagicMock()
+    browser.is_connected.return_value = False
+
+    assert runtime.is_browser_connected(browser) is False
+
+
+@pytest.mark.asyncio
+async def test_close_browser_noop_without_browser():
+    runtime = make_runtime()
+    await runtime.close_browser(None, "terminal")
+
+
+@pytest.mark.asyncio
+async def test_close_skips_disconnected_browser(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.return_value = False
+
+    await runtime.close_browser(browser, "terminal")
+
+    browser.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_transport_race_is_benign_after_disconnect(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, False]
+    browser.close.side_effect = PlaywrightError("transport closed")
+
+    await runtime.close_browser(browser, "terminal")
+
+    browser.close.assert_awaited_once()
+    assert not any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_close_error_while_connected_remains_warning(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.return_value = True
+    browser.close.side_effect = PlaywrightError("close failed")
+
+    await runtime.close_browser(browser, "terminal")
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_generic_close_error_warns_after_disconnect(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, False]
+    browser.close.side_effect = RuntimeError("programming failure")
+
+    await runtime.close_browser(browser, "terminal")
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_generic_close_error_warns_while_connected(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.return_value = True
+    browser.close.side_effect = RuntimeError("programming failure")
+
+    await runtime.close_browser(browser, "terminal")
+
+    assert any("Error closing browser" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_close_inspection_failure_preserves_original_error(caplog):
+    runtime = make_runtime()
+    browser = make_browser()
+    browser.is_connected.side_effect = [True, RuntimeError("inspection failed")]
+    browser.close.side_effect = PlaywrightError("close transport failure")
+
+    await runtime.close_browser(browser, "terminal")
+
+    messages = [record.message for record in caplog.records]
+    assert any("close transport failure" in message for message in messages)
+    assert any("inspection failed" in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_stop_noops_when_never_started():
+    runtime = make_runtime()
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_calls_playwright_stop_and_resets():
+    runtime = make_runtime()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock()
+    runtime._playwright = playwright
+
+    await runtime.stop()
+
+    playwright.stop.assert_awaited_once_with()
+    assert runtime._playwright is None
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_playwright_error():
+    runtime = make_runtime()
+    playwright = MagicMock()
+    playwright.stop = AsyncMock(side_effect=RuntimeError("stop failed"))
+    runtime._playwright = playwright
+
+    await runtime.stop()
+
+    assert runtime._playwright is None

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 from playwright.async_api import Error as PlaywrightError
 
-from app.services.browser.errors import BrowserDisconnectedError
+from app.services.browser.errors import BrowserDisconnectedError, ConversationBusyError
 from app.services.browser.session import ProviderSession
 from app.services.browser.tab import TabStatus
 from app.services.providers.gemini.auth_selector import GeminiAuthCandidate
@@ -411,3 +411,19 @@ async def test_close_resources_logs_unexpected_context_close_error(caplog):
 
     assert session.context is None
     assert "Failed to close browser context: unexpected close failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_acquire_lease_pre_header_busy_conversation_rejected():
+    """Verifies pre-header rejection: acquiring a lease for a conversation that
+    is already active under a different request raises ConversationBusyError.
+    """
+    engine, _ = make_engine()
+    session = ProviderSession(engine, "test_provider")
+    session.active_conversations["existing_cid"] = "req_owner"
+
+    with pytest.raises(ConversationBusyError) as excinfo:
+        await session.acquire_lease(conversation_id="existing_cid", request_id="req_new")
+
+    assert "busy" in str(excinfo.value)
+    assert session.active_conversations["existing_cid"] == "req_owner"

--- a/tests/test_conversation_concurrency.py
+++ b/tests/test_conversation_concurrency.py
@@ -110,6 +110,92 @@ async def test_stale_cleanup_ownership_overwrite_protection(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_register_collision_preserves_winner(tmp_path):
+    """Verifies that when Request B attempts to lazily register a conversation
+    already actively owned by Request A, B fails with ConversationBusyError and
+    A's ownership plus registry tab remain fully intact.
+    """
+    mock_engine = Mock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+
+    session = ProviderSession(mock_engine, "test_provider")
+    session.last_browser_generation = 1
+    session.ensure_healthy = AsyncMock()
+    mock_page = Mock()
+    mock_page.is_closed.return_value = False
+    mock_page.evaluate = AsyncMock()
+    session.context = Mock()
+    session.context.new_page = AsyncMock(return_value=mock_page)
+    session.engine.enforce_soft_cap = AsyncMock()
+
+    cid = "shared_conversation"
+    req_a = "req_a"
+    req_b = "req_b"
+
+    # Request A acquires and registers the conversation
+    lease_a = await session.acquire_lease(conversation_id=cid, request_id=req_a)
+    tab_a = await session.register_conversation(cid, lease_a)
+    assert session.active_conversations[cid] == req_a
+    assert session.conversation_registry[cid] is tab_a
+
+    # Request B (fresh, lazy) attempts to register the same conversation
+    lease_b = await session.acquire_lease(request_id=req_b)
+    with pytest.raises(ConversationBusyError) as excinfo:
+        await session.register_conversation(cid, lease_b)
+
+    assert "busy" in str(excinfo.value)
+    # Winner A remains owner; winner tab/registry intact
+    assert session.active_conversations[cid] == req_a
+    assert session.conversation_registry[cid] is tab_a
+
+
+@pytest.mark.asyncio
+async def test_loser_cleanup_does_not_unregister_winner(tmp_path):
+    """Verifies that a losing request's cleanup (post failed lazy registration)
+    cannot clear or mutate the winner's conversation ownership or registry tab.
+    """
+    mock_engine = Mock()
+    mock_engine.max_pages = 5
+    mock_engine.user_data_dir = str(tmp_path)
+    mock_engine.browser_generation = 1
+    mock_engine.is_shutting_down = False
+
+    session = ProviderSession(mock_engine, "test_provider")
+    session.last_browser_generation = 1
+    session.ensure_healthy = AsyncMock()
+    mock_page = Mock()
+    mock_page.is_closed.return_value = False
+    mock_page.evaluate = AsyncMock()
+    mock_page.close = AsyncMock()
+    session.context = Mock()
+    session.context.new_page = AsyncMock(return_value=mock_page)
+    session.engine.enforce_soft_cap = AsyncMock()
+
+    cid = "shared_conversation"
+    req_a = "req_a"
+    req_b = "req_b"
+
+    # Request A owns the conversation
+    lease_a = await session.acquire_lease(conversation_id=cid, request_id=req_a)
+    tab_a = await session.register_conversation(cid, lease_a)
+
+    # Request B fails lazy registration
+    lease_b = await session.acquire_lease(request_id=req_b)
+    with pytest.raises(ConversationBusyError):
+        await session.register_conversation(cid, lease_b)
+
+    # Losing request cleanup: close its temporary lease
+    await lease_b.close()
+
+    # Winner ownership and registry tab must remain present
+    assert session.active_conversations[cid] == req_a
+    assert session.conversation_registry[cid] is tab_a
+
+
+@pytest.mark.asyncio
 async def test_lock_separation_and_deadlock_prevention(tmp_path):
     """Verifies that ownership rollback/finalization paths do not require registry access,
     do not acquire registry_lock, and cannot deadlock with registry operations.

--- a/tests/test_gemini_extended_thinking.py
+++ b/tests/test_gemini_extended_thinking.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 
 from app.main import app
 from app.schemas.request import OpenAIChatRequest
-from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
+from app.services.providers.gemini.browser_adapter import GeminiProviderAdapter
 from app.services.browser.errors import GatedModelError, ModelNotFoundError, TransientSessionError
 from app.services.providers.atlas.provider import AtlasProvider
 from app.services.providers.gemini.provider import GeminiProvider

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -4,9 +4,9 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import HTTPException
 from app.services.providers.gemini.browser_adapter import GeminiProviderAdapter
 from app.services.providers.gemini.playwright_adapter import (
-    GeminiPlaywrightAdapter, 
-    PlaywrightRequestState, 
-    PlaywrightAdapterConfig
+    GeminiPlaywrightAdapter,
+    BrowserRequestState,
+    BrowserRequestConfig
 )
 from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS, get_gemini_models
 from app.schemas.request import OpenAIChatRequest
@@ -303,7 +303,7 @@ async def test_orchestrate_model_selection_versioned_aliases():
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_browser_adapter.select_model = AsyncMock()
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     mock_state.active_tab = MagicMock()
     
     # Verified Models
@@ -329,7 +329,7 @@ async def test_orchestrate_model_selection_browser_namespace_aliases():
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_browser_adapter.select_model = AsyncMock()
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     mock_state.active_tab = MagicMock()
 
     await adapter._orchestrate_model_selection(
@@ -349,7 +349,7 @@ async def test_orchestrate_model_selection_unsupported_aliases_fail():
     adapter = GeminiPlaywrightAdapter(MagicMock())
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     
     unsupported = [
         "playwright/gemini-3-pro",
@@ -373,7 +373,7 @@ async def test_orchestrate_model_selection_unknown_model_fails_400():
     adapter = GeminiPlaywrightAdapter(MagicMock())
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     
     with pytest.raises(HTTPException) as excinfo:
         await adapter._orchestrate_model_selection(
@@ -395,7 +395,7 @@ async def test_orchestrate_model_selection_gated_model_maps_403():
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_browser_adapter.select_model = AsyncMock(side_effect=GatedModelError("Paywall"))
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     mock_state.active_tab = MagicMock()
     
     with pytest.raises(HTTPException) as excinfo:
@@ -416,7 +416,7 @@ async def test_orchestrate_model_selection_not_found_maps_400():
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_browser_adapter.select_model = AsyncMock(side_effect=ModelNotFoundError("Not in menu"))
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     mock_state.active_tab = MagicMock()
     
     with pytest.raises(HTTPException) as excinfo:
@@ -437,7 +437,7 @@ async def test_orchestrate_model_selection_success():
     mock_browser_adapter = MagicMock(spec=GeminiProviderAdapter)
     mock_browser_adapter.select_model = AsyncMock()
     mock_page = MagicMock()
-    mock_state = MagicMock(spec=PlaywrightRequestState)
+    mock_state = MagicMock(spec=BrowserRequestState)
     mock_state.active_tab = MagicMock()
     
     await adapter._orchestrate_model_selection(

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi import HTTPException
-from app.services.browser.adapters.gemini_adapter import GeminiProviderAdapter
+from app.services.providers.gemini.browser_adapter import GeminiProviderAdapter
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter, 
     PlaywrightRequestState, 
@@ -88,7 +88,7 @@ async def test_find_model_picker_fallbacks(adapter, mock_page):
     mock_fallback_loc.first = mock_fallback_el
     
     def locator_side_effect(selector):
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
         if selector == SELECTORS["MODEL_PICKER"]:
             return mock_primary
         if selector == 'button[aria-label*="Select model"]':
@@ -141,7 +141,7 @@ async def test_select_model_success(adapter, mock_page):
     
     # Route locator calls
     def locator_side_effect(selector):
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
         if selector == SELECTORS["MODEL_PICKER"]:
             return mock_picker_loc
         if selector == SELECTORS["MODEL_OPTION"]:
@@ -198,7 +198,7 @@ async def test_select_model_fails_when_gated_advanced(adapter, mock_page):
     
     # Route locator calls
     def locator_side_effect(selector):
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
         if selector == SELECTORS["MODEL_PICKER"]:
             return mock_picker_loc
         if selector == SELECTORS["MODEL_OPTION"]:
@@ -247,7 +247,7 @@ async def test_select_model_collision_prevention_flash_vs_lite(adapter, mock_pag
     
     # Route locator calls
     def locator_side_effect(selector):
-        from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+        from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
         if selector == SELECTORS["MODEL_PICKER"]:
             return mock_picker_loc
         if selector == SELECTORS["MODEL_OPTION"]:

--- a/tests/test_gemini_observer_script.py
+++ b/tests/test_gemini_observer_script.py
@@ -3,7 +3,7 @@ import pytest_asyncio
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright
 
-from app.services.browser.adapters.scripts.gemini_scripts import (
+from app.services.providers.gemini.scripts.gemini_scripts import (
     STOP_OBSERVER_SCRIPT,
     STREAM_EXTRACTOR_SCRIPT,
 )

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -52,6 +52,43 @@ def make_mock_page(url: str = "https://gemini.google.com/app") -> MagicMock:
     return page
 
 
+class CrashablePage(MagicMock):
+    """MagicMock page whose url raises a raw PlaywrightError once crashed flag is set."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.crashed = False
+        self._crashable_url = "https://gemini.google.com/app"
+        self._gemini_callbacks = {}
+
+    @property
+    def url(self):
+        if self.crashed:
+            raise PlaywrightError("Target page, context or browser has been closed")
+        return self._crashable_url
+
+    @url.setter
+    def url(self, value):
+        self._crashable_url = value
+
+
+def make_crashable_page() -> CrashablePage:
+    page = CrashablePage()
+    page.goto = AsyncMock()
+    page.evaluate = AsyncMock()
+    page.on = MagicMock()
+    page.remove_listener = MagicMock()
+    page.is_closed.return_value = False
+
+    input_locator = AsyncMock()
+    input_locator.wait_for = AsyncMock()
+
+    generic_locator = MagicMock()
+    generic_locator.first = input_locator
+    page.locator.return_value = generic_locator
+    return page
+
+
 def make_mock_lease(page: MagicMock, persistent_tab=None) -> MagicMock:
     lease = MagicMock()
     lease.page = page
@@ -418,6 +455,118 @@ async def test_stream_ends_without_done_when_page_crashes(monkeypatch, caplog):
         and record.reason == "BrowserDisconnectedError"
         for record in caplog.records
     )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_header_raw_playwright_error_restores_recorded_disconnected(monkeypatch, caplog):
+    page = make_crashable_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    state = state_ref["state"]
+
+    await emit_bridge_event(page, {"type": "chunk", "delta": "Hello"})
+
+    gen = response.body_iterator
+    first = await gen.__anext__()
+    assert "Hello" in first
+
+    page.crashed = True
+    state.signal_terminal(BrowserDisconnectedError("Browser page crashed during active request"))
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+    assert any(
+        record.message == "Stream terminated: " + state.request_id
+        and record.reason == "BrowserDisconnectedError"
+        for record in caplog.records
+    )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_header_raw_playwright_error_restores_recorded_shutting_down(monkeypatch, caplog):
+    page = make_crashable_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    state = state_ref["state"]
+
+    await emit_bridge_event(page, {"type": "chunk", "delta": "Hello"})
+
+    gen = response.body_iterator
+    first = await gen.__anext__()
+    assert "Hello" in first
+
+    page.crashed = True
+    state.signal_terminal(BrowserShuttingDownError("Browser request aborted during engine shutdown"))
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+    assert any(
+        record.message == "Stream terminated: " + state.request_id
+        and record.reason == "BrowserShuttingDownError"
+        for record in caplog.records
+    )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_header_raw_playwright_error_without_terminal_state_propagates(monkeypatch):
+    page = make_crashable_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+
+    async def submit_prompt(_page, _prompt, _state):
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    page.crashed = True
+
+    gen = response.body_iterator
+    with pytest.raises(PlaywrightError):
+        await gen.__anext__()
+
     lease.close.assert_awaited_once()
 
 

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -20,7 +20,7 @@ from app.services.browser.errors import (
 from app.services.factory import ProviderFactory
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter,
-    PlaywrightRequestState,
+    BrowserRequestState,
 )
 from app.services.providers.gemini.provider import GeminiProvider
 
@@ -1308,7 +1308,7 @@ async def test_cleanup_is_idempotent_for_repeated_invocation():
     provider = GeminiProvider()
     adapter = provider.playwright_adapter
     page = make_mock_page()
-    request_state = PlaywrightRequestState(request_id="req_1", start_time=0.0)
+    request_state = BrowserRequestState(request_id="req_1", start_time=0.0)
     page._gemini_callbacks = {request_state.request_id: AsyncMock()}
     request_state.on_close_handler = MagicMock()
     request_state.on_crash_handler = MagicMock()

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -1124,11 +1124,50 @@ async def test_post_header_generation_mismatch_terminates_without_done(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_post_header_conversation_busy_error_remains_visible(monkeypatch):
+async def test_post_header_conversation_busy_error_terminates_without_done(monkeypatch, caplog):
     page = make_mock_page(url="https://gemini.google.com/app/abc123")
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
     session.register_conversation = AsyncMock(
+        side_effect=ConversationBusyError("Conversation abc123 is busy with another active request.")
+    )
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    gen = response.body_iterator
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+    request_id = state_ref["state"].request_id
+    assert any(
+        record.message == "Stream terminated: " + request_id
+        and record.reason == "ConversationBusyError"
+        for record in caplog.records
+    )
+    assert not any("data: [DONE]" in c for c in (await collect_stream_chunks(response)))
+    session.handle_session_failure.assert_not_called()
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_header_conversation_busy_returns_409(monkeypatch):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    session.acquire_lease = AsyncMock(
         side_effect=ConversationBusyError("Conversation abc123 is busy with another active request.")
     )
 
@@ -1143,13 +1182,11 @@ async def test_post_header_conversation_busy_error_remains_visible(monkeypatch):
     )
 
     provider = GeminiProvider()
-    response = await provider.chat_completions(make_request(stream=True))
+    with pytest.raises(HTTPException) as excinfo:
+        await provider.chat_completions(make_request(stream=True, conversation_id="abc123"))
 
-    gen = response.body_iterator
-    with pytest.raises(ConversationBusyError):
-        await gen.__anext__()
-
-    lease.close.assert_awaited_once()
+    assert excinfo.value.status_code == 409
+    session.handle_session_failure.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_playwright_parity.py
+++ b/tests/test_gemini_playwright_parity.py
@@ -10,7 +10,13 @@ from playwright.async_api import Error as PlaywrightError
 
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.auth_types import AuthStatus
-from app.services.browser.errors import BrowserDisconnectedError, BrowserShuttingDownError
+from app.services.browser.errors import (
+    BrowserDisconnectedError,
+    BrowserGenerationMismatchError,
+    BrowserShuttingDownError,
+    ConversationBusyError,
+    QueueOverflowError,
+)
 from app.services.factory import ProviderFactory
 from app.services.providers.gemini.playwright_adapter import (
     GeminiPlaywrightAdapter,
@@ -980,12 +986,14 @@ async def test_buffered_chunk_timeout_remains_total_timeout_504(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stream_queue_overflow_fails_request_without_session_poisoning(monkeypatch):
+async def test_stream_queue_overflow_fails_request_without_session_poisoning(monkeypatch, caplog):
     page = make_mock_page()
     lease = make_mock_lease(page)
     session = make_mock_session(lease)
+    state_ref = {}
 
-    async def submit_prompt(_page, _prompt, _state):
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
         async def emit_events():
             await asyncio.sleep(0)
             await emit_bridge_event(page, {"type": "started"})
@@ -1007,11 +1015,140 @@ async def test_stream_queue_overflow_fails_request_without_session_poisoning(mon
     response = await provider.chat_completions(make_request(stream=True))
     await asyncio.sleep(0.05)
 
-    with pytest.raises(Exception) as exc_info:
-        await collect_stream_chunks(response)
+    chunks = await collect_stream_chunks(response)
 
-    assert "Event queue saturated" in str(exc_info.value)
+    assert chunks == []
+    assert not any("data: [DONE]" in c for c in chunks)
+    request_id = state_ref["state"].request_id
+    assert any(
+        record.message == "Stream terminated: " + request_id
+        and record.reason == "QueueOverflowError"
+        for record in caplog.records
+    )
     session.handle_session_failure.assert_not_called()
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_queue_overflow_terminates_without_done(monkeypatch, caplog):
+    page = make_mock_page()
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    state = state_ref["state"]
+
+    await emit_bridge_event(page, {"type": "chunk", "delta": "Hello"})
+
+    gen = response.body_iterator
+    first = await gen.__anext__()
+    assert "Hello" in first
+    assert "data: [DONE]" not in first
+
+    state.queue_overflow = True
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+    request_id = state.request_id
+    assert any(
+        record.message == "Stream terminated: " + request_id
+        and record.reason == "QueueOverflowError"
+        for record in caplog.records
+    )
+    assert not any(
+        record.message == "Stream completed: " + request_id
+        for record in caplog.records
+    )
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_header_generation_mismatch_terminates_without_done(monkeypatch, caplog):
+    persistent_tab = MagicMock(browser_generation=1)
+    page = make_mock_page()
+    lease = make_mock_lease(page, persistent_tab=persistent_tab)
+    session = make_mock_session(lease)
+    state_ref = {}
+
+    async def submit_prompt(_page, _prompt, state):
+        state_ref["state"] = state
+        return True
+
+    engine = await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+    state = state_ref["state"]
+    assert state.active_tab is persistent_tab
+
+    await emit_bridge_event(page, {"type": "chunk", "delta": "Hello"})
+
+    gen = response.body_iterator
+    first = await gen.__anext__()
+    assert "Hello" in first
+
+    engine.browser_generation = 2
+    await emit_bridge_event(page, {"type": "chunk", "delta": "World"})
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+    request_id = state.request_id
+    assert any(
+        record.message == "Stream terminated: " + request_id
+        and record.reason == "BrowserGenerationMismatchError"
+        for record in caplog.records
+    )
+    assert not any("data: [DONE]" in c for c in (first,))
+    session.handle_session_failure.assert_not_called()
+    lease.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_header_conversation_busy_error_remains_visible(monkeypatch):
+    page = make_mock_page(url="https://gemini.google.com/app/abc123")
+    lease = make_mock_lease(page)
+    session = make_mock_session(lease)
+    session.register_conversation = AsyncMock(
+        side_effect=ConversationBusyError("Conversation abc123 is busy with another active request.")
+    )
+
+    async def submit_prompt(_page, _prompt, _state):
+        return True
+
+    await configure_playwright_success(
+        monkeypatch,
+        page=page,
+        session=session,
+        submit_side_effect=submit_prompt,
+    )
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(make_request(stream=True))
+
+    gen = response.body_iterator
+    with pytest.raises(ConversationBusyError):
+        await gen.__anext__()
+
     lease.close.assert_awaited_once()
 
 

--- a/tests/test_generation_invalidation.py
+++ b/tests/test_generation_invalidation.py
@@ -14,6 +14,7 @@ def make_engine(generation=1):
     engine = MagicMock()
     engine.max_pages = 3
     engine.browser = browser
+    engine.runtime.is_browser_connected.return_value = True
     engine.browser_generation = generation
     engine.is_shutting_down = False
     engine.management_lock = asyncio.Lock()

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -13,7 +13,7 @@ def make_session():
     engine.is_shutting_down = False
     engine.max_pages = 2
     engine.browser = MagicMock()
-    engine.browser.is_connected.return_value = True
+    engine.runtime.is_browser_connected.return_value = True
 
     session = ProviderSession(engine, "test_provider")
     session.lease_timeout = 0.1

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -12,7 +12,7 @@ def mock_engine_instance():
         engine = MagicMock()
         engine.is_shutting_down = False
         engine.browser = MagicMock()
-        engine.browser.is_connected.return_value = True
+        engine.runtime.is_browser_connected.return_value = True
         engine.browser_generation = 1
         engine.is_bootstrap = False
         engine.sessions = {}
@@ -80,7 +80,7 @@ def test_ready_503_session_dead(mock_engine_instance):
     assert response.status_code == 503
 
 def test_ready_503_browser_disconnected(mock_engine_instance):
-    mock_engine_instance.browser.is_connected.return_value = False
+    mock_engine_instance.runtime.is_browser_connected.return_value = False
     
     # Even if session is alive, if browser is disconnected, it's not ready
     mock_session = MagicMock()

--- a/verify_login.py
+++ b/verify_login.py
@@ -46,7 +46,7 @@ except ImportError as exc:
     raise
 
 from app.services.browser.engine import get_browser_engine
-from app.services.browser.adapters.scripts.gemini_scripts import SELECTORS
+from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
 from app.logger import logger
 
 


### PR DESCRIPTION
## Summary

Refine browser architecture to separate browser-process mechanics from lifecycle, session, provider, and request policy.

This prepares browser infrastructure for future runtime alternatives without introducing speculative page/context abstractions or changing existing Playwright behavior.

## Changes

- Add `BrowserRuntime` abstraction for browser-process mechanics:
  - driver start/stop
  - browser launch/close
  - disconnect binding
  - connection inspection
- Add `PlaywrightChromiumRuntime` as current implementation.
- Add runtime factory and `[Browser] runtime = playwright` selection.
- Keep lifecycle, recovery, generation, shutdown, and session coordination in `BrowserEngine`.
- Route browser connection inspection through runtime boundary.
- Keep `BrowserContext`, page, persistence, and conversation ownership in `ProviderSession`.
- Move Gemini-specific browser adapter and scripts from generic browser package into `providers/gemini`.
- Rename generic request types:
  - `PlaywrightRequestState` → `BrowserRequestState`
  - `PlaywrightAdapterConfig` → `BrowserRequestConfig`
- Harden post-header streaming termination for:
  - `BrowserDisconnectedError`
  - `BrowserShuttingDownError`
  - `BrowserGenerationMismatchError`
  - `QueueOverflowError`
  - `ConversationBusyError`
- Preserve recorded browser terminal errors over later raw Playwright close errors.
- Preserve conversation winner ownership during concurrent registration and loser cleanup.
- Keep pre-header `ConversationBusyError` behavior as HTTP 409.
- Clarify browser cookie-discovery vs runtime configuration.
- Sync architecture, lifecycle, concurrency, error-policy, provider, and streaming documentation.

## Architecture

`BrowserEngine` remains authoritative owner of browser lifecycle decisions.

`BrowserRuntime` owns the concrete driver instance and executes browser-process mechanics only. It does not own lifecycle, recovery, shutdown, session, context, page, or provider policy.

Playwright-specific behavior remains Playwright-specific where appropriate. No generic page/context abstraction was introduced.

## Compatibility

- Existing Playwright behavior preserved.
- Existing `playwright/*` API compatibility preserved.
- Existing `[Playwright]` configuration preserved.
- Existing auth/storage-state behavior preserved.
- No persistence abstraction or multi-runtime packaging added.

## Verification

- Full test suite: `663 passed`
- `git diff --check`: clean
- Documentation synced with final ownership and streaming contracts