### PR TITLE
feat(gemini): add shared extended thinking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ WebAI-to-API uses model prefixes to route requests to specific backends.
 > [!TIP]
 > Model prefixes force backend selection and override the default Gemini backend configured in `config.conf`. Use `playwright/...` model prefixes to force the Playwright backend explicitly.
 
-Gemini Playwright Extended Thinking is available through `provider_options.gemini.extended_thinking`; see [API Documentation](docs/api.md).
+Gemini WebAPI and Playwright support Extended Thinking through `provider_options.gemini.extended_thinking`; see [API Documentation](docs/api.md).
 
 ---
 

--- a/config.conf.example
+++ b/config.conf.example
@@ -45,14 +45,9 @@ runtime = playwright
 [Gemini]
 backend = webapi
 default_model = gemini-3-flash
+extended_thinking = false
 __Secure-1PSID =
 __Secure-1PSIDTS =
-
-# --- Gemini Playwright Configuration ---
-# Browser-native Gemini-specific defaults.
-# Request provider_options.gemini.extended_thinking takes precedence.
-[GeminiPlaywright]
-extended_thinking = false
 
 # --- Legacy Cookie Support (DEPRECATED) ---
 # For backward compatibility only. Please migrate to [Gemini] section.

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,9 +41,9 @@ OpenAI-compatible chat completion endpoint.
 }
 ```
 
-#### Gemini Playwright Extended Thinking
+#### Gemini Extended Thinking
 
-Gemini Playwright requests may control Gemini Web UI Extended thinking through typed provider options:
+Gemini WebAPI and Playwright requests may control Extended thinking through typed provider options:
 
 ```json
 {
@@ -59,7 +59,7 @@ Gemini Playwright requests may control Gemini Web UI Extended thinking through t
 }
 ```
 
-When request option is omitted, effective value comes from `[GeminiPlaywright].extended_thinking`; missing config section/key falls back to `false`. Explicit `true` or `false` overrides config. The Playwright adapter normalizes UI state before each prompt, so requests do not inherit prior persistent-tab state. The option is unsupported by Gemini WebAPI and Atlas and returns HTTP 400. Unknown provider namespaces/options and invalid types return HTTP 422. This UI toggle is not equivalent to `reasoning_effort`.
+When request option is omitted, effective value comes from `[Gemini].extended_thinking`; missing key falls back to `false`. Explicit `true` or `false` overrides config. The option is request-scoped: reused conversations may switch values between turns, and Playwright requests do not inherit prior persistent-tab UI state. WebAPI passes the resolved value to upstream chat generation. Atlas rejects the option with HTTP 400. Unknown provider namespaces/options and invalid types return HTTP 422. This option is not equivalent to `reasoning_effort`.
 
 Do not use this form. `extended_thinking` must be nested under `provider_options.gemini`; a top-level `extended_thinking` field is not part of the API contract and may be ignored.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,8 +118,6 @@ Example:
 [Gemini]
 backend = webapi
 default_model = gemini-3-flash
-
-[GeminiPlaywright]
 extended_thinking = false
 
 [EnabledAI]
@@ -142,14 +140,9 @@ http_proxy =
 | --------------- | -------------------------------------------- |
 | `backend`       | Execution backend (`webapi` or `playwright`) |
 | `default_model` | Default Gemini model                         |
+| `extended_thinking` | Strict boolean `true`/`false` default for Gemini WebAPI and Playwright requests when request-scoped `provider_options.gemini.extended_thinking` is omitted. |
 
-### Gemini Playwright
-
-| Option | Description |
-| --- | --- |
-| `extended_thinking` | Boolean `true`/`false` default Extended Thinking state for Gemini Playwright requests when request-scoped `provider_options.gemini.extended_thinking` is omitted. |
-
-Precedence is request option, then `[GeminiPlaywright]` default, then `false` when the section or key is missing. This setting applies only to Gemini Playwright; Gemini WebAPI and Atlas are unaffected.
+Precedence is request option, then `[Gemini].extended_thinking`, then `false` when the key is missing. The value is case-insensitive, trimmed, and stored canonically as lowercase `true` or `false`.
 
 #### Supported Cookie Keys (in `[Gemini]` section)
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -184,7 +184,7 @@ curl -X POST http://localhost:6969/v1/chat/completions \
   }'
 ```
 
-Gemini Playwright also supports request-scoped Extended Thinking through `provider_options.gemini`; see [API Documentation](api.md) for the request fragment and semantics.
+Gemini WebAPI and Playwright support request-scoped Extended Thinking through `provider_options.gemini.extended_thinking`; see [API Documentation](api.md) for request format and semantics.
 
 ---
 

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -54,6 +54,8 @@ Requests may use typed provider-scoped options:
 
 `gemini.extended_thinking` applies to Gemini WebAPI and Playwright models. Effective value is resolved on every request: an explicit request value takes precedence over `[Gemini].extended_thinking`, which falls back to `false` when the key is missing. The value accepts only case-insensitive, trimmed `true` or `false`; config stores canonical lowercase values. The option is request-scoped and is not part of session identity or persisted snapshots, so reused conversations may switch values between turns. Omitted Playwright request options do not inherit UI state from a reused `PersistentTab`. Atlas rejects the option with HTTP 400. Unknown namespaces, unknown Gemini options, and invalid value types fail schema validation with HTTP 422. Extended thinking is not declared equivalent to `reasoning_effort`.
 
+For Gemini WebAPI, the resolved boolean applies to buffered generation, progressive streaming, tool-call buffered generation, and generation retry, and is passed through to upstream chat generation.
+
 ### 3.1 Multimodal Content Parts
 
 `messages[].content` supports both plain strings and OpenAI-style content-part arrays.

--- a/docs/specs/api-contract.md
+++ b/docs/specs/api-contract.md
@@ -52,7 +52,7 @@ Requests may use typed provider-scoped options:
 }
 ```
 
-`gemini.extended_thinking` applies only to Gemini Playwright models. Effective value is normalized on every request: an explicit request value takes precedence over `[GeminiPlaywright].extended_thinking`, which falls back to `false` when the section or key is missing. Omitted request options do not inherit UI state from a reused `PersistentTab`. Gemini WebAPI and non-Gemini providers reject the option with HTTP 400. Unknown namespaces, unknown Gemini options, and invalid value types fail schema validation with HTTP 422. Gemini Web UI Extended thinking is a provider UI toggle and is not declared equivalent to `reasoning_effort`.
+`gemini.extended_thinking` applies to Gemini WebAPI and Playwright models. Effective value is resolved on every request: an explicit request value takes precedence over `[Gemini].extended_thinking`, which falls back to `false` when the key is missing. The value accepts only case-insensitive, trimmed `true` or `false`; config stores canonical lowercase values. The option is request-scoped and is not part of session identity or persisted snapshots, so reused conversations may switch values between turns. Omitted Playwright request options do not inherit UI state from a reused `PersistentTab`. Atlas rejects the option with HTTP 400. Unknown namespaces, unknown Gemini options, and invalid value types fail schema validation with HTTP 422. Extended thinking is not declared equivalent to `reasoning_effort`.
 
 ### 3.1 Multimodal Content Parts
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -88,13 +88,16 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
     if "Gemini" not in config:
         config["Gemini"] = {
             "backend": "webapi",
-            "default_model": legacy_gemini_model or "gemini-3-flash"
+            "default_model": legacy_gemini_model or "gemini-3-flash",
+            "extended_thinking": "false",
         }
     else:
         if "backend" not in config["Gemini"]:
             config["Gemini"]["backend"] = "webapi"
         if "default_model" not in config["Gemini"]:
             config["Gemini"]["default_model"] = legacy_gemini_model or "gemini-3-flash"
+        if "extended_thinking" not in config["Gemini"]:
+            config["Gemini"]["extended_thinking"] = "false"
 
     # Validate Gemini backend
     gemini_backend = config["Gemini"].get("backend", "webapi").lower().strip()
@@ -103,18 +106,14 @@ def load_config(config_file: str = "config.conf") -> configparser.ConfigParser:
     
     config["Gemini"]["backend"] = gemini_backend
 
-    if "GeminiPlaywright" not in config:
-        config["GeminiPlaywright"] = {"extended_thinking": "false"}
-    elif "extended_thinking" not in config["GeminiPlaywright"]:
-        config["GeminiPlaywright"]["extended_thinking"] = "false"
-
-    raw_value = config["GeminiPlaywright"].get("extended_thinking", "false")
+    # Validate Gemini extended_thinking (strict boolean, canonical lowercase)
+    raw_value = config["Gemini"].get("extended_thinking", "false")
     normalized = raw_value.strip().lower()
     if normalized not in ("true", "false"):
         raise ValueError(
-            f"Invalid GeminiPlaywright extended_thinking value '{raw_value}'. Expected true/false."
+            f"Invalid Gemini extended_thinking value '{raw_value}'. Expected true/false."
         )
-    config["GeminiPlaywright"]["extended_thinking"] = normalized
+    config["Gemini"]["extended_thinking"] = normalized
 
     return config
 

--- a/src/app/services/providers/gemini/playwright_adapter.py
+++ b/src/app/services/providers/gemini/playwright_adapter.py
@@ -19,9 +19,12 @@ from app.services.browser.request_executor import (
     BrowserRequestState,
 )
 from app.services.browser.tab import TabStatus
-from app.config import CONFIG
 from app.services.providers.gemini.base_adapter import GeminiBackendAdapter
-from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS, convert_to_openai_format
+from app.services.providers.gemini.shared import (
+    PLAYWRIGHT_GEMINI_MODEL_UI_LABELS,
+    convert_to_openai_format,
+    resolve_extended_thinking,
+)
 
 
 class GeminiPlaywrightAdapter(GeminiBackendAdapter):
@@ -131,14 +134,7 @@ class GeminiPlaywrightAdapter(GeminiBackendAdapter):
         request,
         state: BrowserRequestState,
     ) -> None:
-        provider_options = getattr(request, "provider_options", None)
-        gemini_options = getattr(provider_options, "gemini", None) if provider_options else None
-        requested = getattr(gemini_options, "extended_thinking", None) if gemini_options else None
-        extended_thinking = (
-            requested
-            if requested is not None
-            else CONFIG.getboolean("GeminiPlaywright", "extended_thinking", fallback=False)
-        )
+        extended_thinking = resolve_extended_thinking(request)
 
         try:
             await browser_adapter.set_extended_thinking(page, extended_thinking, state)

--- a/src/app/services/providers/gemini/provider.py
+++ b/src/app/services/providers/gemini/provider.py
@@ -60,12 +60,6 @@ class GeminiProvider(BaseProvider):
         # Select adapter to determine target backend
         adapter = self._get_adapter(request.model)
         is_playwright = isinstance(adapter, GeminiPlaywrightAdapter)
-        gemini_options = getattr(request.provider_options, "gemini", None) if request.provider_options else None
-        if gemini_options is not None and not is_playwright:
-            raise HTTPException(
-                status_code=400,
-                detail="provider_options.gemini is supported only by the Gemini Playwright backend.",
-            )
         
         if cid:
             if len(cid) > 128:

--- a/src/app/services/providers/gemini/session_manager.py
+++ b/src/app/services/providers/gemini/session_manager.py
@@ -124,10 +124,12 @@ class SessionManager:
         files=None,
         gem=None,
         lease=None,
+        extended_thinking: bool = False,
     ):
         """
         Thread-safe stateful response execution.
         Resolves whether to reuse or bootstrap the session within the lock.
+        extended_thinking is request-scoped and never part of session identity.
         """
         async with self.lock:
             owns_lease = lease is None
@@ -154,7 +156,11 @@ class SessionManager:
                     conversation_parts = transform_messages(messages, tools_prompt)
                     prompt = "\n\n".join(conversation_parts)
                 
-                response = await self.session.send_message(prompt=prompt, files=files)
+                response = await self.session.send_message(
+                    prompt=prompt,
+                    files=files,
+                    extended_thinking=extended_thinking,
+                )
                 return response, is_reused
             except Exception as e:
                 logger.error(f"Error in stateful session get_response: {e}", exc_info=True)
@@ -172,10 +178,12 @@ class SessionManager:
         files=None,
         gem=None,
         lease=None,
+        extended_thinking: bool = False,
     ) -> AsyncGenerator[Any, None]:
         """
         Thread-safe stateful progressive streaming response execution.
         Safely increments active streams and yields chunks with locked timeout protection.
+        extended_thinking is request-scoped and never part of session identity.
         """
         self.active_streams += 1
         interrupted_sent = False
@@ -208,7 +216,11 @@ class SessionManager:
                 
                 try:
                     async with asyncio.timeout(MAX_GENERATION_DURATION):
-                        async for chunk in self.session.send_message_stream(prompt=prompt, files=files):
+                        async for chunk in self.session.send_message_stream(
+                            prompt=prompt,
+                            files=files,
+                            extended_thinking=extended_thinking,
+                        ):
                             final_response = chunk
                             yield {
                                 "type": "chunk",

--- a/src/app/services/providers/gemini/shared.py
+++ b/src/app/services/providers/gemini/shared.py
@@ -3,6 +3,7 @@ import time
 from typing import Optional, List, Any, Union
 from pathlib import Path
 from fastapi import HTTPException
+from app.config import CONFIG
 from app.logger import logger
 from .webapi_client import resolve_model_name
 
@@ -10,6 +11,15 @@ from .webapi_client import resolve_model_name
 UNRECOVERABLE_CONVERSATION_ERROR_CODES = {
     "1097",
 }
+
+def resolve_extended_thinking(request: Any) -> bool:
+    """Resolve request-scoped extended_thinking: provider override > [Gemini] config > false."""
+    provider_options = getattr(request, "provider_options", None)
+    gemini_options = getattr(provider_options, "gemini", None) if provider_options else None
+    requested = getattr(gemini_options, "extended_thinking", None) if gemini_options else None
+    if requested is not None:
+        return requested
+    return CONFIG.getboolean("Gemini", "extended_thinking", fallback=False)
 
 def is_unknown_model_error(error: ValueError) -> bool:
     """Check if the error is due to an unknown model name."""

--- a/src/app/services/providers/gemini/webapi_adapter.py
+++ b/src/app/services/providers/gemini/webapi_adapter.py
@@ -26,6 +26,7 @@ from app.services.providers.gemini.shared import (
     convert_to_openai_format,
     ensure_gemini_client_ready,
     parse_tool_call,
+    resolve_extended_thinking,
     validate_model_name,
     UNRECOVERABLE_CONVERSATION_ERROR_CODES
 )
@@ -383,6 +384,7 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
             raise
 
         is_stream = request.stream if request.stream is not None else False
+        extended_thinking = resolve_extended_thinking(request)
 
         try:
             # 2. Progressive Streaming Path (only if no tools are used)
@@ -397,6 +399,7 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
                             files=files,
                             gem=request.gem,
                             lease=lease,
+                            extended_thinking=extended_thinking,
                         ):
                             if chunk.get("type") == "chunk" and chunk.get("text_delta"):
                                 openai_chunk = convert_to_openai_format(
@@ -448,6 +451,7 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
                     files=files,
                     gem=request.gem,
                     lease=lease,
+                    extended_thinking=extended_thinking,
                 )
             except GeminiGenerationUnavailableError:
                 await lease.release()
@@ -475,6 +479,7 @@ class GeminiWebAPIAdapter(GeminiBackendAdapter):
                     files=files,
                     gem=request.gem,
                     lease=lease,
+                    extended_thinking=extended_thinking,
                 )
             await registry.save_session_snapshot(cid, self.provider, session_manager)
             

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,33 +11,67 @@ def write_config(tmp_path: Path, content: str) -> str:
     return str(path)
 
 
-def test_gemini_playwright_section_defaults_when_missing(tmp_path):
+def test_gemini_extended_thinking_defaults_when_missing(tmp_path):
     config = load_config(write_config(tmp_path, "[Gemini]\nbackend = webapi\n"))
 
-    assert config["GeminiPlaywright"]["extended_thinking"] == "false"
-    assert config.getboolean("GeminiPlaywright", "extended_thinking") is False
+    assert config["Gemini"]["extended_thinking"] == "false"
+    assert config.getboolean("Gemini", "extended_thinking") is False
 
 
-def test_gemini_playwright_key_defaults_when_section_exists(tmp_path):
-    config = load_config(write_config(tmp_path, "[GeminiPlaywright]\n"))
+def test_gemini_extended_thinking_key_defaults_when_section_exists(tmp_path):
+    config = load_config(write_config(tmp_path, "[Gemini]\n"))
 
-    assert config["GeminiPlaywright"]["extended_thinking"] == "false"
+    assert config["Gemini"]["extended_thinking"] == "false"
 
 
 @pytest.mark.parametrize(
     "value, expected",
-    [("true", "true"), ("false", "false"), ("TRUE", "true"), ("False", "false")],
+    [("true", "true"), ("false", "false"), ("TRUE", "true"), ("False", "false"), ("  true  ", "true")],
 )
-def test_gemini_playwright_boolean_values_are_validated_and_normalized(tmp_path, value, expected):
-    config = load_config(write_config(tmp_path, f"[GeminiPlaywright]\nextended_thinking = {value}\n"))
+def test_gemini_extended_thinking_boolean_values_are_validated_and_normalized(tmp_path, value, expected):
+    config = load_config(write_config(tmp_path, f"[Gemini]\nextended_thinking = {value}\n"))
 
-    assert config["GeminiPlaywright"]["extended_thinking"] == expected
+    assert config["Gemini"]["extended_thinking"] == expected
 
 
 @pytest.mark.parametrize("value", ["yes", "no", "1", "0", "on", "off", "foo", ""])
-def test_gemini_playwright_invalid_value_fails_during_load(tmp_path, value):
-    with pytest.raises(ValueError, match=r"Invalid GeminiPlaywright extended_thinking value"):
-        load_config(write_config(tmp_path, f"[GeminiPlaywright]\nextended_thinking = {value}\n"))
+def test_gemini_extended_thinking_invalid_value_fails_during_load(tmp_path, value):
+    with pytest.raises(ValueError, match=r"Invalid Gemini extended_thinking value"):
+        load_config(write_config(tmp_path, f"[Gemini]\nextended_thinking = {value}\n"))
+
+
+def test_legacy_gemini_playwright_section_has_no_effect(tmp_path):
+    config = load_config(
+        write_config(
+            tmp_path,
+            "[Gemini]\nbackend = webapi\n\n[GeminiPlaywright]\nextended_thinking = true\n",
+        )
+    )
+
+    assert config["Gemini"]["extended_thinking"] == "false"
+    assert config["GeminiPlaywright"]["extended_thinking"] == "true"
+
+
+def test_legacy_gemini_playwright_key_does_not_satisfy_gemini_default(tmp_path):
+    config = load_config(
+        write_config(
+            tmp_path,
+            "[Gemini]\nbackend = webapi\n\n[GeminiPlaywright]\nextended_thinking = true\n",
+        )
+    )
+
+    assert config.getboolean("Gemini", "extended_thinking") is False
+
+
+def test_legacy_gemini_playwright_value_is_not_validated(tmp_path):
+    config = load_config(
+        write_config(
+            tmp_path,
+            "[Gemini]\nbackend = webapi\n\n[GeminiPlaywright]\nextended_thinking = yes\n",
+        )
+    )
+
+    assert config.getboolean("Gemini", "extended_thinking") is False
 
 
 def test_gemini_backend_validation_remains_unchanged(tmp_path):

--- a/tests/test_gemini_chat_concurrency.py
+++ b/tests/test_gemini_chat_concurrency.py
@@ -26,7 +26,7 @@ class _FakeChatSession:
     def metadata(self, value):
         self._ChatSession__metadata = value
 
-    async def send_message(self, prompt, files=None, temporary=False):
+    async def send_message(self, prompt, files=None, temporary=False, extended_thinking=False):
         self.calls.append((prompt, files, temporary))
         return SimpleNamespace(text="ok")
 

--- a/tests/test_gemini_extended_thinking.py
+++ b/tests/test_gemini_extended_thinking.py
@@ -3,6 +3,7 @@ import pytest
 import pytest_asyncio
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from types import SimpleNamespace
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from playwright.async_api import Error as PlaywrightError
@@ -17,7 +18,10 @@ from app.services.browser.errors import GatedModelError, ModelNotFoundError, Tra
 from app.services.providers.atlas.provider import AtlasProvider
 from app.services.providers.gemini.provider import GeminiProvider
 from app.services.providers.gemini.temporary_chat import _resolve_temporary_chat_model
-from app.services.providers.gemini import playwright_adapter as playwright_module
+from app.services.providers.gemini import shared as shared_module
+from app.services.providers.gemini.session_manager import SessionRegistry, SessionManager
+from app.services.providers.gemini.persistence import serialize_session_state
+from app.services.providers.gemini.client import GeminiGenerationUnavailableError
 
 
 def make_request(**kwargs):
@@ -62,8 +66,8 @@ def test_provider_options_schema_accepts_extended_thinking_and_defaults_off():
 async def test_extended_thinking_config_precedence(monkeypatch, config_value, request_value, expected):
     config = configparser.ConfigParser()
     if config_value is not None:
-        config["GeminiPlaywright"] = {"extended_thinking": config_value}
-    monkeypatch.setattr(playwright_module, "CONFIG", config)
+        config["Gemini"] = {"extended_thinking": config_value}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
 
     provider = GeminiProvider()
     browser_adapter = type("Adapter", (), {"set_extended_thinking": AsyncMock()})()
@@ -79,24 +83,28 @@ async def test_extended_thinking_config_precedence(monkeypatch, config_value, re
 
 
 @pytest.mark.asyncio
-async def test_gemini_playwright_config_does_not_affect_webapi(monkeypatch):
+async def test_missing_gemini_config_key_defaults_off(monkeypatch):
     config = configparser.ConfigParser()
-    config["GeminiPlaywright"] = {"extended_thinking": "true"}
-    monkeypatch.setattr(playwright_module, "CONFIG", config)
+    config["Gemini"] = {}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
 
     provider = GeminiProvider()
-    provider.webapi_adapter.chat_completions = AsyncMock(return_value={"ok": True})
-    result = await provider.chat_completions(make_request(model="gemini-3-flash"))
+    browser_adapter = type("Adapter", (), {"set_extended_thinking": AsyncMock()})()
+    await provider.playwright_adapter._configure_request_options(
+        browser_adapter,
+        object(),
+        make_request(),
+        None,
+    )
 
-    assert result == {"ok": True}
-    provider.webapi_adapter.chat_completions.assert_awaited_once()
+    assert browser_adapter.set_extended_thinking.await_args.args[1] is False
 
 
 @pytest.mark.asyncio
-async def test_missing_gemini_playwright_config_key_defaults_off(monkeypatch):
+async def test_legacy_gemini_playwright_config_has_no_effect(monkeypatch):
     config = configparser.ConfigParser()
-    config["GeminiPlaywright"] = {}
-    monkeypatch.setattr(playwright_module, "CONFIG", config)
+    config["GeminiPlaywright"] = {"extended_thinking": "true"}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
 
     provider = GeminiProvider()
     browser_adapter = type("Adapter", (), {"set_extended_thinking": AsyncMock()})()
@@ -125,17 +133,6 @@ async def test_http_schema_errors_are_422():
             assert response.status_code == 422
 
 
-@pytest.mark.asyncio
-async def test_gemini_webapi_rejects_playwright_options():
-    provider = GeminiProvider()
-    provider.webapi_adapter.chat_completions = AsyncMock()
-    with pytest.raises(HTTPException) as error:
-        await provider.chat_completions(
-            make_request(model="gemini-3-flash", provider_options={"gemini": {"extended_thinking": True}})
-        )
-    assert error.value.status_code == 400
-
-
 def test_gemini_temporary_webapi_rejects_playwright_options():
     with pytest.raises(HTTPException) as error:
         _resolve_temporary_chat_model(
@@ -143,6 +140,231 @@ def test_gemini_temporary_webapi_rejects_playwright_options():
             MagicMock(),
         )
     assert error.value.status_code == 400
+
+
+def _make_webapi_mocks(mocker, registry=None):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_client.resolve_model.return_value = SimpleNamespace(model_name="gemini-3-flash", is_available=True)
+    if registry is None:
+        registry = mocker.Mock(spec=SessionRegistry)
+    mock_registry = registry
+    mock_manager = mocker.Mock(spec=SessionManager)
+    mock_manager.get_response_stateful = mocker.AsyncMock(
+        return_value=(SimpleNamespace(text="response"), True)
+    )
+    mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
+    mock_registry.save_session_snapshot = mocker.AsyncMock()
+    return mock_client, mock_registry, mock_manager
+
+
+def _make_webapi_request(**kwargs):
+    from app.schemas.request import OpenAIChatRequest
+    defaults = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "model": "gemini-3-flash",
+        "conversation_id": "test_token_XYZ",
+        "stream": False,
+    }
+    defaults.update(kwargs)
+    return OpenAIChatRequest(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_webapi_buffered_request_override_true(mocker, install_gemini_client):
+    mock_client, mock_registry, mock_manager = _make_webapi_mocks(mocker)
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    result = await provider.chat_completions(
+        _make_webapi_request(provider_options={"gemini": {"extended_thinking": True}})
+    )
+
+    assert result["choices"][0]["message"]["content"] == "response"
+    mock_manager.get_response_stateful.assert_awaited_once()
+    assert mock_manager.get_response_stateful.await_args.kwargs["extended_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_webapi_buffered_request_override_false(mocker, install_gemini_client, monkeypatch):
+    config = configparser.ConfigParser()
+    config["Gemini"] = {"extended_thinking": "true"}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
+
+    mock_client, mock_registry, mock_manager = _make_webapi_mocks(mocker)
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    await provider.chat_completions(
+        _make_webapi_request(provider_options={"gemini": {"extended_thinking": False}})
+    )
+
+    assert mock_manager.get_response_stateful.await_args.kwargs["extended_thinking"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [("true", True), ("false", False)],
+)
+async def test_webapi_buffered_fallback_to_shared_config(mocker, install_gemini_client, monkeypatch, config_value, expected):
+    config = configparser.ConfigParser()
+    config["Gemini"] = {"extended_thinking": config_value}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
+
+    mock_client, mock_registry, mock_manager = _make_webapi_mocks(mocker)
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    await provider.chat_completions(_make_webapi_request())
+
+    assert mock_manager.get_response_stateful.await_args.kwargs["extended_thinking"] is expected
+
+
+@pytest.mark.asyncio
+async def test_webapi_progressive_streaming_propagation(mocker, install_gemini_client):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_client.resolve_model.return_value = SimpleNamespace(model_name="gemini-3-flash", is_available=True)
+    mock_registry = mocker.Mock(spec=SessionRegistry)
+    mock_manager = mocker.Mock(spec=SessionManager)
+
+    received = {}
+
+    async def mock_generator(*args, **kwargs):
+        received.update(kwargs)
+        yield {"type": "chunk", "text_delta": "delta", "is_reused": True}
+        yield {
+            "type": "final",
+            "response": SimpleNamespace(text="response", images=[], videos=[], media=[], thoughts="hidden"),
+            "is_reused": True,
+        }
+
+    mock_manager.get_streaming_response_stateful = mock_generator
+    mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
+    mock_registry.save_session_snapshot = mocker.AsyncMock()
+
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(
+        _make_webapi_request(
+            stream=True,
+            provider_options={"gemini": {"extended_thinking": True}},
+        )
+    )
+    assert response is not None
+    async for _ in response.body_iterator:
+        pass
+    assert received["extended_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_manager_progressive_passes_extended_thinking_to_upstream(mocker, install_registry_generation):
+    client = mocker.Mock()
+    session = mocker.Mock()
+    received = {}
+
+    async def send_message_stream(**kwargs):
+        received.update(kwargs)
+        yield SimpleNamespace(text_delta="delta")
+
+    session.send_message_stream = send_message_stream
+    client.start_chat.return_value = session
+    generation = install_registry_generation(client)
+    manager = SessionManager(client, generation)
+
+    async for _ in manager.get_streaming_response_stateful(
+        "model",
+        [{"content": "hello"}],
+        "",
+        extended_thinking=True,
+    ):
+        pass
+
+    assert received["extended_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_webapi_tool_call_buffered_path_propagation(mocker, install_gemini_client):
+    mock_client, mock_registry, mock_manager = _make_webapi_mocks(mocker)
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    response = await provider.chat_completions(
+        _make_webapi_request(
+            stream=True,
+            tools=[{"type": "function", "function": {"name": "lookup", "description": "look up"}}],
+            provider_options={"gemini": {"extended_thinking": True}},
+        )
+    )
+    assert response is not None
+    mock_manager.get_response_stateful.assert_awaited_once()
+    assert mock_manager.get_response_stateful.await_args.kwargs["extended_thinking"] is True
+
+
+@pytest.mark.asyncio
+async def test_webapi_generation_retry_preserves_extended_thinking(mocker, install_gemini_client):
+    mock_client = mocker.Mock()
+    mock_client.client.account_status.name = "AVAILABLE"
+    mock_client.resolve_model.return_value = SimpleNamespace(model_name="gemini-3-flash", is_available=True)
+    mock_registry = mocker.Mock(spec=SessionRegistry)
+    mock_manager = mocker.Mock(spec=SessionManager)
+    mock_manager.get_response_stateful = mocker.AsyncMock(
+        side_effect=[GeminiGenerationUnavailableError("generation retired"), (SimpleNamespace(text="response"), True)]
+    )
+    mock_registry.get_session = mocker.AsyncMock(return_value=mock_manager)
+    mock_registry.save_session_snapshot = mocker.AsyncMock()
+
+    install_gemini_client(mock_client)
+    mocker.patch("app.services.providers.gemini.webapi_adapter.get_gemini_chat_registry", return_value=mock_registry)
+
+    provider = GeminiProvider()
+    result = await provider.chat_completions(
+        _make_webapi_request(provider_options={"gemini": {"extended_thinking": True}})
+    )
+
+    assert result["choices"][0]["message"]["content"] == "response"
+    calls = mock_manager.get_response_stateful.await_args_list
+    assert len(calls) == 2
+    assert all(call.kwargs["extended_thinking"] is True for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_reused_session_switches_extended_thinking_without_rebuild(mocker, install_registry_generation):
+    client = mocker.Mock()
+    session = mocker.Mock()
+    received = []
+    session.send_message = mocker.AsyncMock(side_effect=lambda **kwargs: received.append(kwargs.get("extended_thinking")) or SimpleNamespace(text="ok"))
+    client.start_chat.return_value = session
+    generation = install_registry_generation(client)
+    registry = SessionRegistry(client, generation=generation)
+    manager = await registry.get_session("reused-conversation")
+
+    await manager.get_response_stateful("model", [{"content": "first"}], "", extended_thinking=True)
+    await manager.get_response_stateful("model", [{"content": "second"}], "", extended_thinking=False)
+
+    assert received == [True, False]
+    client.start_chat.assert_called_once_with(model="model", gem=None)
+    assert manager.session is session
+
+
+def test_session_snapshot_state_has_no_extended_thinking():
+    session = SimpleNamespace(
+        gem=None,
+        model="gemini-3-flash",
+        metadata=["cid", "rid", "rcid", "context"],
+    )
+    payload = serialize_session_state(session)
+    assert "extended_thinking" not in payload
+
+    manager = SessionManager(None, client_generation=0)
+    assert not hasattr(manager, "extended_thinking")
 
 
 @pytest.mark.asyncio
@@ -352,8 +574,8 @@ async def test_failed_extended_thinking_verification_is_explicit(extended_page):
 @pytest.mark.asyncio
 async def test_request_option_normalization_forces_off_when_omitted_or_false(monkeypatch):
     config = configparser.ConfigParser()
-    config["GeminiPlaywright"] = {"extended_thinking": "false"}
-    monkeypatch.setattr(playwright_module, "CONFIG", config)
+    config["Gemini"] = {"extended_thinking": "false"}
+    monkeypatch.setattr(shared_module, "CONFIG", config)
 
     provider = GeminiProvider()
     browser_adapter = type("Adapter", (), {"set_extended_thinking": AsyncMock()})()


### PR DESCRIPTION
## Summary

Add `extended_thinking` support to Gemini WebAPI and make the option shared across Gemini WebAPI and Playwright backends.

## Changes

- Move `extended_thinking` default from `[GeminiPlaywright]` to `[Gemini]`.
- Use shared precedence:
  `provider_options.gemini.extended_thinking > [Gemini].extended_thinking > false`.
- Add Gemini WebAPI propagation for:
  - buffered responses
  - progressive streaming
  - tool-call buffered requests
  - generation retry
- Keep `extended_thinking` request-scoped.
- Allow reused conversations to switch Extended Thinking between turns without rebuilding the session.
- Keep Extended Thinking out of session identity and persisted snapshots.
- Preserve existing Playwright behavior using the shared Gemini config.
- Remove obsolete `[GeminiPlaywright]` config contract.
- Update API/configuration docs and tests.

## Verification

- Full suite: 676 passed
- Targeted suite: 84 passed
- `git diff --check`: clean

Runtime verification against Gemini WebAPI also confirmed:

- `extended_thinking: true` reaches upstream call as `True`
- `extended_thinking: false` reaches upstream call as `False`
- progressive streaming propagates `True`
- all verification requests returned HTTP 200

Temporary runtime instrumentation was removed after verification.

Refs: #115