### PR TITLE
fix(setup): align and validate Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Provides access to cloud-hosted AI models through a native API integration power
 
 ## Quick Start
 
+> **Prerequisite:** Python 3.11–3.12 (see `pyproject.toml`).
+
 ### 1. Install Dependencies
 ```bash
 poetry install

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -16,8 +16,14 @@ except ImportError:
         return None, "Unknown", False
 
 # Constants
-REQUIRED_PYTHON_VERSION = (3, 10)
+# Must mirror pyproject.toml requires-python (">=3.11,<3.13").
+# Guarded by tests/test_version_alignment.py::test_python_version_contract_alignment.
+REQUIRED_PYTHON_VERSION = (3, 11)
 MAX_PYTHON_VERSION = (3, 13)
+SUPPORTED_RANGE_TEXT = (
+    f"{REQUIRED_PYTHON_VERSION[0]}.{REQUIRED_PYTHON_VERSION[1]} to "
+    f"<{MAX_PYTHON_VERSION[0]}.{MAX_PYTHON_VERSION[1]}"
+)
 CONFIG_FILE = "config.conf"
 CONFIG_EXAMPLE = "config.conf.example"
 ENV_FILE = ".env"
@@ -38,13 +44,15 @@ def print_error(message):
 def check_python_version():
     current_version = sys.version_info[:2]
     if current_version < REQUIRED_PYTHON_VERSION:
-        print_error(f"Python version {REQUIRED_PYTHON_VERSION[0]}.{REQUIRED_PYTHON_VERSION[1]} or newer is required.")
+        print_error(f"Python {SUPPORTED_RANGE_TEXT} is required.")
         print_error(f"Current version is {current_version[0]}.{current_version[1]}.")
         return False
-    
+
     if current_version >= MAX_PYTHON_VERSION:
-        print(f"--> WARNING: Python {current_version[0]}.{current_version[1]} is newer than the tested range ({REQUIRED_PYTHON_VERSION[0]}.{REQUIRED_PYTHON_VERSION[1]} to {MAX_PYTHON_VERSION[0]}.{MAX_PYTHON_VERSION[1]-1}); continuing.")
-    
+        print_error(f"Python {SUPPORTED_RANGE_TEXT} is required.")
+        print_error(f"Current version is {current_version[0]}.{current_version[1]}.")
+        return False
+
     return True
 
 def check_poetry():

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -17,6 +17,16 @@ except ImportError:
     def get_linux_distro():
         return None, sys.platform, False
 
+# Constants
+# Must mirror pyproject.toml requires-python (">=3.11,<3.13").
+# Guarded by tests/test_version_alignment.py::test_python_version_contract_alignment.
+REQUIRED_PYTHON_VERSION = (3, 11)
+MAX_PYTHON_VERSION = (3, 13)
+SUPPORTED_RANGE_TEXT = (
+    f"{REQUIRED_PYTHON_VERSION[0]}.{REQUIRED_PYTHON_VERSION[1]} to "
+    f"<{MAX_PYTHON_VERSION[0]}.{MAX_PYTHON_VERSION[1]}"
+)
+
 # Colors
 class Colors:
     HEADER = '\033[95m'
@@ -33,6 +43,18 @@ def print_status(label, status, message="", color=Colors.ENDC):
     print(f"{Colors.BOLD}{label:<20}{Colors.ENDC} [{color}{status:<7}{Colors.ENDC}] {lines[0]}")
     for line in lines[1:]:
         print(f"{' ':<20}           {line}")
+
+def check_python_version():
+    current_version = sys.version_info[:2]
+    version_text = f"{current_version[0]}.{current_version[1]}"
+    if REQUIRED_PYTHON_VERSION <= current_version < MAX_PYTHON_VERSION:
+        print_status("Python", "PASS", f"Version {version_text} is supported ({SUPPORTED_RANGE_TEXT})")
+        return True
+    print_status("Python", "FAIL", (
+        f"Version {version_text} is unsupported. Python {SUPPORTED_RANGE_TEXT} is required. "
+        "Run: poetry run python scripts/doctor.py"
+    ), Colors.FAIL)
+    return False
 
 def check_config():
     if os.path.isdir("config.conf"):
@@ -255,6 +277,8 @@ def main():
     print("=" * 60)
 
     has_fail = False
+
+    if not check_python_version(): has_fail = True
 
     config_ok, config = check_config()
     if not config_ok: has_fail = True

--- a/tests/test_bootstrap_doctor.py
+++ b/tests/test_bootstrap_doctor.py
@@ -15,6 +15,14 @@ def _load_bootstrap_module():
     spec.loader.exec_module(module)
     return module
 
+
+def _load_doctor_module():
+    path = os.path.abspath("scripts/doctor.py")
+    spec = importlib.util.spec_from_file_location("doctor_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
 class TestBootstrapDoctor(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory for tests
@@ -186,6 +194,33 @@ def test_check_python_version_matches_pyproject_contract(monkeypatch, capsys, ve
         captured = capsys.readouterr()
         assert "3.11 to <3.13 is required." in captured.err
         assert f"Current version is {version[0]}.{version[1]}." in captured.err
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_ok"),
+    [
+        ((3, 10), False),
+        ((3, 11), True),
+        ((3, 12), True),
+        ((3, 13), False),
+    ],
+)
+def test_doctor_check_python_version_matches_pyproject_contract(monkeypatch, capsys, version, expected_ok):
+    doctor = _load_doctor_module()
+    monkeypatch.setattr(doctor.sys, "version_info", version + (0, 0, "final"))
+
+    result = doctor.check_python_version()
+
+    assert result is expected_ok
+    captured = capsys.readouterr()
+    if expected_ok:
+        assert "PASS" in captured.out
+        assert "is supported" in captured.out
+    else:
+        assert "FAIL" in captured.out
+        assert f"Version {version[0]}.{version[1]} is unsupported" in captured.out
+        assert "Python 3.11 to <3.13 is required" in captured.out
+        assert "Run: poetry run python scripts/doctor.py" in captured.out
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bootstrap_doctor.py
+++ b/tests/test_bootstrap_doctor.py
@@ -4,7 +4,16 @@ import shutil
 import unittest
 import tempfile
 import json
-from pathlib import Path
+import importlib.util
+import pytest
+
+
+def _load_bootstrap_module():
+    path = os.path.abspath("scripts/bootstrap.py")
+    spec = importlib.util.spec_from_file_location("bootstrap_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 class TestBootstrapDoctor(unittest.TestCase):
     def setUp(self):
@@ -155,6 +164,28 @@ class TestBootstrapDoctor(unittest.TestCase):
         res = subprocess.run(["python", self.doctor_path], cwd=self.test_dir, capture_output=True, text=True)
         self.assertIn("WARN", res.stdout)
         self.assertIn("No Gemini auth material found", res.stdout)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_ok"),
+    [
+        ((3, 10), False),
+        ((3, 11), True),
+        ((3, 12), True),
+        ((3, 13), False),
+    ],
+)
+def test_check_python_version_matches_pyproject_contract(monkeypatch, capsys, version, expected_ok):
+    bootstrap = _load_bootstrap_module()
+    monkeypatch.setattr(bootstrap.sys, "version_info", version + (0, 0, "final"))
+
+    result = bootstrap.check_python_version()
+
+    assert result is expected_ok
+    if not expected_ok:
+        captured = capsys.readouterr()
+        assert "3.11 to <3.13 is required." in captured.err
+        assert f"Current version is {version[0]}.{version[1]}." in captured.err
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -54,3 +54,42 @@ def test_playwright_version_alignment():
         f"Dockerfile:       {docker_version}\n"
         f"Run 'make export-reqs' and update Dockerfile to match poetry.lock."
     )
+
+
+def test_python_version_contract_alignment():
+    """
+    Ensures scripts/bootstrap.py mirrors the authoritative Python range
+    declared in pyproject.toml (requires-python).
+    """
+    import ast
+
+    root = get_project_root()
+    pyproject_content = read_file(os.path.join(root, "pyproject.toml"))
+    bootstrap_path = os.path.join(root, "scripts", "bootstrap.py")
+
+    requires_match = re.search(r'requires-python\s*=\s*"([^"]+)"', pyproject_content)
+    assert requires_match is not None, "Could not find requires-python in pyproject.toml"
+    match = re.fullmatch(r">=(\d+)\.(\d+),<(\d+)\.(\d+)", requires_match.group(1))
+    assert match is not None, f"Unsupported requires-python shape: {requires_match.group(1)}"
+    expected_min = (int(match.group(1)), int(match.group(2)))
+    expected_max = (int(match.group(3)), int(match.group(4)))
+
+    tree = ast.parse(read_file(bootstrap_path))
+    constants = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in (
+                    "REQUIRED_PYTHON_VERSION",
+                    "MAX_PYTHON_VERSION",
+                ):
+                    constants[target.id] = ast.literal_eval(node.value)
+
+    assert constants.get("REQUIRED_PYTHON_VERSION") == expected_min, (
+        f"bootstrap minimum Python {constants.get('REQUIRED_PYTHON_VERSION')} "
+        f"does not match pyproject.toml floor {expected_min}."
+    )
+    assert constants.get("MAX_PYTHON_VERSION") == expected_max, (
+        f"bootstrap maximum Python {constants.get('MAX_PYTHON_VERSION')} "
+        f"does not match pyproject.toml ceiling {expected_max}."
+    )

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -58,14 +58,13 @@ def test_playwright_version_alignment():
 
 def test_python_version_contract_alignment():
     """
-    Ensures scripts/bootstrap.py mirrors the authoritative Python range
-    declared in pyproject.toml (requires-python).
+    Ensures BOTH scripts/bootstrap.py and scripts/doctor.py mirror the
+    authoritative Python range declared in pyproject.toml (requires-python).
     """
     import ast
 
     root = get_project_root()
     pyproject_content = read_file(os.path.join(root, "pyproject.toml"))
-    bootstrap_path = os.path.join(root, "scripts", "bootstrap.py")
 
     requires_match = re.search(r'requires-python\s*=\s*"([^"]+)"', pyproject_content)
     assert requires_match is not None, "Could not find requires-python in pyproject.toml"
@@ -74,22 +73,24 @@ def test_python_version_contract_alignment():
     expected_min = (int(match.group(1)), int(match.group(2)))
     expected_max = (int(match.group(3)), int(match.group(4)))
 
-    tree = ast.parse(read_file(bootstrap_path))
-    constants = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id in (
-                    "REQUIRED_PYTHON_VERSION",
-                    "MAX_PYTHON_VERSION",
-                ):
-                    constants[target.id] = ast.literal_eval(node.value)
+    for script in ("bootstrap.py", "doctor.py"):
+        script_path = os.path.join(root, "scripts", script)
+        tree = ast.parse(read_file(script_path))
+        constants = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id in (
+                        "REQUIRED_PYTHON_VERSION",
+                        "MAX_PYTHON_VERSION",
+                    ):
+                        constants[target.id] = ast.literal_eval(node.value)
 
-    assert constants.get("REQUIRED_PYTHON_VERSION") == expected_min, (
-        f"bootstrap minimum Python {constants.get('REQUIRED_PYTHON_VERSION')} "
-        f"does not match pyproject.toml floor {expected_min}."
-    )
-    assert constants.get("MAX_PYTHON_VERSION") == expected_max, (
-        f"bootstrap maximum Python {constants.get('MAX_PYTHON_VERSION')} "
-        f"does not match pyproject.toml ceiling {expected_max}."
-    )
+        assert constants.get("REQUIRED_PYTHON_VERSION") == expected_min, (
+            f"{script} minimum Python {constants.get('REQUIRED_PYTHON_VERSION')} "
+            f"does not match pyproject.toml floor {expected_min}."
+        )
+        assert constants.get("MAX_PYTHON_VERSION") == expected_max, (
+            f"{script} maximum Python {constants.get('MAX_PYTHON_VERSION')} "
+            f"does not match pyproject.toml ceiling {expected_max}."
+        )


### PR DESCRIPTION
## Summary

Align setup tooling with the project Python requirement: `>=3.11,<3.13`.

## Changes

- Bootstrap now rejects unsupported Python versions early.
- Doctor now validates the active Python interpreter.
- Added version matrix tests for Python 3.10–3.13.
- Added alignment guard against `pyproject.toml`.
- Documented supported Python versions in README.

## Tests

- Full suite: 699 passed
- `git diff --check`: passed