### PR TITLE
docs: streamline README and add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 **WebAI-to-API** is a browser-native AI runtime that exposes browser-based AI services through OpenAI-compatible APIs.
 
-WebAI-to-API combines browser-native automation with WebAPI-based provider integrations to expose AI services through a flexible OpenAI-compatible API layer.
-
 ---
 
 ## Features
@@ -40,12 +38,9 @@ Provides access to cloud-hosted AI models through a native API integration power
 
 ## Quick Start
 
-> **Prerequisite:** Python `>=3.11,<3.13` (see `pyproject.toml`).
-> **Windows:** Python `3.11.10+` or `3.12.4+` is required for secure Gemini WebAPI temporary cookie-cache handling. Linux and macOS require only the supported Python range above.
+### 1. Install and Set Up
 
-### 1. Host Setup
-
-Run the setup wrapper from an existing Git checkout.
+From an existing Git checkout, run the setup wrapper for your platform:
 
 **Linux / macOS**
 ```bash
@@ -57,160 +52,33 @@ Run the setup wrapper from an existing Git checkout.
 .\install.ps1
 ```
 
-If PowerShell blocks the script, use this current-session-only fallback:
+See the [Installation Guide](docs/installation.md) for prerequisites, manual setup, diagnostics, Windows troubleshooting, and Make shortcuts.
 
-```powershell
-Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-.\install.ps1
-```
+### 2. Configure
 
-This does not permanently change user or machine execution policy.
-
-The wrapper validates Python and Poetry, runs bootstrap (including project
-dependencies and Playwright Chromium) and diagnostics, and does not perform
-login or start the server.
-
-If Poetry was just installed but `poetry` is not found, reopen PowerShell. If it
-is still unavailable, verify Poetry's user Scripts or install directory is on
-`PATH`; `%APPDATA%\Python\Scripts` is a common location, but not universal.
-
-Manual pre-Poetry fallback (without wrapper):
-```bash
-python scripts/bootstrap.py
-```
-
-Bootstrap creates `config.conf`, `.env` when its example exists, and the required
-`runtime/` directory tree before installing dependencies and Chromium. Prefer
-the wrappers; on Windows, `.\install.ps1` also selects a supported Python interpreter.
-
-After bootstrap, run diagnostics:
-
-```bash
-poetry run python scripts/doctor.py
-```
-
-### 2. Configuration
-The installer creates `config.conf` and `.env` from their example files when
-missing. Review `config.conf` and edit settings as needed; do not copy example
-files over existing configuration.
-
-*For detailed settings (including logging verbosity and access log configurations), see [Configuration Guide](docs/configuration.md).*
-
+Review the generated `config.conf` and `.env` files, then configure the providers you want to use. See the [Configuration Guide](docs/configuration.md).
 
 ### 3. Authenticate
+
+For browser-based Gemini authentication:
+
 ```bash
 poetry run python verify_login.py
 ```
 
+See the [Configuration Guide](docs/configuration.md) for authentication methods. For Docker authentication, see the [Docker Deployment Guide](docs/docker.md).
+
 ### 4. Start the Server
+
 ```bash
 poetry run python src/run.py
 ```
-
-> [!TIP]
-> New users can run `make setup` and `make doctor` for automated setup and diagnostics. See [Convenience Shortcuts](#optional-convenience-shortcuts) below.
 
 ---
 
 ## Updating
 
-For host installations:
-
-**Linux / macOS**
-
-```bash
-./update-linux-macos.sh
-```
-
-**Windows**
-
-```cmd
-update-windows.cmd
-```
-
-> [!NOTE] The updater checks `origin/master` and installs the update when the remote
-`[project].version` differs from the locally installed version.
-
-For Docker deployments:
-
-```bash
-git pull
-APP_UID=$(id -u) APP_GID=$(id -g) docker compose up -d --build
-```
-
-Docker listens on container port `6969`. By default, Compose publishes it on
-`127.0.0.1:6969` only. `WEB_PORT` changes only the host-side port; its default
-is also `6969`.
-
-Previous Docker behavior published on all host interfaces. Users requiring LAN
-or remote access must opt in explicitly:
-
-```env
-DOCKER_BIND_ADDRESS=0.0.0.0
-```
-
-The project has no caller API authentication. Keep the default localhost bind,
-or put external authentication in front of the entire service before exposing
-it to an untrusted network.
-
-Run `python scripts/bootstrap.py` first so `config.conf`, `.env`, and Docker's
-runtime source exist. Docker defaults to `./runtime`; set `DOCKER_RUNTIME_DIR`
-to choose a different host source mounted at `/app/runtime`. This is pre-Poetry host setup; Windows users should prefer
-`.\install.ps1`. Non-Linux hosts can use the documented defaults or their Docker
-Desktop equivalent; see the [Docker Deployment Guide](docs/docker.md).
-
-See the [Updater Guide](docs/updating.md) for update checks, rollback behavior,
-locking, protected files, and platform-specific details.
-
----
-
-## Optional: Convenience Shortcuts
-
-WebAI-to-API includes a bootstrap utility and a Makefile for common setup tasks.
-
-| Command | Description |
-|---------|-------------|
-| `make setup` | One-step install, directory creation, and config setup. |
-| `make doctor` | Run environment and dependency diagnostics. |
-
-*Alternative (no Make): `python scripts/bootstrap.py`, then `poetry run python scripts/doctor.py`*
-
----
-
-## Authentication
-
-Gemini requires an authenticated Google session.
-
-| Method | Recommended For |
-|----------|----------|
-| **Browser Login (`verify_login.py`)** | **Recommended.** Playwright backend, Docker, and long-term usage. |
-| Manual Cookies | Quick testing and WebAPI-only usage. |
-
-### 1. Browser Login (Recommended)
-1. Run the interactive login helper:
-   ```bash
-   poetry run python verify_login.py
-   ```
-2. Complete the sign-in process in the browser window.
-3. A successful login creates one shared configured auth-state file for Playwright and WebAPI, defaulting to `runtime/auth/gemini.json`.
-
-For Docker, use the selected `DOCKER_RUNTIME_DIR` for both native login paths so
-existing native auth overrides cannot redirect state outside the Docker mount:
-
-```bash
-RUNTIME_DIR=runtime AUTH_STATE_DIR=runtime/auth poetry run python verify_login.py
-```
-
-For `DOCKER_RUNTIME_DIR=/srv/webai/runtime`:
-
-```bash
-RUNTIME_DIR=/srv/webai/runtime AUTH_STATE_DIR=/srv/webai/runtime/auth poetry run python verify_login.py
-```
-
-### 2. Manual Cookies
-1. Sign in to [Gemini](https://gemini.google.com/).
-2. `__Secure-1PSID` is required; `__Secure-1PSIDTS` is optional. Copy available values from your browser cookies.
-3. Paste available values into the `[Gemini]` section of `config.conf`.
+See the [Updater Guide](docs/updating.md) for host updates and the [Docker Deployment Guide](docs/docker.md) for Docker rebuilds and updates.
 
 ---
 
@@ -234,80 +102,25 @@ curl -X POST http://localhost:6969/v1/chat/completions \
 
 ## Dashboard
 
-Open the dashboard at `http://localhost:6969/ui`.
-
-The dashboard provides a visual interface for runtime status, authentication management, API discovery, and interactive testing.
-
-### Available Endpoints
-
-| Endpoint | Purpose |
-| --- | --- |
-| `/v1/chat/completions` | OpenAI-compatible chat completions |
-| `/v1/temporary/chat/completions` | Gemini WebAPI temporary chat |
-| `/v1/models` | List supported models |
-| `/v1/auth/status` | Check authentication status |
-| `/v1/auth/login` | Start authentication flow |
-| `/v1/conversations` | Manage Gemini WebAPI conversation snapshots |
-| `/translate` | Legacy translation compatibility |
-| `/ui/*` | Dashboard and playground |
-
-### Temporary Gemini Chat
-
-`/v1/temporary/chat/completions` is Gemini WebAPI-only and uses Gemini temporary requests (`temporary=True`).
-Requests are not stored in Gemini history and do not create SQLite conversation snapshots.
-It supports streaming, non-streaming, multimodal file inputs, and artifact outputs. See [docs/api.md](docs/api.md) for details.
-
-### Legacy Translate Endpoint
-
-The `/translate` endpoint is maintained for compatibility with the [Translate It!](https://github.com/iSegaro/Translate-It/) browser extension.
-
-It uses stateless Gemini temporary requests with no conversation state. Independent requests can execute concurrently at the application layer. See [docs/api.md](docs/api.md) for additional details.
-
-### File Support
-
-File input is supported through OpenAI-style `content` parts on `/v1/chat/completions` when routed to the Gemini WebAPI backend.
-The currently verified file formats are documented in [docs/api.md](docs/api.md).
-
-> [!NOTE]
-> File parts are supported only by the Gemini WebAPI backend in the MVP. Gemini Playwright and Atlas reject file parts with a clear capability error.
-> For Gemini WebAPI, text content parts are concatenated into one prompt and file parts are passed as attachments. Exact text/file interleaving order is not preserved.
-> The built-in `/ui/playground` page uses the same contract for file attachments.
+Open the dashboard at `http://localhost:6969/ui`. It provides local runtime inspection, authentication management, API discovery, and interactive testing. See the [Dashboard Guide](docs/dashboard.md).
 
 ---
 
 ## Supported Models
 
-Available models may vary depending on the configured provider and backend.
-
-Use the `/v1/models` endpoint to retrieve the current list of supported models.
-
----
-
-## Model Routing
-
-WebAI-to-API uses model prefixes to route requests to specific backends.
-
-| Model | Backend |
-|---------|---------|
-| `gemini-3-flash` | Gemini (default configured backend) |
-| `playwright/gemini-3-flash` | Gemini Playwright |
-| `atlas/<model-id>` | Atlas Cloud via OpenAI-compatible API, with 50 validated chat models exposed in `/v1/models` |
-
-> [!TIP]
-> Model prefixes force backend selection and override the default Gemini backend configured in `config.conf`. Use `playwright/...` model prefixes to force the Playwright backend explicitly.
-
-Gemini WebAPI and Playwright support Extended Thinking through `provider_options.gemini.extended_thinking`; see [API Documentation](docs/api.md).
+Available models depend on configured providers and runtime availability. Use `/v1/models` as the authoritative current catalog. Model prefixes can select a provider or backend; see [API Documentation](docs/api.md) for routing and endpoint behavior.
 
 ---
 
 ## Documentation
 
-- [API Documentation](docs/api.md)
-- [Configuration Guide](docs/configuration.md)
-- [Architecture Guide](docs/architecture.md)
-- [Docker Deployment Guide](docs/docker.md)
-- [Dashboard Guide](docs/dashboard.md)
-- [Updater Guide](docs/updating.md)
+* [Installation Guide](docs/installation.md)
+* [API Documentation](docs/api.md)
+* [Configuration Guide](docs/configuration.md)
+* [Architecture Guide](docs/architecture.md)
+* [Docker Deployment Guide](docs/docker.md)
+* [Dashboard Guide](docs/dashboard.md)
+* [Updater Guide](docs/updating.md)
 
 Interactive API documentation is available through Swagger UI when the server is running.
 

--- a/README.md
+++ b/README.md
@@ -38,25 +38,39 @@ Provides access to cloud-hosted AI models through a native API integration power
 
 ## Quick Start
 
+**Prerequisites:** Git, Python `>=3.11,<3.13` and Poetry. On Windows, use Python `3.11.10+` or `3.12.4+` for secure Gemini WebAPI temporary-cookie-cache handling. See the [Installation Guide](docs/installation.md) for full installation and troubleshooting details.
+
 ### 1. Install and Set Up
 
-From an existing Git checkout, run the setup wrapper for your platform:
+Clone the repository, enter the project directory, then run the setup wrapper for your platform.
 
 **Linux / macOS**
+
 ```bash
+git clone https://github.com/Amm1rr/WebAI-to-API.git
+cd WebAI-to-API
 ./install.sh
-```
 
 **Windows PowerShell**
-```powershell
+git clone https://github.com/Amm1rr/WebAI-to-API.git
+cd WebAI-to-API
 .\install.ps1
 ```
 
-See the [Installation Guide](docs/installation.md) for prerequisites, manual setup, diagnostics, Windows troubleshooting, and Make shortcuts.
+The wrappers create missing configuration and runtime state, install project dependencies and Playwright Chromium, then run diagnostics. See the [Installation Guide](docs/installation.md) for manual setup, troubleshooting, and Make shortcuts.
 
 ### 2. Configure
 
-Review the generated `config.conf` and `.env` files, then configure the providers you want to use. See the [Configuration Guide](docs/configuration.md).
+Review the generated `config.conf`. Core Gemini settings include:
+
+```ini
+[Gemini]
+backend = webapi
+default_model = gemini-3-flash
+extended_thinking = false
+```
+
+Configure Atlas separately when needed. See the [Configuration Guide](docs/configuration.md) for provider, proxy, logging, and authentication settings.
 
 ### 3. Authenticate
 
@@ -66,7 +80,7 @@ For browser-based Gemini authentication:
 poetry run python verify_login.py
 ```
 
-See the [Configuration Guide](docs/configuration.md) for authentication methods. For Docker authentication, see the [Docker Deployment Guide](docs/docker.md).
+Gemini WebAPI can also use configured cookies. See the [Configuration Guide](docs/configuration.md) for authentication methods. For Docker authentication, see the [Docker Deployment Guide](docs/docker.md).
 
 ### 4. Start the Server
 
@@ -74,11 +88,36 @@ See the [Configuration Guide](docs/configuration.md) for authentication methods.
 poetry run python src/run.py
 ```
 
+* API: `http://localhost:6969`
+* Dashboard: `http://localhost:6969/ui`
+* Swagger UI: `http://localhost:6969/docs`
+
 ---
 
 ## Updating
 
-See the [Updater Guide](docs/updating.md) for host updates and the [Docker Deployment Guide](docs/docker.md) for Docker rebuilds and updates.
+### Host
+
+**Linux / macOS**
+```bash
+./update-linux-macos.sh
+```
+
+**Windows**
+```cmd
+update-windows.cmd
+```
+
+Updates are version-driven from `origin/master`. See the [Updater Guide](docs/updating.md) for locking, preflight checks, rollback, dependency sync, and platform details.
+
+### Docker
+
+```bash
+git pull
+APP_UID=$(id -u) APP_GID=$(id -g) docker compose up -d --build
+```
+
+See the [Docker Deployment Guide](docs/docker.md) for Docker setup and deployment details.
 
 ---
 
@@ -102,13 +141,59 @@ curl -X POST http://localhost:6969/v1/chat/completions \
 
 ## Dashboard
 
-Open the dashboard at `http://localhost:6969/ui`. It provides local runtime inspection, authentication management, API discovery, and interactive testing. See the [Dashboard Guide](docs/dashboard.md).
+Open the dashboard at `http://localhost:6969/ui`. It provides runtime status, authentication view, model and API discovery, a playground, and conversation management where supported. See the [Dashboard Guide](docs/dashboard.md).
 
 ---
 
-## Supported Models
+## Main Endpoints
 
-Available models depend on configured providers and runtime availability. Use `/v1/models` as the authoritative current catalog. Model prefixes can select a provider or backend; see [API Documentation](docs/api.md) for routing and endpoint behavior.
+| Endpoint | Purpose |
+| --- | --- |
+| `/v1/chat/completions` | Main OpenAI-compatible chat endpoint |
+| `/v1/temporary/chat/completions` | Temporary Gemini WebAPI chat without durable conversation persistence |
+| `/v1/models` | Current runtime model catalog |
+| `/v1/conversations` | Manage persisted Gemini WebAPI conversations |
+| `/v1/auth/status` | Authentication status |
+| `/v1/auth/login` | Interactive browser login trigger |
+| `/v1/runtime/status` | Runtime diagnostics |
+| `/health` | Liveness |
+| `/ready` | Runtime readiness |
+| `/translate` | Translate It! compatibility endpoint |
+| `/ui` | Dashboard |
+
+See [API Documentation](docs/api.md) for the complete API surface, including compatibility and legacy endpoints.
+
+---
+
+## Supported Models and Routing
+
+Available models depend on configured providers and runtime availability. Use `/v1/models` as the authoritative current catalog.
+
+```text
+gemini-3-flash
+playwright/gemini-3-flash
+atlas/<model-id>
+```
+
+Unprefixed Gemini models use the configured Gemini backend. `playwright/...` forces browser-native Gemini routing, while `atlas/...` routes to Atlas. See [API Documentation](docs/api.md) for full routing behavior.
+
+---
+
+## Configuration Summary
+
+Configure Gemini backend selection (`webapi` or `playwright`), default model, provider enablement, proxy, logging, and Atlas API access in `config.conf` and `.env`. Set a default for Extended Thinking with `[Gemini].extended_thinking`, or override it per request with `provider_options.gemini.extended_thinking`. See the [Configuration Guide](docs/configuration.md).
+
+---
+
+## File Support
+
+OpenAI-style file content parts are supported by Gemini WebAPI. Gemini Playwright and Atlas do not currently support file parts, and Gemini WebAPI does not preserve exact text/file interleaving. See [API Documentation](docs/api.md) for supported formats and limits.
+
+---
+
+## Security
+
+WebAI-to-API does not provide caller API authentication. Keep the default localhost binding unless external authentication and access control protect the service. See the [Docker Deployment Guide](docs/docker.md) and [Dashboard Guide](docs/dashboard.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,13 @@ This directory contains user guides and runtime specifications for WebAI-to-API.
 
 ## User Guides
 
+* [Installation Guide](installation.md)
 * [API Documentation](api.md)
 * [Configuration Guide](configuration.md)
 * [Architecture Guide](architecture.md)
 * [Docker Deployment Guide](docker.md)
 * [Dashboard Guide](dashboard.md)
+* [Updater Guide](updating.md)
 
 ## Runtime Specifications
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,101 @@
+# Installation Guide
+
+This guide covers host installation, setup, diagnostics, and common Windows issues. For Docker deployment, see the [Docker Deployment Guide](docker.md).
+
+## Prerequisites
+
+* Python `>=3.11,<3.13`
+* [Poetry](https://python-poetry.org/docs/#installation) available on `PATH`
+
+On Windows, secure Gemini WebAPI temporary cookie-cache isolation requires Python `3.11.10+` or `3.12.4+`.
+
+Install Poetry before running any setup command. `scripts/bootstrap.py` requires Poetry; it is not a pre-Poetry installer.
+
+---
+
+## Recommended Setup
+
+Run a platform wrapper from an existing Git checkout.
+
+### Linux / macOS
+
+```bash
+./install.sh
+```
+
+The wrapper selects a supported `python3` or `python` interpreter, verifies Poetry is available, then runs bootstrap and diagnostics.
+
+### Windows PowerShell
+
+```powershell
+.\install.ps1
+```
+
+The wrapper selects a supported Python interpreter from `py -3.12`, `py -3.11`, or `python`, verifies Poetry is available, then runs bootstrap and diagnostics.
+
+Both wrappers create setup state and validate the environment. They do not perform provider login or start the server.
+
+---
+
+## Windows Troubleshooting
+
+If PowerShell blocks `install.ps1`, allow it for the current PowerShell session only:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\install.ps1
+```
+
+This does not change user or machine execution policy permanently.
+
+If Poetry was installed but `poetry` is not found, reopen PowerShell. If it is still unavailable, ensure Poetry's user Scripts or install directory is on `PATH`; `%APPDATA%\Python\Scripts` is a common location but not universal.
+
+---
+
+## Manual Setup
+
+After Poetry is available, run:
+
+```bash
+python scripts/bootstrap.py
+```
+
+Bootstrap:
+
+* validates Python and Poetry
+* creates missing `config.conf` and `.env` from their examples without overwriting existing user configuration
+* creates required runtime directories
+* installs project dependencies and Playwright Chromium
+
+Then run diagnostics:
+
+```bash
+poetry run python scripts/doctor.py
+```
+
+Doctor checks Python, configuration, Poetry, runtime directories, Playwright Chromium, authentication material, and local port availability. It does not start the server.
+
+---
+
+## Convenience Shortcuts
+
+When GNU Make is available:
+
+| Command | Description |
+| --- | --- |
+| `make setup` | Run `python scripts/bootstrap.py`. |
+| `make doctor` | Run `python scripts/doctor.py`. |
+
+---
+
+## Next Steps
+
+1. Review [Configuration Guide](configuration.md).
+2. Set up provider authentication with `poetry run python verify_login.py` or another documented method in the Configuration Guide.
+3. Start the server:
+
+   ```bash
+   poetry run python src/run.py
+   ```
+
+4. Use the [Docker Deployment Guide](docker.md) for container deployment and Docker-specific authentication.


### PR DESCRIPTION
### Summary

Simplify the root README while keeping it useful as a self-contained onboarding entry point.

The README now focuses on the essential user flow:

* clone and install the project
* configure providers
* authenticate
* start the server
* send the first request
* discover main endpoints
* understand basic model routing
* update host and Docker installations

Detailed setup, troubleshooting, API semantics, and operational behavior remain in the canonical documentation.

### Changes

* Simplified and reorganized `README.md`
* Added `docs/installation.md` for host installation and setup
* Added Installation and Updater guides to `docs/README.md`
* Restored concise Quick Start, update commands, main endpoint reference, model routing, configuration, file-support, and security summaries
* Added Git clone instructions to the installation flow
* Removed stale fixed Atlas model-count wording
* Corrected bootstrap documentation to reflect that Poetry is required
* Preserved Star History and visit counter

### Documentation Ownership

* `README.md` — project overview and essential onboarding
* `docs/installation.md` — host setup, prerequisites, diagnostics, and troubleshooting
* `docs/configuration.md` — configuration and authentication
* `docs/api.md` — complete API surface and routing semantics
* `docs/docker.md` — Docker deployment and authentication
* `docs/updating.md` — updater behavior and platform-specific details

### Scope

Documentation only.

No source code, tests, configuration templates, runtime behavior, Docker files, or `docs/specs/*` contracts were changed.

### Verification

* Reviewed relative documentation links
* Confirmed no fixed Atlas model count remains
* Confirmed Star History and visit counter are preserved
* `git diff --check` passes
