### PR TITLE
ci: migrate updater validation to poetry sync

### DIFF
--- a/.github/workflows/updater-validation.yml
+++ b/.github/workflows/updater-validation.yml
@@ -33,7 +33,7 @@ jobs:
           poetry --version
           git --version
       - name: Install dependencies (locked)
-        run: poetry install --sync
+        run: poetry sync
       - name: Full test suite (includes updater integration)
         run: poetry run pytest -q --durations=30 --durations-min=0.5
 
@@ -57,7 +57,7 @@ jobs:
           bash --version | head -1
           uname -a
       - name: Install dependencies (locked)
-        run: poetry install --sync
+        run: poetry sync
       - name: Focused suites + updater integration
         run: >
           poetry run pytest -q --durations=30 --durations-min=0.5
@@ -103,7 +103,7 @@ jobs:
         run: py -3.11 --version
         continue-on-error: true
       - name: Install dependencies (locked)
-        run: poetry install --sync
+        run: poetry sync
       - name: Focused suites + updater integration
         run: >
           poetry run pytest -q --durations=30 --durations-min=0.5

--- a/.github/workflows/updater-validation.yml
+++ b/.github/workflows/updater-validation.yml
@@ -3,9 +3,6 @@
 # Purpose: occasional real-platform validation of the updater lifecycle on
 # Linux, macOS, and Windows hosted runners. Runs ONLY via workflow_dispatch;
 # regular commits and PRs never trigger it.
-#
-# Phase 7 contract: a green run here is required before any cross-platform
-# support claims.
 
 name: Updater Cross-Platform Validation
 


### PR DESCRIPTION
## Summary

Update updater validation CI to use the non-deprecated Poetry synchronization command.

## Changes

- Replaced `poetry install --sync` with `poetry sync` in Linux, macOS, and Windows updater validation jobs.
- Removed obsolete Phase 7 workflow comment.

## Why

`poetry install --sync` is deprecated in Poetry 2.3.4.

`poetry sync` is the supported equivalent for the current CI usage and preserves:

- locked dependency installation
- default dependency groups
- project root installation
- environment synchronization

Production updater behavior is intentionally unchanged because production hosts may use older Poetry versions.

## Validation

- Workflow YAML parsed successfully.
- `poetry sync --dry-run --no-interaction --no-ansi` passed.
- `tests/test_update.py`: `114 passed, 1 skipped`.
- `git diff --check`: passed.