### PR TITLE
fix(gemini): harden Playwright UI detection and model verification

### DIFF
--- a/src/app/services/providers/gemini/browser_adapter.py
+++ b/src/app/services/providers/gemini/browser_adapter.py
@@ -347,7 +347,8 @@ class GeminiProviderAdapter(BaseProviderAdapter):
                 "index": i,
                 "label": label,
                 "score": score,
-                "locator": opt
+                "locator": opt,
+                "mode_id": await opt.get_attribute("data-mode-id"),
             })
 
         if not candidates:
@@ -371,10 +372,56 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         # Sort candidates by score (descending)
         candidates.sort(key=lambda x: x["score"], reverse=True)
         target_option = candidates[0]["locator"]
+        target_mode_id = candidates[0]["mode_id"]
 
         await target_option.click()
-        
-        # 4. Verify Selection (polling with short timeout)
+
+        if target_mode_id:
+            await self._verify_selection_by_mode_id(page, requested_model_label, target_mode_id, state)
+        else:
+            await self._verify_selection_by_label(page, requested_model_label, state)
+
+        logger.info(f"Gemini model successfully switched to '{requested_model_label}'", extra={"request_id": getattr(state, "request_id", "unknown")})
+
+    async def _verify_selection_by_mode_id(self, page: Page, requested_model_label: str, mode_id: str, state: Optional[Any] = None) -> None:
+        """
+        Verify the clicked option via its session-captured data-mode-id: after
+        reopening the menu exactly one item must carry that id and the `selected`
+        class. `data-active`/`active` are focus artifacts and never count.
+        The id is re-read from the same DOM moments after the click, so it cannot
+        go stale like a hardcoded mapping would.
+        """
+        verification_timeout = 3.0
+        poll_interval = 0.5
+        elapsed = 0.0
+
+        while elapsed < verification_timeout:
+            await self._open_mode_menu(page)
+            matches = page.locator(f'gem-menu-item[data-mode-id="{mode_id}"]')
+            match_count = await matches.count()
+            if match_count != 1:
+                await page.keyboard.press("Escape")
+                raise TransientSessionError(
+                    f"Gemini model selection verification is ambiguous. Requested: '{requested_model_label}', "
+                    f"matching options for id '{mode_id}': {match_count}"
+                )
+            selected_class = (await matches.nth(0).get_attribute("class")) or ""
+            if "selected" in selected_class.split():
+                await page.keyboard.press("Escape")
+                return
+            # Close the menu before backoff so the next poll's picker click
+            # reopens it instead of toggling a still-open menu shut.
+            await page.keyboard.press("Escape")
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+        raise TransientSessionError(
+            f"Gemini model selection verification failed. Requested: '{requested_model_label}', "
+            f"option '{mode_id}' never became selected."
+        )
+
+    async def _verify_selection_by_label(self, page: Page, requested_model_label: str, state: Optional[Any] = None) -> None:
+        """Legacy text-based verification fallback when no data-mode-id exists."""
         verification_timeout = 3.0
         poll_interval = 0.5
         elapsed = 0.0
@@ -394,5 +441,3 @@ class GeminiProviderAdapter(BaseProviderAdapter):
             raise TransientSessionError(
                 f"Gemini model selection verification failed. Requested: '{requested_model_label}', Found: '{last_found}'"
             )
-        
-        logger.info(f"Gemini model successfully switched to '{last_found}'", extra={"request_id": getattr(state, "request_id", "unknown")})

--- a/src/app/services/providers/gemini/browser_adapter.py
+++ b/src/app/services/providers/gemini/browser_adapter.py
@@ -105,14 +105,31 @@ class GeminiProviderAdapter(BaseProviderAdapter):
                 
         return confirmed
 
+    async def _resolve_extended_thinking_item(self, page: Page) -> Any:
+        """
+        Identify the Extended Thinking menu item without relying on UI text.
+
+        Structural signal: inside [data-test-id="gem-mode-menu"], Extended
+        Thinking is the only gem-menu-item lacking a data-mode-id (model modes
+        own one; the toggle is a mode modifier). When zero or multiple
+        candidates match, fall back to the English role/name matcher.
+        """
+        menu = page.locator('[role="menu"][data-test-id="gem-mode-menu"]').first
+        structural = menu.locator('gem-menu-item[role="menuitem"]:not([data-mode-id])')
+        if await structural.count() == 1:
+            return structural.first
+        return page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
+
     async def set_extended_thinking(self, page: Page, enabled: bool, state: Optional[Any] = None) -> None:
         """Normalize Gemini mode-picker Extended thinking state for one request.
 
-        An absent control after the mode menu opened means the feature is
-        unavailable for this session/model; that satisfies a requested OFF state.
+        Detection is language-independent when possible (structural item lookup,
+        English fallback). An absent control after the mode menu opened means the
+        feature is unavailable; that satisfies a requested OFF state. Capability
+        gating uses aria-disabled; ON/OFF state lives in the `selected` class.
         """
         await self._open_mode_menu(page)
-        item = page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
+        item = await self._resolve_extended_thinking_item(page)
         try:
             await item.wait_for(state="visible", timeout=1000)
         except PlaywrightTimeoutError as error:
@@ -136,21 +153,20 @@ class GeminiProviderAdapter(BaseProviderAdapter):
         await item.click()
 
         for _ in range(12):
-            picker = await self._find_model_picker(page)
-            label = await picker.get_attribute("aria-label") if picker else None
-            label_enabled = bool(label and re.search(r"\bExtended\b", label, re.I))
-            if label_enabled == enabled:
+            try:
                 await self._open_mode_menu(page)
-                verified_item = page.get_by_role("menuitem", name=re.compile("Extended thinking", re.I)).first
-                try:
-                    await verified_item.wait_for(state="visible", timeout=1000)
-                except PlaywrightTimeoutError:
-                    await page.keyboard.press("Escape")
-                    raise TransientSessionError("Gemini Extended thinking state verification failed.")
+                verified_item = await self._resolve_extended_thinking_item(page)
+                await verified_item.wait_for(state="visible", timeout=1000)
                 verified = "selected" in (await verified_item.get_attribute("class") or "").split()
                 await page.keyboard.press("Escape")
-                if verified == enabled:
-                    return
+            except PlaywrightTimeoutError:
+                try:
+                    await page.keyboard.press("Escape")
+                except Exception:
+                    pass
+                raise TransientSessionError("Gemini Extended thinking state verification failed.")
+            if verified == enabled:
+                return
             await asyncio.sleep(0.25)
 
         raise TransientSessionError("Gemini Extended thinking state transition could not be verified.")

--- a/src/app/services/providers/gemini/scripts/gemini_scripts.py
+++ b/src/app/services/providers/gemini/scripts/gemini_scripts.py
@@ -11,7 +11,7 @@ SELECTORS = {
     "SEND_BUTTON": 'button.send-button, button[aria-label*="Send message"], button[aria-label="Send"], [data-test-id="send-button"]',
     "STOP_BUTTON": 'button[aria-label*="Stop"], .stop-button',
     "RESPONSE_CONTAINER": 'message-content, .message-content, [data-test-id="message-content"]',
-    "MODEL_PICKER": 'button[aria-label*="Open mode picker"]',
+    "MODEL_PICKER": '[data-test-id="bard-mode-menu-button"], button[aria-label*="Open mode picker"]',
     "MODEL_OPTION": '[role="menuitem"], [role="option"], .mat-mdc-menu-item'
 }
 

--- a/tests/test_gemini_extended_thinking.py
+++ b/tests/test_gemini_extended_thinking.py
@@ -387,7 +387,7 @@ async def extended_page():
         page = await context.new_page()
         await page.set_content(
             """
-            <button id="picker" aria-label="Open mode picker, currently Flash"></button>
+            <button id="picker" data-test-id="bard-mode-menu-button" aria-label="Open mode picker, currently Flash"></button>
             <div id="menu" role="menu" data-test-id="gem-mode-menu" hidden>
               <gem-menu-item role="menuitem" aria-disabled="false">Extended thinking</gem-menu-item>
             </div>
@@ -441,6 +441,9 @@ async def test_picker_missing_fails_for_false_and_true(extended_page):
 
 @pytest.mark.asyncio
 async def test_missing_item_after_menu_render_false_succeeds_true_fails(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('data-mode-id', 'decoy')"
+    )
     picker = MagicMock()
     picker.click = AsyncMock()
     picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash")
@@ -459,6 +462,9 @@ async def test_missing_item_after_menu_render_false_succeeds_true_fails(extended
 
 @pytest.mark.asyncio
 async def test_missing_item_with_extended_label_succeeds_off(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('data-mode-id', 'decoy')"
+    )
     picker = MagicMock()
     picker.click = AsyncMock()
     picker.get_attribute = AsyncMock(return_value="Open mode picker, currently Flash Extended")
@@ -475,6 +481,9 @@ async def test_missing_item_with_extended_label_succeeds_off(extended_page):
 
 @pytest.mark.asyncio
 async def test_missing_item_succeeds_off_without_secondary_picker_verification(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('data-mode-id', 'decoy')"
+    )
     item = MagicMock()
     item.first = item
     item.wait_for = AsyncMock(side_effect=PlaywrightTimeoutError("missing"))
@@ -499,6 +508,9 @@ async def test_absent_control_false_succeeds_true_capability_error(extended_page
 
 @pytest.mark.asyncio
 async def test_playwright_failure_during_control_check_still_fails(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('data-mode-id', 'decoy')"
+    )
     item = MagicMock()
     item.first = item
     item.wait_for = AsyncMock(side_effect=PlaywrightError("Target closed"))
@@ -619,3 +631,72 @@ async def test_request_option_normalization_forces_off_when_omitted_or_false(mon
     )
 
     assert [call.args[1] for call in browser_adapter.set_extended_thinking.await_args_list] == [True, False, False]
+
+
+@pytest.mark.asyncio
+async def test_mode_picker_found_via_test_id_without_english_label(extended_page):
+    await extended_page.locator("#picker").evaluate("element => element.removeAttribute('aria-label')")
+    assert await GeminiProviderAdapter()._find_model_picker(extended_page) is not None
+
+
+@pytest.mark.asyncio
+async def test_structural_detection_toggles_without_english_text(extended_page):
+    await extended_page.evaluate(
+        """
+        () => {
+            const menu = document.querySelector('#menu');
+            const item = document.querySelector('gem-menu-item');
+            item.textContent = 'Erweitertes Denken';
+            const picker = document.querySelector('#picker');
+            picker.setAttribute('aria-label', 'Modusauswahl, derzeit Flash');
+            item.onclick = () => {
+                item.classList.toggle('selected');
+                menu.hidden = true;
+            };
+        }
+        """
+    )
+    adapter = GeminiProviderAdapter()
+    item = extended_page.locator("gem-menu-item")
+
+    await adapter.set_extended_thinking(extended_page, True)
+    assert "selected" in ((await item.get_attribute("class")) or "").split()
+
+    await adapter.set_extended_thinking(extended_page, False)
+    assert "selected" not in ((await item.get_attribute("class")) or "").split()
+
+
+@pytest.mark.asyncio
+async def test_multiple_modeless_items_rejected_structural_uses_english_fallback(extended_page):
+    await extended_page.evaluate(
+        """
+        () => {
+            const menu = document.querySelector('#menu');
+            const decoy = document.createElement('gem-menu-item');
+            decoy.setAttribute('role', 'menuitem');
+            decoy.textContent = 'Anderer Modus';
+            menu.append(decoy);
+        }
+        """
+    )
+    real = extended_page.locator("gem-menu-item").first
+
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, True)
+    assert "selected" in ((await real.get_attribute("class")) or "").split()
+
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, False)
+    assert "selected" not in ((await real.get_attribute("class")) or "").split()
+
+
+@pytest.mark.asyncio
+async def test_no_modeless_candidate_uses_english_fallback(extended_page):
+    await extended_page.locator("gem-menu-item").evaluate(
+        "element => element.setAttribute('data-mode-id', 'decoy')"
+    )
+
+    # false + present-but-off succeeds via fallback; true would toggle it.
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, False)
+    await GeminiProviderAdapter().set_extended_thinking(extended_page, True)
+    assert "selected" in (
+        (await extended_page.locator("gem-menu-item").get_attribute("class")) or ""
+    ).split()

--- a/tests/test_gemini_model_selection.py
+++ b/tests/test_gemini_model_selection.py
@@ -9,6 +9,7 @@ from app.services.providers.gemini.playwright_adapter import (
     BrowserRequestConfig
 )
 from app.services.providers.gemini.shared import PLAYWRIGHT_GEMINI_MODEL_UI_LABELS, get_gemini_models
+from app.services.providers.gemini.scripts.gemini_scripts import SELECTORS
 from app.schemas.request import OpenAIChatRequest
 from app.services.browser.errors import TransientSessionError, GatedModelError, ModelNotFoundError
 from app.services.browser.auth_types import AuthStatus
@@ -132,9 +133,11 @@ async def test_select_model_success(adapter, mock_page):
     
     opt_flash = MagicMock()
     opt_flash.inner_text = AsyncMock(return_value="3.5 Flash")
-    
+    opt_flash.get_attribute = AsyncMock(return_value=None)
+
     opt_pro = MagicMock()
     opt_pro.inner_text = AsyncMock(return_value="3.1 Pro")
+    opt_pro.get_attribute = AsyncMock(return_value=None)
     opt_pro.click = AsyncMock()
     
     mock_options.nth.side_effect = [opt_flash, opt_pro]
@@ -237,10 +240,12 @@ async def test_select_model_collision_prevention_flash_vs_lite(adapter, mock_pag
     
     opt_lite = MagicMock()
     opt_lite.inner_text = AsyncMock(return_value="Gemini 1.5 Flash-Lite")
+    opt_lite.get_attribute = AsyncMock(return_value=None)
     opt_lite.click = AsyncMock()
-    
+
     opt_flash = MagicMock()
     opt_flash.inner_text = AsyncMock(return_value="Gemini 1.5 Flash")
+    opt_flash.get_attribute = AsyncMock(return_value=None)
     opt_flash.click = AsyncMock()
     
     mock_options.nth.side_effect = [opt_lite, opt_flash, opt_lite, opt_flash]
@@ -262,6 +267,260 @@ async def test_select_model_collision_prevention_flash_vs_lite(adapter, mock_pag
     # Verify '3.5 Flash' (opt_flash) was clicked, NOT 'Flash-Lite'
     assert opt_flash.click.call_count == 1
     assert opt_lite.click.call_count == 0
+
+
+GEM_MENU_SEL = '[role="menu"][data-test-id="gem-mode-menu"]'
+
+
+def _build_mode_selection_page(options, id_item_classes=None, id_match_count=1, events=None):
+    """
+    Build a mock page for select_model flows.
+
+    options: list of {"text": str, "mode_id": Optional[str]}
+    id_item_classes: side_effect (or value) for the matched mode-id item's
+                     get_attribute("class"); None -> never queried
+    id_match_count: how many items the post-click data-mode-id query returns
+    events: optional list; interaction lifecycle is appended to it as
+            "picker_click", "menu_open", "escape"
+
+    Returns (page, selectors_seen, option_els).
+    """
+    page = MagicMock()
+    page._gemini_callbacks = {}
+    page.url = "https://gemini.google.com/app"
+    selectors_seen = []
+    option_els = []
+    record = events.append if events is not None else (lambda _e: None)
+
+    def make_loc():
+        loc = MagicMock()
+        loc.first = loc
+        return loc
+
+    picker_el = MagicMock()
+    picker_el.count = AsyncMock(return_value=1)
+    picker_el.get_attribute = AsyncMock(return_value=None)
+    picker_el.inner_text = AsyncMock(return_value="")
+
+    async def _picker_click(*_a, **_k):
+        record("picker_click")
+
+    picker_el.click = _picker_click
+    picker_el.scroll_into_view_if_needed = AsyncMock()
+
+    menu_loc = make_loc()
+
+    async def _menu_wait(*_a, **_k):
+        record("menu_open")
+
+    menu_loc.first.wait_for = _menu_wait
+
+    # Reuse one id-locator instance per selector so sequential class reads
+    # (one per verification poll) advance the same side_effect sequence.
+    id_locators = {}
+
+    def make_id_locator():
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=id_match_count)
+        item = MagicMock()
+        if isinstance(id_item_classes, list):
+            item.get_attribute = AsyncMock(side_effect=list(id_item_classes))
+        else:
+            item.get_attribute = AsyncMock(return_value=id_item_classes)
+        loc.nth.return_value = item
+        return loc
+
+    # Build option elements once: every MODEL_OPTION locator call must return
+    # the SAME instances so tests observe the clicks production performs.
+    for opt in options:
+        el = MagicMock()
+        el.inner_text = AsyncMock(return_value=opt["text"])
+        el.get_attribute = AsyncMock(return_value=opt["mode_id"])
+        el.click = AsyncMock()
+        option_els.append(el)
+
+    def make_opts():
+        opts = MagicMock()
+        opts.first = opts
+        opts.wait_for = AsyncMock()
+        opts.count = AsyncMock(return_value=len(options))
+        for i, el in enumerate(option_els):
+            setattr(opts, f"opt_{i}", el)
+
+        def _nth(i, _opts=opts):
+            return getattr(_opts, f"opt_{i}")
+
+        opts.nth = _nth
+        return opts
+
+    def locator_side_effect(selector):
+        selectors_seen.append(selector)
+        if selector == SELECTORS["MODEL_PICKER"]:
+            loc = make_loc()
+            loc.first = picker_el
+            return loc
+        if selector == GEM_MENU_SEL:
+            return menu_loc
+        if selector.startswith('gem-menu-item[data-mode-id='):
+            if selector not in id_locators:
+                id_locators[selector] = make_id_locator()
+            return id_locators[selector]
+        if selector == SELECTORS["MODEL_OPTION"]:
+            return make_opts()
+        return make_loc()
+
+    page.locator.side_effect = locator_side_effect
+
+    async def _escape(key, **_k):
+        record("escape")
+
+    page.keyboard.press = _escape
+    return page, selectors_seen, option_els
+
+
+@pytest.mark.asyncio
+async def test_select_model_verifies_via_captured_mode_id_without_picker_text(adapter, monkeypatch):
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, seen, opts = _build_mode_selection_page(
+        options, id_item_classes="ng-star-inserted selected"
+    )
+    monkeypatch.setattr(
+        "app.services.providers.gemini.browser_adapter.asyncio.sleep", AsyncMock()
+    )
+
+    await adapter.select_model(page, "Flash")
+
+    assert opts[0].click.call_count == 1
+    assert 'gem-menu-item[data-mode-id="abc123session"]' in seen
+    # Picker text stayed unusable throughout; verification still succeeded.
+    assert GEM_MENU_SEL in seen
+
+
+@pytest.mark.asyncio
+async def test_select_model_without_mode_id_uses_text_verification_fallback(adapter):
+    options = [{"text": "3.1 Pro", "mode_id": None}]
+    page, seen, opts = _build_mode_selection_page(options)
+    # No-op pre-check sees a different model; post-click check sees the target.
+    active_reads = iter(["Flash", "Pro", "Pro", "Pro", "Pro", "Pro"])
+
+    async def fake_get_active_model(_page):
+        return next(active_reads, "Pro")
+
+    adapter.get_active_model = fake_get_active_model
+
+    await adapter.select_model(page, "Pro")
+
+    assert opts[0].click.call_count == 1
+    assert not any("data-mode-id" in s for s in seen)
+
+
+@pytest.mark.asyncio
+async def test_select_model_mode_id_never_selected_fails_transient(adapter, monkeypatch):
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, _, _ = _build_mode_selection_page(
+        options, id_item_classes=["ng-star-inserted"] * 10
+    )
+    monkeypatch.setattr(
+        "app.services.providers.gemini.browser_adapter.asyncio.sleep", AsyncMock()
+    )
+
+    with pytest.raises(TransientSessionError, match="never became selected"):
+        await adapter.select_model(page, "Flash")
+
+
+@pytest.mark.asyncio
+async def test_select_model_duplicate_mode_id_is_ambiguous_failure(adapter, monkeypatch):
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, _, _ = _build_mode_selection_page(
+        options,
+        id_item_classes="ng-star-inserted selected",
+        id_match_count=2,
+    )
+
+    with pytest.raises(TransientSessionError, match="ambiguous"):
+        await adapter.select_model(page, "Flash")
+
+
+@pytest.mark.asyncio
+async def test_select_model_data_active_without_selected_does_not_count(adapter, monkeypatch):
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, _, _ = _build_mode_selection_page(
+        options, id_item_classes=["active"] * 10
+    )
+    monkeypatch.setattr(
+        "app.services.providers.gemini.browser_adapter.asyncio.sleep", AsyncMock()
+    )
+
+    with pytest.raises(TransientSessionError, match="never became selected"):
+        await adapter.select_model(page, "Flash")
+
+
+@pytest.mark.asyncio
+async def test_mode_id_unsuccessful_poll_escapes_before_retry_reopens_cleanly(adapter, monkeypatch):
+    events = []
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    # Poll 1: not selected -> Escape + backoff; poll 2: selected -> Escape + success.
+    page, _, opts = _build_mode_selection_page(
+        options,
+        id_item_classes=["ng-star-inserted", "ng-star-inserted selected"],
+        events=events,
+    )
+
+    async def _sleep(_delay):
+        events.append("sleep")
+
+    monkeypatch.setattr(
+        "app.services.providers.gemini.browser_adapter.asyncio.sleep", _sleep
+    )
+
+    await adapter.select_model(page, "Flash")
+
+    assert opts[0].click.call_count == 1
+    assert events == [
+        "picker_click",   # select_model opens options menu
+        "picker_click",   # verification poll 1 reopens menu
+        "menu_open",
+        "escape",         # not selected: close before backoff
+        "sleep",
+        "picker_click",   # poll 2 reopens cleanly (no toggle-shut)
+        "menu_open",
+        "escape",         # success closes menu
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mode_id_timeout_leaves_menu_closed(adapter, monkeypatch):
+    events = []
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, _, _ = _build_mode_selection_page(
+        options, id_item_classes="ng-star-inserted", events=events
+    )
+    monkeypatch.setattr(
+        "app.services.providers.gemini.browser_adapter.asyncio.sleep", AsyncMock()
+    )
+
+    with pytest.raises(TransientSessionError, match="never became selected"):
+        await adapter.select_model(page, "Flash")
+
+    assert events[-1] == "escape"
+    assert events.count("picker_click") == 7  # initial open + 6 polls
+
+
+@pytest.mark.asyncio
+async def test_mode_id_ambiguous_match_closes_menu_before_error(adapter):
+    events = []
+    options = [{"text": "3.6 Flash", "mode_id": "abc123session"}]
+    page, _, _ = _build_mode_selection_page(
+        options,
+        id_item_classes="ng-star-inserted selected",
+        id_match_count=2,
+        events=events,
+    )
+
+    with pytest.raises(TransientSessionError, match="ambiguous"):
+        await adapter.select_model(page, "Flash")
+
+    assert events == ["picker_click", "picker_click", "menu_open", "escape"]
 
 def test_get_gemini_models_preserves_playwright_models_without_runtime_catalog():
     """Runtime catalog absence must not remove Playwright models."""


### PR DESCRIPTION
## Summary

Harden Gemini Playwright UI interaction against localized UI text and fragile model-selection verification.

## Changes

- Prefer `data-test-id="bard-mode-menu-button"` for the Gemini mode picker.
- Detect Extended Thinking structurally inside `gem-mode-menu`.
- Keep English text matching only as fallback.
- Verify Extended Thinking state using the `selected` class instead of picker text.
- Capture each selected model option's `data-mode-id`.
- Verify model selection using the captured ID + `selected` class.
- Fall back to existing text verification when `data-mode-id` is unavailable.
- Fail safely on ambiguous model-ID matches.

## Preserved behavior

- No hardcoded model IDs.
- Existing model text scoring remains unchanged.
- Flash / Flash-Lite collision handling remains unchanged.
- Extended Thinking Guest Mode behavior remains unchanged.
- WebAPI behavior unchanged.
- Browser/session error handling unchanged.

## Tests

- Full suite: 690 passed
- `git diff --check`: passed


Refs: #130