### PR TITLE
fix(gemini): allow missing Extended Thinking control when disabled

### DIFF
--- a/src/app/services/providers/gemini/browser_adapter.py
+++ b/src/app/services/providers/gemini/browser_adapter.py
@@ -106,40 +106,22 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         return confirmed
 
     async def set_extended_thinking(self, page: Page, enabled: bool, state: Optional[Any] = None) -> None:
-        """Normalize Gemini mode-picker Extended thinking state for one request."""
+        """Normalize Gemini mode-picker Extended thinking state for one request.
+
+        An absent control after the mode menu opened means the feature is
+        unavailable for this session/model; that satisfies a requested OFF state.
+        """
         await self._open_mode_menu(page)
         item = page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
         try:
             await item.wait_for(state="visible", timeout=1000)
         except PlaywrightTimeoutError as error:
-            if not enabled:
-                verification_error = None
-                try:
-                    picker = await self._find_model_picker(page)
-                    label = await picker.get_attribute("aria-label") if picker else None
-                except Exception as exc:
-                    picker = None
-                    label = None
-                    verification_error = exc
-                finally:
-                    try:
-                        await page.keyboard.press("Escape")
-                    except Exception:
-                        pass
-
-                if not picker or label is None:
-                    raise TransientSessionError(
-                        "Gemini Extended thinking state could not be verified off."
-                    ) from (verification_error or error)
-                if re.search(r"\bExtended\b", label, re.I):
-                    raise TransientSessionError(
-                        "Gemini Extended thinking state could not be normalized off."
-                    )
-                return
             try:
                 await page.keyboard.press("Escape")
             except Exception:
                 pass
+            if not enabled:
+                return
             raise ModelNotFoundError("Gemini Extended thinking control is unavailable.") from error
 
         aria_disabled = await item.get_attribute("aria-disabled")

--- a/tests/test_gemini_extended_thinking.py
+++ b/tests/test_gemini_extended_thinking.py
@@ -458,7 +458,7 @@ async def test_missing_item_after_menu_render_false_succeeds_true_fails(extended
 
 
 @pytest.mark.asyncio
-async def test_missing_item_with_extended_label_fails_off(extended_page):
+async def test_missing_item_with_extended_label_succeeds_off(extended_page):
     picker = MagicMock()
     picker.click = AsyncMock()
     picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash Extended")
@@ -470,23 +470,42 @@ async def test_missing_item_with_extended_label_fails_off(extended_page):
     adapter = GeminiProviderAdapter()
     adapter._find_model_picker = AsyncMock(return_value=picker)
 
-    with pytest.raises(TransientSessionError, match="normalized off"):
-        await adapter.set_extended_thinking(extended_page, False)
+    await adapter.set_extended_thinking(extended_page, False)
 
 
 @pytest.mark.asyncio
-async def test_missing_item_with_disappeared_picker_fails_off(extended_page):
-    picker = MagicMock()
-    picker.click = AsyncMock()
+async def test_missing_item_succeeds_off_without_secondary_picker_verification(extended_page):
     item = MagicMock()
     item.first = item
     item.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("missing"))
     extended_page.get_by_role = MagicMock(return_value=item)
     await extended_page.locator("#menu").evaluate("element => element.hidden = false")
     adapter = GeminiProviderAdapter()
-    adapter._find_model_picker = AsyncMock(side_effect=[picker, None])
 
-    with pytest.raises(TransientSessionError, match="verified off"):
+    await adapter.set_extended_thinking(extended_page, False)
+
+
+@pytest.mark.asyncio
+async def test_absent_control_false_succeeds_true_capability_error(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => { element.textContent = 'Other'; element.removeAttribute('role'); }"
+    )
+    adapter = GeminiProviderAdapter()
+
+    await adapter.set_extended_thinking(extended_page, False)
+    with pytest.raises(ModelNotFoundError):
+        await adapter.set_extended_thinking(extended_page, True)
+
+
+@pytest.mark.asyncio
+async def test_playwright_failure_during_control_check_still_fails(extended_page):
+    item = MagicMock()
+    item.first = item
+    item.wait_for = AsyncMock(side_effect=PlaywrightError("Target closed"))
+    extended_page.get_by_role = MagicMock(return_value=item)
+    adapter = GeminiProviderAdapter()
+
+    with pytest.raises(PlaywrightError):
         await adapter.set_extended_thinking(extended_page, False)
 
 


### PR DESCRIPTION
## Summary

Fix Gemini Playwright requests failing when the Extended Thinking control is unavailable, such as in Guest Mode.

## Changes

- Treat an absent Extended Thinking control as satisfying `extended_thinking=false`.
- Keep `extended_thinking=true` behavior unchanged.
- Preserve existing Playwright/session failure handling.
- Remove unnecessary secondary `aria-label` verification for the absent-control OFF case.

## Behavior

- `false` + control absent → continue request
- `true` + control absent → existing capability error
- control present → existing ON/OFF normalization
- browser/session failure → existing error handling

## Tests

- Extended Thinking tests: 38 passed
- Related Gemini Playwright tests: 80 passed
- Full suite: 678 passed
- `git diff --check`: passed



Refs: #130